### PR TITLE
[OC-4235] 'delay-loading' changes to reduce load-time

### DIFF
--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
 require File.expand_path('../../../azure/connection', __FILE__)
 
 class Chef
@@ -33,6 +32,8 @@ class Chef
           deps do
             require 'readline'
             require 'chef/json_compat'
+            require 'chef/knife'
+            Chef::Knife.load_deps
           end
 
           option :azure_subscription_id,

--- a/lib/chef/knife/azure_image_list.rb
+++ b/lib/chef/knife/azure_image_list.rb
@@ -18,12 +18,16 @@
 # limitations under the License.
 #
 
-require 'highline'
 require File.expand_path('../azure_base', __FILE__)
 
 class Chef
   class Knife
     class AzureImageList < Knife
+
+      deps do
+        require 'highline'
+        Chef::Knife.load_deps
+      end
 
       include Knife::AzureBase
 

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -28,8 +28,6 @@ class Chef
       include Knife::WinrmBase
 
       deps do
-        require 'readline'
-        require 'chef/json_compat'
         require 'chef/knife/bootstrap'
         require 'chef/knife/bootstrap_windows_winrm'
         require 'chef/knife/bootstrap_windows_ssh'


### PR DESCRIPTION
Here are findings with load-time differences before & after code changes.
# knife-core(no-plugins)

```
    real    0m0.744s
    user    0m0.688s
    sys     0m0.052s
```
# knife(with knife-azure, knife-google, knife-hp, knife-ec2, knife-windows,knife-terremark, knife-rackspace)

```
# before changes, 
    real    0m5.835s
    user    0m3.736s
    sys     0m0.376s

# After changes, 
    real    0m3.805s
    user    0m3.452s
    sys     0m0.272s
```

Environment:
1. Chef Version: 10.14.2
2. Ruby Version: 1.9.3p194
3. Gem Version: 1.8.24
