### PR TITLE
OC-7830 Fixed: azure_host_name option in Azure as azure-host-name

### DIFF
--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -49,7 +49,7 @@ class Chef
 
           option :azure_host_name,
             :short => "-H HOSTNAME",
-            :long => "--azure_host_name HOSTNAME",
+            :long => "--azure-host-name HOSTNAME",
             :description => "Your Azure host name",
             :proc => Proc.new { |key| Chef::Config[:knife][:azure_host_name] = key }
 


### PR DESCRIPTION
Please review and accept changes to update azure_host_name option in Azure as azure-host-name.

Thank You !!!
