### PR TITLE
[OC-8763] Fix up to use valid nomenclature in server delete display output

### DIFF
--- a/lib/chef/knife/azure_server_delete.rb
+++ b/lib/chef/knife/azure_server_delete.rb
@@ -105,7 +105,6 @@ class Chef
             end
             puts "\n"
             msg_pair('DNS Name', server.hostedservicename + ".cloudapp.net")
-            msg_pair('Deployment', server.deployname)
             msg_pair('VM Name', server.name)
             msg_pair('Size', server.size)
             msg_pair('Public Ip Address', server.publicipaddress)

--- a/spec/unit/azure_server_delete_spec.rb
+++ b/spec/unit/azure_server_delete_spec.rb
@@ -43,7 +43,6 @@ end
 		@server_instance.name_args = ['role001']
 		@server_instance.ui.should_receive(:warn).twice
 		@server_instance.should_receive(:msg_pair).with("DNS Name", Chef::Config[:knife][:azure_dns_name] + ".cloudapp.net")
-		@server_instance.should_receive(:msg_pair).with("Deployment", "deployment001")
 		@server_instance.should_receive(:msg_pair).with("VM Name", "role001")
 		@server_instance.should_receive(:msg_pair).with("Size", "Small")
 		@server_instance.should_receive(:msg_pair).with("Public Ip Address", "65.52.249.191")


### PR DESCRIPTION
Implemented changes to use valid nomenclature in server delete display output.
Please review and accept it.
Thanks
