### PR TITLE
Remove hard-coded date from gemspec

### DIFF
--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Barry Davis", "Chirag Jog"]
-  s.date = "2012-06-06"
   s.summary = "A plugin to Opscode knife for creating instances on the Microsoft Azure platform"
   s.description = s.summary
   s.email = "oss@opscode.com"

--- a/lib/knife-azure/version.rb
+++ b/lib/knife-azure/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Azure
-    VERSION = "1.1.0"
+    VERSION = "1.1.2"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
Our gemspec has a hard-coded date of 6-6-2012 -- this causes our gem to show up as being released more than a year ago despite being released a few days ago. This change only affects the gemspec -- all other functionality is the same.
