### PR TITLE
KNIFE-361: Delete underlying VHD blob image from Azure Storage by default when deleting Virtual Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,12 @@ Sample knife.rb for bootstrapping Windows Node with basic authentication
 ### Azure Server Delete Subcommand
 Deletes an existing server in the currently configured Azure account. By
 default, this does not delete the associated node and client objects from the
-Chef server. To do so, add the --purge flag. Also by default, the DNS name, also called "cloud service", is deleted if you are deleting the last VM from that service. By default, the OS disk is also deleted. If you want to retain them add the --preserve flag as shown below. To delete the storage account, add the --delete-azure-storage-account flag since by default the storage account is not deleted.
+Chef server. To do so, add the --purge flag. Also by default, the DNS name, also called "cloud service", is deleted if you are deleting the last VM from that service. By default, the OS disk is also deleted. The underlying VHD blob is also deleted by default. If you want to retain them add the --preserve flag as shown below. To delete the storage account, add the --delete-azure-storage-account flag since by default the storage account is not deleted.
 
     knife azure server delete "myvm01"
     knife azure server delete "myvm01" --purge  #purge chef node
     knife azure server delete "myvm01" --preserve-azure-os-disk
+    knife azure server delete "myvm01" --preserve-azure-vhd
     knife azure server delete "myvm01" --preserve-azure-dns-name
     knife azure server delete "myvm01" --delete-azure-storage-account
 

--- a/lib/azure/connection.rb
+++ b/lib/azure/connection.rb
@@ -39,10 +39,10 @@ class Azure
       @disks = Disks.new(self)
       @certificates = Certificates.new(self)
     end
-    def query_azure(service_name, verb = 'get', body = '')
+    def query_azure(service_name, verb = 'get', body = '', params = '')
       Chef::Log.info 'calling ' + verb + ' ' + service_name
       Chef::Log.debug body unless body == ''
-      response = @rest.query_azure(service_name, verb, body)
+      response = @rest.query_azure(service_name, verb, body, params)
       if response.code.to_i == 200
         ret_val = Nokogiri::XML response.body
       elsif response.code.to_i >= 201 && response.code.to_i <= 299

--- a/lib/azure/rest.rb
+++ b/lib/azure/rest.rb
@@ -28,10 +28,11 @@ module AzureAPI
       @host_name = params[:azure_api_host_name]
       @verify_ssl = params[:verify_ssl_cert]
     end
-    def query_azure(service_name, verb = 'get', body = '')
+    def query_azure(service_name, verb = 'get', body = '', params = '')
       request_url = "https://#{@host_name}/#{@subscription_id}/services/#{service_name}"
       print '.'
       uri = URI.parse(request_url)
+      uri.query = params
       http = http_setup(uri)
       request = request_setup(uri, verb, body)
       response = http.request(request)

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -119,7 +119,12 @@ class Azure
              break if @connection.query_azure(servicecall, "get").search("AttachedTo").text == ""
              if attempt == 12 then puts "The associated disk could not be deleted due to time out." else sleep 25 end
           end
-          @connection.query_azure(servicecall, "delete")
+
+          unless params[:preserve_azure_vhd]
+           @connection.query_azure(servicecall, 'delete', '', 'comp=media')
+          else
+            @connection.query_azure(servicecall, 'delete')
+          end
 
           if params[:delete_azure_storage_account]
             storage_account_name = xml_content(storage_account, "MediaLink")

--- a/lib/chef/knife/azure_server_delete.rb
+++ b/lib/chef/knife/azure_server_delete.rb
@@ -38,6 +38,12 @@ class Chef
         :default => false,
         :description => "Preserve corresponding OS Disk"
 
+      option :preserve_azure_vhd,
+       :long => "--preserve-azure-vhd",
+       :boolean => true,
+       :default => false,
+       :description => "Preserve underlying VHD"
+
       option :purge,
         :short => "-P",
         :long => "--purge",
@@ -118,6 +124,7 @@ class Chef
             end
 
             connection.roles.delete(name, params = { :preserve_azure_os_disk => locate_config_value(:preserve_azure_os_disk),
+                                                     :preserve_azure_vhd => locate_config_value(:preserve_azure_vhd),
                                                      :preserve_azure_dns_name => locate_config_value(:preserve_azure_dns_name),
                                                      :azure_dns_name => server.hostedservicename,
                                                      :delete_azure_storage_account => locate_config_value(:delete_azure_storage_account) })

--- a/spec/unit/azure_server_delete_spec.rb
+++ b/spec/unit/azure_server_delete_spec.rb
@@ -110,15 +110,24 @@ end
 		@server_instance.run
 	end
 
-	it "should delete OS Disk when --preserve-azure-os-disk is not set." do
+	it "should delete OS Disk and VHD when --preserve-azure-os-disk and --preserve-azure-vhd are not set." do
 		test_hostname = 'role001'
 		test_diskname = 'deployment001-role002-0-201241722728'
 		@server_instance.name_args = [test_hostname]
 		@server_instance.connection.roles.should_receive(:delete).exactly(1).and_call_original
-		@server_instance.connection.should_receive(:query_azure).with("disks/#{test_diskname}", "delete")
+		@server_instance.connection.should_receive(:query_azure).with("disks/#{test_diskname}", "delete", "", "comp=media")
 		@server_instance.run
 	end
 
+  it "should preserve VHD when --preserve-azure-vhd is set." do
+    test_hostname = 'role001'
+    test_diskname = 'deployment001-role002-0-201241722728'
+    Chef::Config[:knife][:preserve_azure_vhd] = true
+    @server_instance.name_args = [test_hostname]
+    @server_instance.connection.roles.should_receive(:delete).exactly(1).and_call_original
+    @server_instance.connection.should_receive(:query_azure).with("disks/#{test_diskname}", "delete")
+    @server_instance.run
+  end
 
 	describe "Storage Account" do
 		before(:each) do


### PR DESCRIPTION
Created from https://github.com/opscode/knife-azure/pull/84.
