### PR TITLE
OC-9994 Knife Azure server create used with --azure-connect-to-existing-dns option assumes ssh/winrm tcp endpoints port 22/5985 already used by existing vm.

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -71,8 +71,7 @@ class Chef
 
       option :ssh_port,
         :long => "--ssh-port PORT",
-        :description => "The ssh port. Default is 22.",
-        :default => '22'
+        :description => "The ssh port. Default is 22. If --azure-connect-to-existing-dns set then default SSH port is random"
 
       option :prerelease,
         :long => "--prerelease",
@@ -705,14 +704,16 @@ class Chef
         # If user is connecting a new VM to an existing dns, then
         # the VM needs to have a unique public port. Logic below takes care of this.
         if !is_image_windows? or locate_config_value(:bootstrap_protocol) == 'ssh'
-          port = locate_config_value(:ssh_port) || '22'
-          if locate_config_value(:azure_connect_to_existing_dns) && (port == '22')
-            port = Random.rand(64000) + 1000
+          if locate_config_value(:azure_connect_to_existing_dns)
+            port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000
+          else
+            port = locate_config_value(:ssh_port) || '22'
           end
         else
-          port = locate_config_value(:winrm_port) || '5985'
-          if locate_config_value(:azure_connect_to_existing_dns) && (port == '5985')
-            port = Random.rand(64000) + 1000
+          if locate_config_value(:azure_connect_to_existing_dns)
+            port = locate_config_value(:winrm_port) || Random.rand(64000) + 1000
+          else
+            port = locate_config_value(:winrm_port) || '5985'
           end
         end
 

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -406,14 +406,24 @@ describe Chef::Knife::AzureServerCreate do
         expect(@server_params[:port]).to be == '24'
       end
 
-      it "port should be be different if ssh-port = 22" do
+      it "port should be 22 if user specified --ssh-port 22" do
         Chef::Config[:knife][:ssh_user] = 'azureuser'
         Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
         Chef::Config[:knife][:ssh_port] = '22'
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(false)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to_not be == '22'
+        expect(@server_params[:port]).to be == '22'
       end
+
+      it "port should be 5985 if user specified --winrm-port 5985" do
+        Chef::Config[:knife][:winrm_user] = 'azureuser'
+        Chef::Config[:knife][:winrm_password] = 'Jetstream123!'
+        Chef::Config[:knife][:winrm_port] = '5985'
+        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
+        expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
+        @server_params = @server_instance.create_server_def
+        expect(@server_params[:port]).to be == '5985'
+      end      
     end
   end
 


### PR DESCRIPTION
Implemented changes to use ssh/winrm port 22/5985 with --azure-connect-to-existing-dns option.
PBI details: https://tickets.corp.opscode.com/browse/OC-9994

@adamedx Please review the changes. Let me know your comments for this PBI.
Thanks.
