### PR TITLE
OC-11236 knife-azure display incorrect flag names in error messages.

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -524,10 +524,10 @@ class Chef
           exit 1
         end
         if locate_config_value(:azure_service_location) && locate_config_value(:azure_affinity_group)
-          ui.error("Cannot specify both --azure_service_location and --azure_affinity_group, use one or the other.")
+          ui.error("Cannot specify both --azure-service-location and --azure-affinity-group, use one or the other.")
           exit 1
         elsif locate_config_value(:azure_service_location).nil? && locate_config_value(:azure_affinity_group).nil?
-          ui.error("Must specify either --azure_service_location or --azure_affinity_group.")
+          ui.error("Must specify either --azure-service-location or --azure-affinity-group.")
           exit 1
         end
       end

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -83,12 +83,12 @@ describe "parameter test:" do
 
     it "azure_service_location and azure_affinity_group not allowed" do
       Chef::Config[:knife][:azure_affinity_group] = 'test-affinity'
-      @server_instance.ui.should_receive(:error)
+      @server_instance.ui.should_receive(:error).with("Cannot specify both --azure-service-location and --azure-affinity-group, use one or the other.")
       expect {@server_instance.run}.to raise_error
     end
     it "azure_service_location or azure_affinity_group must be provided" do
       Chef::Config[:knife].delete(:azure_service_location)
-      @server_instance.ui.should_receive(:error)
+      @server_instance.ui.should_receive(:error).with("Must specify either --azure-service-location or --azure-affinity-group.")
       expect {@server_instance.run}.to raise_error
     end
 	end


### PR DESCRIPTION
PBI ref: https://tickets.corp.opscode.com/browse/OC-11236
Fixed incorrect flag with rspec tests.
^@adamedx 
