### PR TITLE
OC-11255: Remove the az prefix from DNS name when VM name is specified and ...

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -632,7 +632,7 @@ class Chef
         if locate_config_value(:azure_vm_name).nil?
           azure_dns_name = prefix + SecureRandom.hex(( MAX_VM_NAME_CHARACTERS - prefix.length)/2)
         else
-          azure_dns_name = prefix + locate_config_value(:azure_vm_name)
+          azure_dns_name = locate_config_value(:azure_vm_name)
         end
       end
 


### PR DESCRIPTION
...DNS name not specified.