### PR TITLE
KNIFE-481 - Virtual machine state 'provisioning' not reached after 5 minutes.

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -192,8 +192,13 @@ class Chef
 
       option :azure_vm_startup_timeout,
         :long => "--azure_startup_timeout TIMEOUT",
-        :description => "The number of minutes that knife-azure will wait for the virtual machine to be ready. Default is 5.",
-        :default => 5
+        :description => "The number of minutes that knife-azure will wait for the virtual machine to reach the 'provisioning' state. Default is 10.",
+        :default => 10
+
+      option :azure_vm_ready_timeout,
+        :long => "--azure_vm_ready TIMEOUT",
+        :description => "The number of minutes that knife-azure will wait for the virtual machine state to transition from 'provisioning' to 'ready'. Default is 15.",
+        :default => 15 
 
       option :identity_file,
         :long => "--identity-file FILENAME",
@@ -220,16 +225,23 @@ class Chef
         (0...len).map{65.+(rand(25)).chr}.join
       end
 
+      def azure_vm_startup_timeout
+        locate_config_value(:azure_vm_startup_timeout) || 10
+      end
+
+      def azure_vm_ready_timeout
+        locate_config_value(:azure_vm_ready_timeout) || 15
+      end
+
       def wait_until_virtual_machine_ready(retry_interval_in_seconds = 30)
         vm_status = nil
-        timeout = locate_config_value(:azure_vm_startup_timeout) || 5
 
         puts
 
         begin
-          vm_status = wait_for_virtual_machine_state(:vm_status_provisioning, timeout, retry_interval_in_seconds)
+          vm_status = wait_for_virtual_machine_state(:vm_status_provisioning, azure_vm_startup_timeout, retry_interval_in_seconds)
           if vm_status != :vm_status_ready
-            wait_for_virtual_machine_state(:vm_status_ready, 15, retry_interval_in_seconds)
+            wait_for_virtual_machine_state(:vm_status_ready, azure_vm_ready_timeout, retry_interval_in_seconds)
           end
         rescue Exception => e
           Chef::Log.error("#{e.to_s}")

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -190,6 +190,11 @@ class Chef
         :long => "--azure-subnet-name SUBNET_NAME",
         :description => "Optional. Specifies the subnet of virtual machine"
 
+      option :azure_vm_startup_timeout,
+        :long => "--azure_startup_timeout TIMEOUT",
+        :description => "The number of minutes that knife-azure will wait for the virtual machine to be ready. Default is 5.",
+        :default => 5
+
       option :identity_file,
         :long => "--identity-file FILENAME",
         :description => "SSH identity file for authentication, optional. It is the RSA private key path. Specify either ssh-password or identity-file"
@@ -217,10 +222,12 @@ class Chef
 
       def wait_until_virtual_machine_ready(retry_interval_in_seconds = 30)
         vm_status = nil
+        timeout = locate_config_value(:azure_vm_startup_timeout) || 5
+
         puts
 
         begin
-          vm_status = wait_for_virtual_machine_state(:vm_status_provisioning, 5, retry_interval_in_seconds)
+          vm_status = wait_for_virtual_machine_state(:vm_status_provisioning, timeout, retry_interval_in_seconds)
           if vm_status != :vm_status_ready
             wait_for_virtual_machine_state(:vm_status_ready, 15, retry_interval_in_seconds)
           end

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -93,6 +93,24 @@ describe "parameter test:" do
     end
 	end
 
+	context "timeout parameters" do
+	
+		it "uses correct values when not specified" do
+			@server_instance.azure_vm_startup_timeout.should == 10
+			@server_instance.azure_vm_ready_timeout.should == 15
+		end		
+
+
+		it "matches the CLI options" do
+			#Set params to non-default values
+			Chef::Config[:knife][:azure_vm_startup_timeout] = 5
+			Chef::Config[:knife][:azure_vm_ready_timeout] = 10
+			@server_instance.azure_vm_startup_timeout.should == Chef::Config[:knife][:azure_vm_startup_timeout] 
+			@server_instance.azure_vm_ready_timeout.should == Chef::Config[:knife][:azure_vm_ready_timeout]
+		end		
+
+	end
+
 	context "server create options" do
 		before do
 			Chef::Config[:knife][:bootstrap_protocol] = 'ssh'


### PR DESCRIPTION
Added a new parameter to configure the previously hardcoded timeout in wait_for_virtual_machine_state

Details: https://tickets.opscode.com/browse/KNIFE-481