### PR TITLE
Fixed documentation of TCP and UDP options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ These options may also be configured from knife.rb, as in this example:
     knife[:identity_file]='/path/to/RSA/private/key'
     knife[:azure_storage_account]='auxpreview104'
     knife[:azure_os_disk_name]='disk107'
-    knife[:tcp_endpoints]='66'
-    knife[:udp_endpoints]='77,88,99'
+    knife[:tcp-endpoints]='80:80,3389:5678'
+    knife[:udp-endpoints]='123:123'
 
 #### Options for Bootstrapping a Windows Node in Azure
 

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -167,12 +167,12 @@ class Chef
       option :tcp_endpoints,
         :short => "-t PORT_LIST",
         :long => "--tcp-endpoints PORT_LIST",
-        :description => "Comma separated list of TCP local and public ports to open i.e. '80:80,433:5000'"
+        :description => "Comma-separated list of TCP local and public ports to open e.g. '80:80,433:5000'"
 
       option :udp_endpoints,
         :short => "-u PORT_LIST",
         :long => "--udp-endpoints PORT_LIST",
-        :description => "Comma separated list of UDP local and public ports to open i.e. '80:80,433:5000'"
+        :description => "Comma-separated list of UDP local and public ports to open e.g. '80:80,433:5000'"
 
       option :azure_connect_to_existing_dns,
         :short => "-c",


### PR DESCRIPTION
- In README, underscores were used instead of the correct "-"
- In the code, "i.e." is used instead of "e.g." (the former means "in other words", the latter means "for example")
