### PR TITLE
Remove em-winrm dependency in knife-azure

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -40,7 +40,6 @@ class Chef
 
       def load_winrm_deps
         require 'winrm'
-        require 'em-winrm'
         require 'chef/knife/winrm'
         require 'chef/knife/bootstrap_windows_winrm'
       end


### PR DESCRIPTION
"em-winrm" dependency has been removed from knife-windows. Removing this dependency from knife-azure as well.
