### PR TITLE
ffi-yajl warning with knife-azure

### DIFF
--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nokogiri", ">= 1.5.5"
   s.add_dependency "knife-windows", ">= 0.8.2"
+  s.add_dependency "ffi-yajl", "< 1.3", "~> 1.2"
 
   s.add_development_dependency "chef", ">= 11.8.2", '< 12'
-  s.add_development_dependency "ffi-yajl", "< 1.3"
   s.add_development_dependency "mixlib-config", "~> 2.0"
   s.add_development_dependency "equivalent-xml", "~> 0.2.9"
   s.add_development_dependency "knife-cloud", ">= 1.0.0"


### PR DESCRIPTION
Getting this warning with ffi-yajl -v1.3.1 gem:
failed to load the ffi-yajl c-extension, falling back to ffi interface
ffi-yajl/json_gem is deprecated, these monkeypatches will be dropped shortly
