### PR TITLE
Disabled certificate genaration code for ssl transport

### DIFF
--- a/lib/azure/deploy.rb
+++ b/lib/azure/deploy.rb
@@ -81,9 +81,11 @@ class Azure
       if params[:cert_path]
         cert_data = File.read (params[:cert_path])
         @connection.certificates.add cert_data, params[:cert_password], 'pfx', params[:azure_dns_name]
-      elsif(params[:winrm_transport] == "ssl")
-        thumbprint = @connection.certificates.create_ssl_certificate params[:azure_dns_name]
-        params[:ssl_cert_fingerprint] = thumbprint.to_s.upcase
+
+##########  Uncomment the code below to activate automatic certificate generation for ssl communication
+#      elsif(params[:winrm_transport] == "ssl")
+#        thumbprint = @connection.certificates.create_ssl_certificate params[:azure_dns_name]
+#        params[:ssl_cert_fingerprint] = thumbprint.to_s.upcase
       end
 
       params['deploy_name'] = get_deploy_name_for_hostedservice(params[:azure_dns_name])

--- a/lib/azure/deploy.rb
+++ b/lib/azure/deploy.rb
@@ -81,11 +81,8 @@ class Azure
       if params[:cert_path]
         cert_data = File.read (params[:cert_path])
         @connection.certificates.add cert_data, params[:cert_password], 'pfx', params[:azure_dns_name]
-
-##########  Uncomment the code below to activate automatic certificate generation for ssl communication
-#      elsif(params[:winrm_transport] == "ssl")
-#        thumbprint = @connection.certificates.create_ssl_certificate params[:azure_dns_name]
-#        params[:ssl_cert_fingerprint] = thumbprint.to_s.upcase
+      elsif(params[:winrm_transport] == "ssl")
+        #TODO: generate certificates for ssl listener
       end
 
       params['deploy_name'] = get_deploy_name_for_hostedservice(params[:azure_dns_name])

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -274,6 +274,8 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.run
       end
 
+##########  Uncomment the code below to test automatic certificate generation for ssl communication
+=begin
       it 'create with automatic certificates creation if winrm-transport=ssl' do
         # set all params
         Chef::Config[:knife][:azure_dns_name] = 'service001'
@@ -296,6 +298,7 @@ describe Chef::Knife::AzureServerCreate do
         #Delete temp directory
         FileUtils.remove_entry_secure dir
       end
+=end
     end
 
     context "when --azure-dns-name is not specified" do

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -274,9 +274,9 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.run
       end
 
-##########  Uncomment the code below to test automatic certificate generation for ssl communication
-=begin
+
       it 'create with automatic certificates creation if winrm-transport=ssl' do
+        pending "with automatic certificates creation if winrm-transport=ssl"
         # set all params
         Chef::Config[:knife][:azure_dns_name] = 'service001'
         Chef::Config[:knife][:azure_vm_name] = 'vm002'
@@ -298,7 +298,6 @@ describe Chef::Knife::AzureServerCreate do
         #Delete temp directory
         FileUtils.remove_entry_secure dir
       end
-=end
     end
 
     context "when --azure-dns-name is not specified" do


### PR DESCRIPTION
Disabling certificate generation for the coming `knife-azure` release. 
This code is replicated in `knife-windows` and `knife-azure` both. `knife-azure` should either user `knife-windows` or this code should be in `knife-cloud` in future.