### PR TITLE
Adding winrm_ssl_verify_mode to bootstrap config

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -622,6 +622,8 @@ class Chef
             bootstrap.config[:winrm_authentication_protocol] = locate_config_value(:winrm_authentication_protocol)
             bootstrap.config[:winrm_port] = port
             bootstrap.config[:auth_timeout] = locate_config_value(:auth_timeout)
+            # Todo: we should skip cert generate in case when winrm_ssl_verify_mode=verify_none
+            bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
 
         elsif locate_config_value(:bootstrap_protocol) == 'ssh'
             bootstrap = Chef::Knife::BootstrapWindowsSsh.new


### PR DESCRIPTION
This option exists in knife-windows master branch.