### PR TITLE
Stop requiring `em-winrm`

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -39,8 +39,6 @@ class Chef
       end
 
       def load_winrm_deps
-        require 'winrm'
-        require 'em-winrm'
         require 'chef/knife/winrm'
         require 'chef/knife/bootstrap_windows_winrm'
       end


### PR DESCRIPTION
This dependency was removed in chef/knife-windows@30709ba

/cc @adamedx 