### PR TITLE
Issue 205: External/Public Load Balancer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Do not include Gemfile.lock in a gem
 # http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
 Gemfile.lock
+vendor
+.bundle
 
 # OS X Metadata file
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :development do
   gem 'rspec_junit_formatter'
   gem 'rake'
   gem 'mixlib-shellout'
+  gem 'activesupport'
 end

--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ These options may also be configured from knife.rb, as in this example:
     knife[:tcp-endpoints]='80:80,3389:5678'
     knife[:udp-endpoints]='123:123'
 
+#### Endpoint configuration
+
+Endpoints are configured using tcp-endpoints and udp-endpoints. This is a string in the form:
+{localPort}:{publicPort}:{load_balancer_set_name}:{load_balancer_probe_path}
+
+Examples:
+
+    knife[:tcp-endpoints]='80'                            # Allow Port 80 inbound
+    knife[:tcp-endpoints]='80:8080'                       # Allow Port 80 inbound and map it to local port 8080
+    knife[:tcp-endpoints]='80:8080:web-set'               # Allow Port 80 and add it to the load balancing set called 'web-set'
+    knife[:tcp-endpoints]='80:8080:web-set:/healthcheck'  # Allow Port 80, add it to the load balancing set, and use an HTTP probe at path "/healthcheck"
+
+Note that the load balancing set will be created if it does not exist. If it exists within another VM in the cloud service, it will re-use those values for the probe.
+
 #### Options for Bootstrapping a Windows Node in Azure
 
     :bootstrap_protocol           Default is winrm for a windows image

--- a/lib/azure/deploy.rb
+++ b/lib/azure/deploy.rb
@@ -177,6 +177,10 @@ class Azure
       %w{LoadBalancedEndpointSetName LocalPort Name Port Protocol EnableDirectServerReturn LoadBalancerName IdleTimeoutInMinutes}.each do |key|
         hash[key] = xml_content(inputendpoint_xml, key, nil)
       end
+      # Protocol could be in there twice... If we have two, pick the second one as the first is for the probe.
+      if inputendpoint_xml.css('Protocol').count > 1
+        hash['Protocol'] = inputendpoint_xml.css('Protocol')[1].content
+      end
       probe = inputendpoint_xml.css('LoadBalancerProbe')
       if probe
         hash['LoadBalancerProbe'] = Hash.new

--- a/lib/azure/deploy.rb
+++ b/lib/azure/deploy.rb
@@ -116,7 +116,7 @@ class Azure
 
   class Deploy
     include AzureUtility
-    attr_accessor :connection, :name, :status, :url, :hostedservicename
+    attr_accessor :connection, :name, :status, :url, :hostedservicename, :input_endpoints
 
     def initialize(connection)
       @connection = connection
@@ -135,8 +135,14 @@ class Azure
           role.parse(roleXML, hostedservicename, @name)
           @roles[role.name] = role
         end
+        @input_endpoints = Array.new
+        endpointsXML = deployXML.css('InputEndpoint')
+        endpointsXML.each do |endpointXML|
+          @input_endpoints << parse_endpoint(endpointXML)
+        end
       end
     end
+
     def setup(params)
       role = Role.new(@connection)
       roleXML = role.setup(params)
@@ -158,9 +164,27 @@ class Azure
       builder.doc.at_css('Role') << roleXML.at_css('PersistentVMRole').children.to_s
       builder.doc
     end
+
     def create(params, deployXML)
       servicecall = "hostedservices/#{params[:azure_dns_name]}/deployments"
       @connection.query_azure(servicecall, "post", deployXML.to_xml)
+    end
+
+    # This parses endpoints from a RoleList-Role-InputEndpoint, NOT a RoleInstanceList-RoleInstance-InstanceEndpoint
+    # Refactor: make this an object rather than a hash..?
+    def parse_endpoint(inputendpoint_xml)
+      hash = Hash.new
+      %w{LoadBalancedEndpointSetName LocalPort Name Port Protocol EnableDirectServerReturn LoadBalancerName IdleTimeoutInMinutes}.each do |key|
+        hash[key] = xml_content(inputendpoint_xml, key, nil)
+      end
+      probe = inputendpoint_xml.css('LoadBalancerProbe')
+      if probe
+        hash['LoadBalancerProbe'] = Hash.new
+        %w{Path Port Protocol IntervalInSeconds TimeoutInSeconds}.each do |key|
+          hash['LoadBalancerProbe'][key] = xml_content(probe, key, nil)
+        end
+      end
+      hash
     end
 
     def roles

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -228,7 +228,7 @@ class Azure
         hash['LoadBalancerProbe'] = Hash.new
         hash['LoadBalancerProbe']['Path'] = fields[3]
         hash['LoadBalancerProbe']['Port'] = fields[0]
-        hash['LoadBalancerProbe']['Protocol'] = fields[3] ? 'HTTP' : 'TCP'
+        hash['LoadBalancerProbe']['Protocol'] = fields[3] ? 'HTTP' : protocol
       end
       hash
     end
@@ -267,7 +267,7 @@ class Azure
               xml.TimeoutInSeconds ep['LoadBalancerProbe']['TimeoutInSeconds'] if ep['LoadBalancerProbe']['TimeoutInSeconds']
             }
           end
-          xml.Protocol 'TCP'
+          xml.Protocol ep['Protocol']
           xml.EnableDirectServerReturn ep['EnableDirectServerReturn'] if ep['EnableDirectServerReturn']
           xml.LoadBalancerName ep['LoadBalancerName'] if ep['LoadBalancerName']
           xml.IdleTimeoutInMinutes ep['IdleTimeoutInMinutes'] if ep['IdleTimeoutInMinutes']

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -204,12 +204,75 @@ class Azure
           hash['Vip'] = xml_content(endpoint, 'Vip')
           hash['PublicPort'] = xml_content(endpoint, 'PublicPort')
           hash['LocalPort'] = xml_content(endpoint, 'LocalPort')
+
           if xml_content(endpoint, 'Protocol') == 'tcp'
             @tcpports << hash
           else # == 'udp'
             @udpports << hash
           end
         end
+      end
+    end
+
+    # Expects endpoint_param_string to be in the form {localport}:{publicport}:{lb_set_name}:{lb_probe_path}
+    # Only localport is mandatory.
+    def parse_endpoint_from_params(protocol, azure_vm_name, endpoint_param_string)
+      fields = endpoint_param_string.split(':')
+      hash = Hash.new
+      hash['LocalPort'] = fields[0]
+      hash['Port'] = fields[1] || fields[0]
+      hash['LoadBalancedEndpointSetName'] = fields[2]
+      hash['Protocol'] = protocol
+      hash['Name'] = "#{protocol.downcase}port_#{fields[0]}_#{azure_vm_name}"
+      if fields[2]
+        hash['LoadBalancerProbe'] = Hash.new
+        hash['LoadBalancerProbe']['Path'] = fields[3]
+        hash['LoadBalancerProbe']['Port'] = fields[0]
+        hash['LoadBalancerProbe']['Protocol'] = fields[3] ? 'HTTP' : 'TCP'
+      end
+      hash
+    end
+
+    def find_deploy(params)
+      @connection.hosts.find(params[:azure_dns_name]).deploys[0] # TODO this relies on the 'production only' bug.
+    end
+
+    def add_endpoints_to_xml(xml, endpoints, params)
+      existing_endpoints = find_deploy(params).input_endpoints
+
+      endpoints.each do |ep|
+      
+        if existing_endpoints
+          existing_endpoints.each do |eep|
+            ep = eep if eep['LoadBalancedEndpointSetName'] && ep['LoadBalancedEndpointSetName'] && ( eep['LoadBalancedEndpointSetName'] == ep['LoadBalancedEndpointSetName'] )
+          end
+        end
+
+        if ep['Port'] == params[:port] && ep['Protocol'].downcase == 'tcp'
+          puts("Skipping tcp-endpoints: #{ep['LocalPort']} because this port is already in use by ssh/winrm endpoint in current VM.")
+          next
+        end
+
+        xml.InputEndpoint {
+          xml.LoadBalancedEndpointSetName ep['LoadBalancedEndpointSetName'] if ep['LoadBalancedEndpointSetName']
+          xml.LocalPort ep['LocalPort']
+          xml.Name ep['Name']
+          xml.Port ep['Port']
+          if ep['LoadBalancerProbe']
+            xml.LoadBalancerProbe {
+              xml.Path ep['LoadBalancerProbe']['Path'] if ep['LoadBalancerProbe']['Path']
+              xml.Port ep['LoadBalancerProbe']['Port']
+              xml.Protocol ep['LoadBalancerProbe']['Protocol']
+              xml.IntervalInSeconds ep['LoadBalancerProbe']['IntervalInSeconds'] if ep['LoadBalancerProbe']['IntervalInSeconds']
+              xml.TimeoutInSeconds ep['LoadBalancerProbe']['TimeoutInSeconds'] if ep['LoadBalancerProbe']['TimeoutInSeconds']
+            }
+          end
+          xml.Protocol 'TCP'
+          xml.EnableDirectServerReturn ep['EnableDirectServerReturn'] if ep['EnableDirectServerReturn']
+          xml.LoadBalancerName ep['LoadBalancerName'] if ep['LoadBalancerName']
+          xml.IdleTimeoutInMinutes ep['IdleTimeoutInMinutes'] if ep['IdleTimeoutInMinutes']
+        }
+
       end
     end
 
@@ -309,43 +372,18 @@ class Azure
                   xml.Protocol 'TCP'
                 }
                 end
-
+                all_endpoints = Array.new
                 if params[:tcp_endpoints]
                   params[:tcp_endpoints].split(',').each do |endpoint|
-                    ports = endpoint.split(':')
-                    if !(ports.length > 1 && ports[1] == params[:port] || ports.length == 1 && ports[0] == params[:port])
-                      xml.InputEndpoint {
-                        xml.LocalPort ports[0]
-                        xml.Name 'tcpport_' + ports[0] + '_' + params[:azure_vm_name]
-                        if ports.length > 1
-                          xml.Port ports[1]
-                        else
-                          xml.Port ports[0]
-                        end
-                        xml.Protocol 'TCP'
-                      }
-                    else
-                      warn_message = ports.length > 1 ? "#{ports.join(':')} because this ports are" : "#{ports[0]} because this port is"
-                      puts("Skipping tcp-endpoints: #{warn_message} already in use by ssh/winrm endpoint in current VM.")
-                    end
+                    all_endpoints << parse_endpoint_from_params('TCP', params[:azure_vm_name], endpoint)
                   end
                 end
-
                 if params[:udp_endpoints]
                   params[:udp_endpoints].split(',').each do |endpoint|
-                    ports = endpoint.split(':')
-                    xml.InputEndpoint {
-                      xml.LocalPort ports[0]
-                      xml.Name 'udpport_' + ports[0] + '_' + params[:azure_vm_name]
-                      if ports.length > 1
-                        xml.Port ports[1]
-                      else
-                        xml.Port ports[0]
-                      end
-                      xml.Protocol 'UDP'
-                    }
+                    all_endpoints << parse_endpoint_from_params('UDP', params[:azure_vm_name], endpoint)
                   end
                 end
+                add_endpoints_to_xml(xml, all_endpoints, params) if all_endpoints.any?
               }
               if params[:azure_subnet_name]
                 xml.SubnetNames {

--- a/lib/knife-azure/version.rb
+++ b/lib/knife-azure/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Azure
-    VERSION = "1.4.1"
+    VERSION = "1.4.0"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/lib/knife-azure/version.rb
+++ b/lib/knife-azure/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Azure
-    VERSION = "1.4.0"
+    VERSION = "1.4.1"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/spec/unit/assets/list_deployments_for_vmname.xml
+++ b/spec/unit/assets/list_deployments_for_vmname.xml
@@ -51,6 +51,22 @@
               <Protocol>tcp</Protocol>
               <Vip>65.52.249.191</Vip>
             </InputEndpoint>
+            <InputEndpoint>
+              <LoadBalancedEndpointSetName>lb_set2</LoadBalancedEndpointSetName>
+              <LocalPort>443</LocalPort>
+              <Name>existing_lb</Name>
+              <Port>443</Port>
+              <LoadBalancerProbe>
+                <Path>/healthcheck2</Path>
+                <Port>443</Port>
+                <Protocol>http</Protocol>
+                <IntervalInSeconds>15</IntervalInSeconds>
+                <TimeoutInSeconds>31</TimeoutInSeconds>
+              </LoadBalancerProbe>
+              <Protocol>tcp</Protocol>
+              <Vip>23.102.63.187</Vip>
+              <EnableDirectServerReturn>false</EnableDirectServerReturn>
+            </InputEndpoint>
           </InputEndpoints>
           <SubnetNames/>
         </ConfigurationSet>

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -8,6 +8,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
 require 'chef/knife/bootstrap'
 require 'chef/knife/bootstrap_windows_winrm'
 require 'chef/knife/bootstrap_windows_ssh'
+require 'active_support/core_ext/hash/conversions'
 
 describe Chef::Knife::AzureServerCreate do
   include AzureSpecHelper
@@ -266,6 +267,72 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
         expect(xml_content(testxml, 'SubnetName')).to be == 'test-subnet'
+      end
+
+      it "creates new load balanced endpoints" do
+        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        @server_instance.config[:tcp_endpoints] = "80:80:lb_set,443:443:lb_set_ssl:/healthcheck" #TODO is this a good way of specifying this?
+        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
+        @server_instance.run
+        testxml = Nokogiri::XML(@receivedXML)
+        endpoints = testxml.css('InputEndpoint')
+
+        # Should be 3 endpoints, 1 for SSH, 1 for port 80 using LB set name lb_set, and 1 for port 443 using lb_set2 and with healtcheck path.
+        expect(endpoints.count).to be  == 3
+
+        # Convert it to a hash as it's easier to test.
+        eps = []
+        endpoints.each do | ep |
+          eps << Hash.from_xml(ep.to_s)
+        end
+
+        expect(eps[0]['InputEndpoint']['Name']).to be == 'SSH'
+
+        lb_set_ep = eps[1]['InputEndpoint']
+        expect(lb_set_ep['LoadBalancedEndpointSetName']).to be == 'lb_set'
+        expect(lb_set_ep['LocalPort']).to be == '80'
+        expect(lb_set_ep['Port']).to be == '80'
+        expect(lb_set_ep['Protocol']).to be == 'TCP'
+        expect(lb_set_ep['LoadBalancerProbe']['Port']).to be == '80'
+        expect(lb_set_ep['LoadBalancerProbe']['Protocol']).to be == 'TCP'
+
+        lb_set2_ep = eps[2]['InputEndpoint']
+        expect(lb_set2_ep['LoadBalancedEndpointSetName']).to be == 'lb_set_ssl'
+        expect(lb_set2_ep['LocalPort']).to be == '443'
+        expect(lb_set2_ep['Port']).to be == '443'
+        expect(lb_set2_ep['Protocol']).to be == 'TCP'
+        expect(lb_set2_ep['LoadBalancerProbe']['Path']).to be == '/healthcheck'
+        expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
+        expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'HTTP'
+      end
+      
+      it "re-uses existing load balanced endpoints" do
+        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        @server_instance.config[:tcp_endpoints] = "443:443:lb_set2:/healthcheck"
+        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
+        
+        @server_instance.run
+        testxml = Nokogiri::XML(@receivedXML)
+        endpoints = testxml.css('InputEndpoint')
+
+        expect(endpoints.count).to be  == 2
+        
+        # Convert it to a hash as it's easier to test.
+        eps = []
+        endpoints.each do | ep |
+          eps << Hash.from_xml(ep.to_s)
+        end
+        expect(eps[0]['InputEndpoint']['Name']).to be == 'SSH'
+
+        lb_set2_ep = eps[1]['InputEndpoint']
+        expect(lb_set2_ep['LoadBalancedEndpointSetName']).to be == 'lb_set2'
+        expect(lb_set2_ep['LocalPort']).to be == '443'
+        expect(lb_set2_ep['Port']).to be == '443'
+        expect(lb_set2_ep['Protocol']).to be == 'TCP'
+        expect(lb_set2_ep['LoadBalancerProbe']['Path']).to be == '/healthcheck2' # The existing one wins. This is defined in the stub.
+        expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
+        expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'http'
+
       end
 
       it "server create display server summary" do

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -328,7 +328,7 @@ describe Chef::Knife::AzureServerCreate do
         expect(lb_set2_ep['LoadBalancedEndpointSetName']).to be == 'lb_set2'
         expect(lb_set2_ep['LocalPort']).to be == '443'
         expect(lb_set2_ep['Port']).to be == '443'
-        expect(lb_set2_ep['Protocol']).to be == 'TCP'
+        expect(lb_set2_ep['Protocol']).to be == 'tcp'
         expect(lb_set2_ep['LoadBalancerProbe']['Path']).to be == '/healthcheck2' # The existing one wins. This is defined in the stub.
         expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
         expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'http'


### PR DESCRIPTION
Allowing TCP and UDP endpoint param string to also specify a load balancer set name and probe path. This is for load balancing public IPs - not internal ones.