### PR TITLE
Allow user to specify chef extension version by using knife_rb 

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -807,8 +807,12 @@ class Chef
 
       # get latest version
       def get_chef_extension_version
-        extensions = @connection.query_azure("resourceextensions/#{get_chef_extension_publisher}/#{get_chef_extension_name}")
-        extensions.css("Version").max.text.split(".").first + ".*"
+        if locate_config_value(:azure_chef_extension_version)
+          Chef::Config[:knife][:azure_chef_extension_version]
+        else
+          extensions = @connection.query_azure("resourceextensions/#{get_chef_extension_publisher}/#{get_chef_extension_name}")
+          extensions.css("Version").max.text.split(".").first + ".*"
+        end
       end
 
       def get_chef_extension_public_params

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -751,6 +751,13 @@ describe Chef::Knife::AzureServerCreate do
       end
     end
 
+    context "get azure chef extension version" do
+      it "take user specified verison" do
+        Chef::Config[:knife][:azure_chef_extension_version] = "1200.12"
+        expect(@server_instance.get_chef_extension_version).to eq("1200.12")
+      end
+    end
+
     context "windows instance:" do
       it "successful create" do
         expect(@server_instance).to_not receive(:bootstrap_exec)


### PR DESCRIPTION
Added support to specify extension version by using knife_rb. 
Ex: `knife[:azure_chef_extension_version] = "1200.12"`
