### PR TITLE
Added --delete-chef-config option to knife azure server create

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -253,6 +253,12 @@ class Chef
         :long => "--winrm-max-memoryPerShell MB",
         :description => "Set winrm max memory per shell in MB"
 
+      option :delete_chef_config,
+        :long => "--delete-chef-config",
+        :boolean => true,
+        :default => false,
+        :description => "Set this flag if you want to delete chef configuration files on uninsall or update"
+
       def strip_non_ascii(string)
         string.gsub(/[^0-9a-z ]/i, '')
       end
@@ -602,7 +608,6 @@ class Chef
       end
 
       def bootstrap_common_params(bootstrap, server)
-
         bootstrap.config[:run_list] = config[:run_list]
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:first_boot_attributes] = locate_config_value(:json_attributes) || {}
@@ -830,6 +835,7 @@ class Chef
         pub_config[:client_rb] = "chef_server_url \t #{Chef::Config[:chef_server_url].to_json}\nvalidation_client_name\t#{Chef::Config[:validation_client_name].to_json}"
         pub_config[:runlist] = locate_config_value(:run_list).empty? ? "" : locate_config_value(:run_list).join(",").to_json
         pub_config[:autoUpdateClient] = locate_config_value(:auto_update_client) ? "true" : "false"
+        pub_config[:deleteChefConfig] = locate_config_value(:delete_chef_config) ? "true" : "false"
         pub_config[:custom_json_attr] = locate_config_value(:json_attributes) || {}
 
         # bootstrap attributes

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -257,7 +257,7 @@ class Chef
         :long => "--delete-chef-config",
         :boolean => true,
         :default => false,
-        :description => "Set this flag if you want to delete chef configuration files on uninsall or update"
+        :description => "Set this flag to delete chef configuration files during chef extension uninstall or update process it by default set to false"
 
       def strip_non_ascii(string)
         string.gsub(/[^0-9a-z ]/i, '')

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -749,6 +749,22 @@ describe Chef::Knife::AzureServerCreate do
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
       end
+
+      it "should set deleteChefConfig flag to true" do
+        @server_instance.config[:delete_chef_config] = true
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"deleteChefConfig\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+
+        expect(Base64).to receive(:encode64).with(public_config)
+        @server_instance.get_chef_extension_public_params
+      end
+
+      it "should set deleteChefConfig flag to false" do
+        @server_instance.config[:delete_chef_config] = false
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+
+        expect(Base64).to receive(:encode64).with(public_config)
+        @server_instance.get_chef_extension_public_params
+      end
     end
 
     context "get azure chef extension version" do

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -736,7 +736,7 @@ describe Chef::Knife::AzureServerCreate do
     context "get_chef_extension_public_params" do
       it "should set autoUpdateClient flag to true" do
         @server_instance.config[:auto_update_client] = true
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"true\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
@@ -744,7 +744,7 @@ describe Chef::Knife::AzureServerCreate do
 
       it "should set autoUpdateClient flag to false" do
         @server_instance.config[:auto_update_client] = false
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
@@ -752,7 +752,7 @@ describe Chef::Knife::AzureServerCreate do
 
       it "should set deleteChefConfig flag to true" do
         @server_instance.config[:delete_chef_config] = true
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"deleteChefConfig\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
@@ -760,7 +760,7 @@ describe Chef::Knife::AzureServerCreate do
 
       it "should set deleteChefConfig flag to false" do
         @server_instance.config[:delete_chef_config] = false
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params


### PR DESCRIPTION
Added --delete-chef-config option to set deleteChefConfig value for deleting configuration files while chef extension uninstall or update process based on option value.