### PR TITLE
Added --delete-chef-config option in knife azure server create

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -254,11 +254,11 @@ class Chef
         :description => "Set winrm max memory per shell in MB"
 
 
-      option :delete_chef_config,
-        :long => "--delete-chef-config",
+      option :delete_chef_extension_config,
+        :long => "--delete-chef-extension-config",
         :boolean => true,
         :default => false,
-        :description => "Set this flag to delete chef configuration files during chef extension uninstall or update process it by default set to false"
+        :description => "Determines whether Chef configuration files removed when Azure removes the Chef resource extension from the VM. This option is only valid for the 'cloud-api' bootstrap protocol. The default is false."
 
 
       def strip_non_ascii(string)
@@ -493,6 +493,12 @@ class Chef
 
         Chef::Log.info("validating...")
         validate!
+
+        if (locate_config_value(:auto_update_client) ||  locate_config_value(:delete_chef_extension_config))  &&  (locate_config_value(:bootstrap_protocol) != 'cloud-api')
+          ui.error("--auto-update-client option works with --bootstrap-protocol cloud-api") if locate_config_value(:auto_update_client)
+          ui.error("--delete-chef-extension-config option works with --bootstrap-protocol cloud-api") if locate_config_value(:delete_chef_extension_config)
+          exit 1
+        end
 
         ssh_override_winrm if %w(ssh cloud-api).include?(locate_config_value(:bootstrap_protocol)) and !is_image_windows?
 
@@ -838,7 +844,7 @@ class Chef
         pub_config[:client_rb] = "chef_server_url \t #{Chef::Config[:chef_server_url].to_json}\nvalidation_client_name\t#{Chef::Config[:validation_client_name].to_json}"
         pub_config[:runlist] = locate_config_value(:run_list).empty? ? "" : locate_config_value(:run_list).join(",").to_json
         pub_config[:autoUpdateClient] = locate_config_value(:auto_update_client) ? "true" : "false"
-        pub_config[:deleteChefConfig] = locate_config_value(:delete_chef_config) ? "true" : "false"
+        pub_config[:deleteChefConfig] = locate_config_value(:delete_chef_extension_config) ? "true" : "false"
         pub_config[:custom_json_attr] = locate_config_value(:json_attributes) || {}
 
         # bootstrap attributes

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -253,6 +253,14 @@ class Chef
         :long => "--winrm-max-memoryPerShell MB",
         :description => "Set winrm max memory per shell in MB"
 
+
+      option :delete_chef_config,
+        :long => "--delete-chef-config",
+        :boolean => true,
+        :default => false,
+        :description => "Set this flag to delete chef configuration files during chef extension uninstall or update process it by default set to false"
+
+
       def strip_non_ascii(string)
         string.gsub(/[^0-9a-z ]/i, '')
       end
@@ -830,6 +838,7 @@ class Chef
         pub_config[:client_rb] = "chef_server_url \t #{Chef::Config[:chef_server_url].to_json}\nvalidation_client_name\t#{Chef::Config[:validation_client_name].to_json}"
         pub_config[:runlist] = locate_config_value(:run_list).empty? ? "" : locate_config_value(:run_list).join(",").to_json
         pub_config[:autoUpdateClient] = locate_config_value(:auto_update_client) ? "true" : "false"
+        pub_config[:deleteChefConfig] = locate_config_value(:delete_chef_config) ? "true" : "false"
         pub_config[:custom_json_attr] = locate_config_value(:json_attributes) || {}
 
         # bootstrap attributes

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -736,7 +736,7 @@ describe Chef::Knife::AzureServerCreate do
     context "get_chef_extension_public_params" do
       it "should set autoUpdateClient flag to true" do
         @server_instance.config[:auto_update_client] = true
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"true\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
@@ -744,7 +744,23 @@ describe Chef::Knife::AzureServerCreate do
 
       it "should set autoUpdateClient flag to false" do
         @server_instance.config[:auto_update_client] = false
-        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+
+        expect(Base64).to receive(:encode64).with(public_config)
+        @server_instance.get_chef_extension_public_params
+      end
+
+      it "should set deleteChefConfig flag to true" do
+        @server_instance.config[:delete_chef_config] = true
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
+
+        expect(Base64).to receive(:encode64).with(public_config)
+        @server_instance.get_chef_extension_public_params
+      end
+
+      it "should set deleteChefConfig flag to false" do
+        @server_instance.config[:delete_chef_config] = false
+        public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -717,6 +717,31 @@ describe Chef::Knife::AzureServerCreate do
     end
   end
 
+  describe "for --auto-udpate-client and --delete-chef-extension-config" do
+    before do
+      allow(@server_instance).to receive(:msg_server_summary)
+      Chef::Config[:knife][:run_list] = ['getting-started']
+      Chef::Config[:knife][:validation_client_name] = 'testorg-validator'
+      Chef::Config[:knife][:chef_server_url] = 'https://api.opscode.com/organizations/testorg'
+    end
+
+    after do
+      Chef::Config[:knife].delete(:bootstrap_protocol)
+      Chef::Config[:knife].delete(:run_list)
+      Chef::Config[:knife].delete(:validation_client_name)
+      Chef::Config[:knife].delete(:chef_server_url)
+    end
+
+    context 'option --bootstrap-protocol cloud-api not passed' do
+      it 'throws error and server create command fails.' do
+        @server_instance.config[:auto_update_client] = true
+        @server_instance.config[:delete_chef_extension_config] = true
+        allow(@server_instance.ui).to receive(:error)
+        expect {@server_instance.run}.to raise_error
+      end
+    end
+  end
+
   describe "for bootstrap protocol cloud-api:" do
     before do
       Chef::Config[:knife][:bootstrap_protocol] = 'cloud-api'
@@ -750,16 +775,16 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.get_chef_extension_public_params
       end
 
-      it "should set deleteChefConfig flag to true" do
-        @server_instance.config[:delete_chef_config] = true
+      it "sets deleteChefConfig flag to true" do
+        @server_instance.config[:delete_chef_extension_config] = true
         public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"true\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)
         @server_instance.get_chef_extension_public_params
       end
 
-      it "should set deleteChefConfig flag to false" do
-        @server_instance.config[:delete_chef_config] = false
+      it "sets deleteChefConfig flag to false" do
+        @server_instance.config[:delete_chef_extension_config] = false
         public_config = "{\"client_rb\":\"chef_server_url \\t \\\"https://localhost:443\\\"\\nvalidation_client_name\\t\\\"chef-validator\\\"\",\"runlist\":\"\\\"getting-started\\\"\",\"autoUpdateClient\":\"false\",\"deleteChefConfig\":\"false\",\"custom_json_attr\":{},\"bootstrap_options\":{\"chef_server_url\":\"https://localhost:443\",\"validation_client_name\":\"chef-validator\"}}"
 
         expect(Base64).to receive(:encode64).with(public_config)


### PR DESCRIPTION
Added --delete-chef-config option to set deleteChefConfig value. It allows to delete chef configuration files during chef extension uninstall or update process by default its set to false and will not delete the configuration files.