### PR TITLE
Added em-winrm dependency back

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -40,6 +40,7 @@ class Chef
 
       def load_winrm_deps
         require 'winrm'
+        require 'em-winrm'
         require 'chef/knife/winrm'
         require 'chef/knife/bootstrap_windows_winrm'
       end


### PR DESCRIPTION
`knife azure server create` command with negotiate protocol fails due to removal of this dependency as `knife-windows` released version still uses `em-winrm`