### PR TITLE
VM not getting created for linux unless --bootstrap-protocol=ssh

### DIFF
--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -431,7 +431,7 @@ class Azure
                   xml.Port params[:port]
                   xml.Protocol 'TCP'
                 }
-                elsif params[:os_type] == 'Linux' and params[:bootstrap_proto].downcase == 'ssh'
+                else
                   xml.InputEndpoint {
                   xml.LocalPort '22'
                   xml.Name 'SSH'

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -420,6 +420,9 @@ class Azure
               xml.ConfigurationSetType 'NetworkConfiguration'
               xml.InputEndpoints {
 
+                #1. bootstrap_proto = 'winrm' for windows => Set winrm port
+                #2. bootstrap_proto = 'ssh' for windows and linux => Set ssh port
+                #3. bootstrap_proto = 'cloud-api' for windows and linux => Set no port
                 if params[:os_type] == 'Windows' and params[:bootstrap_proto].downcase == 'winrm'
                   xml.InputEndpoint {
                   if params[:winrm_transport] == "ssl"
@@ -431,7 +434,7 @@ class Azure
                   xml.Port params[:port]
                   xml.Protocol 'TCP'
                 }
-                else
+                elsif(params[:bootstrap_proto].downcase == 'ssh')
                   xml.InputEndpoint {
                   xml.LocalPort '22'
                   xml.Name 'SSH'

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -919,7 +919,7 @@ class Chef
           server_def[:bootstrap_proto] = locate_config_value(:bootstrap_protocol)
         else
           server_def[:os_type] = 'Linux'
-          server_def[:bootstrap_proto] = 'ssh'
+          server_def[:bootstrap_proto] = (locate_config_value(:bootstrap_protocol) == 'winrm') ? 'ssh' : locate_config_value(:bootstrap_protocol)
           server_def[:ssh_user] = locate_config_value(:ssh_user)
           server_def[:ssh_password] = locate_config_value(:ssh_password)
           server_def[:identity_file] = locate_config_value(:identity_file)

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -919,7 +919,7 @@ class Chef
           server_def[:bootstrap_proto] = locate_config_value(:bootstrap_protocol)
         else
           server_def[:os_type] = 'Linux'
-          server_def[:bootstrap_proto] =  locate_config_value(:bootstrap_protocol) || 'ssh'
+          server_def[:bootstrap_proto] = 'ssh'
           server_def[:ssh_user] = locate_config_value(:ssh_user)
           server_def[:ssh_password] = locate_config_value(:ssh_password)
           server_def[:identity_file] = locate_config_value(:identity_file)

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -1020,7 +1020,7 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
         testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
-          expect(port.parent.css("LocalPort").text).to_not eq("22")
+          expect(port.parent.css("LocalPort").text).to eq("22")
         end
       end
 


### PR DESCRIPTION
We have to specify --bootstrap-protocol=shh while creating linux VM. This was not the case earlier. Specifying  --bootstrap-protocol was not mandatory. 