### PR TITLE
Implemented changes to set winrm_ssl_verify_mode to none for server create

### DIFF
--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -365,9 +365,9 @@ class Azure
                     end
                     xml.WinRM {
                       xml.Listeners {
-                       if params[:ssl_cert_fingerprint]
+                       if params[:winrm_transport] == "ssl" || params[:ssl_cert_fingerprint]
                         xml.Listener {
-                          xml.CertificateThumbprint params[:ssl_cert_fingerprint]
+                          xml.CertificateThumbprint params[:ssl_cert_fingerprint] if params[:ssl_cert_fingerprint]
                           xml.Protocol 'Https'
                         }
                         else

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -740,11 +740,7 @@ class Chef
             bootstrap.config[:winrm_port] = port
             bootstrap.config[:auth_timeout] = locate_config_value(:auth_timeout)
             # Todo: we should skip cert generate in case when winrm_ssl_verify_mode=verify_none
-            if locate_config_value(:winrm_transport) == "ssl" && locate_config_value(:thumbprint).nil? && locate_config_value(:winrm_ssl_verify_mode) == :verify_peer
-              bootstrap.config[:winrm_ssl_verify_mode] = :verify_none
-            else
-              bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
-            end
+            bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
         elsif locate_config_value(:bootstrap_protocol) == 'ssh'
             bootstrap = Chef::Knife::BootstrapWindowsSsh.new
             bootstrap.config[:ssh_user] = locate_config_value(:ssh_user)
@@ -832,6 +828,11 @@ class Chef
             ui.error("Must specify both --azure-domain-user and --azure-domain-passwd.")
             exit 1
           end
+        end
+
+        if locate_config_value(:winrm_transport) == "ssl" && locate_config_value(:thumbprint).nil? && ( locate_config_value(:winrm_ssl_verify_mode).nil? || locate_config_value(:winrm_ssl_verify_mode) == :verify_peer )
+          ui.error("For SSL transport must specify --winrm-ssl-verify-mode option to 'verify_none' OR specify --thumbprint option.")
+          exit 1
         end
       end
 

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -831,7 +831,7 @@ class Chef
         end
 
         if locate_config_value(:winrm_transport) == "ssl" && locate_config_value(:thumbprint).nil? && ( locate_config_value(:winrm_ssl_verify_mode).nil? || locate_config_value(:winrm_ssl_verify_mode) == :verify_peer )
-          ui.error("For SSL transport must specify --winrm-ssl-verify-mode option to 'verify_none' OR specify --thumbprint option.")
+          ui.error("The SSL transport was specified without the --thumbprint option. Specify a thumbprint, or alternatively set the --winrm-ssl-verify-mode option to 'verify_none' to skip verification.")
           exit 1
         end
       end

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -740,8 +740,11 @@ class Chef
             bootstrap.config[:winrm_port] = port
             bootstrap.config[:auth_timeout] = locate_config_value(:auth_timeout)
             # Todo: we should skip cert generate in case when winrm_ssl_verify_mode=verify_none
-            bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
-
+            if locate_config_value(:winrm_transport) == "ssl" && locate_config_value(:thumbprint).nil? && locate_config_value(:winrm_ssl_verify_mode) == :verify_peer
+              bootstrap.config[:winrm_ssl_verify_mode] = :verify_none
+            else
+              bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
+            end
         elsif locate_config_value(:bootstrap_protocol) == 'ssh'
             bootstrap = Chef::Knife::BootstrapWindowsSsh.new
             bootstrap.config[:ssh_user] = locate_config_value(:ssh_user)

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -147,6 +147,15 @@ describe Chef::Knife::AzureServerCreate do
           expect {@server_instance.run}.to raise_error
         end
       end
+
+      context "when winrm-transport ssl and missing thumbprint" do
+        it "raise error on :winrm_ssl_verify_mode verify_peer" do
+          Chef::Config[:knife][:winrm_transport] = 'ssl'
+          Chef::Config[:knife][:winrm_ssl_verify_mode] = :verify_peer
+          expect(@server_instance.ui).to receive(:error)
+          expect {@server_instance.run}.to raise_error
+        end
+      end
     end
 
     context "timeout parameters" do
@@ -759,13 +768,6 @@ describe Chef::Knife::AzureServerCreate do
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(true)
         @server_instance.run
         expect(@bootstrap.config[:winrm_authentication_protocol]).to be == 'negotiate'
-      end
-      it "sets winrm_ssl_verify_mode to verify_none for ssl transport and missing thumbprint" do
-        Chef::Config[:knife][:winrm_transport] = 'ssl'
-        Chef::Config[:knife][:winrm_ssl_verify_mode] = :verify_peer
-        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(true)
-        @server_instance.run
-        expect(@bootstrap.config[:winrm_ssl_verify_mode]).to be == :verify_none
       end
     end
   end

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -760,6 +760,13 @@ describe Chef::Knife::AzureServerCreate do
         @server_instance.run
         expect(@bootstrap.config[:winrm_authentication_protocol]).to be == 'negotiate'
       end
+      it "sets winrm_ssl_verify_mode to verify_none for ssl transport and missing thumbprint" do
+        Chef::Config[:knife][:winrm_transport] = 'ssl'
+        Chef::Config[:knife][:winrm_ssl_verify_mode] = :verify_peer
+        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(true)
+        @server_instance.run
+        expect(@bootstrap.config[:winrm_ssl_verify_mode]).to be == :verify_none
+      end
     end
   end
 


### PR DESCRIPTION
knife azure server create with `winrm_transport = :ssl` and `thumbprint = nil` should always use `winrm_ssl_verify = verify_none` by default. 
