### PR TITLE
Added meaningful names  for TCP endpoint

### DIFF
--- a/lib/chef/knife/azure_internal-lb_create.rb
+++ b/lib/chef/knife/azure_internal-lb_create.rb
@@ -35,10 +35,10 @@ class Chef
         :description => 'Optional. The Virtual IP that will be used for the load balancer.'
 
       option :azure_subnet_name,
-        :long => '--azure-subnet_name SUBNET_NAME',
+        :long => '--azure-subnet-name SUBNET_NAME',
         :description => 'Required if static VIP is set. Specifies the subnet name '\
                         'the load balancer is located in.'
-      
+
       option :azure_dns_name,
         :long => "--azure-dns-name DNS_NAME",
         :description => "The DNS prefix name that will be used to add this load balancer to. This must be an existing service/deployment."

--- a/spec/unit/assets/create_role.xml
+++ b/spec/unit/assets/create_role.xml
@@ -21,26 +21,38 @@
           <Protocol>TCP</Protocol>
         </InputEndpoint>
         <InputEndpoint>
+          <LocalPort>80</LocalPort>
+          <Name>HTTP</Name>
+          <Port>80</Port>
+          <Protocol>TCP</Protocol>
+        </InputEndpoint>
+        <InputEndpoint>
+          <LocalPort>3389</LocalPort>
+          <Name>Remote Desktop</Name>
+          <Port>3389</Port>
+          <Protocol>TCP</Protocol>
+        </InputEndpoint>
+        <InputEndpoint>
+          <LocalPort>993</LocalPort>
+          <Name>IMAPS</Name>
+          <Port>993</Port>
+          <Protocol>TCP</Protocol>
+        </InputEndpoint>
+        <InputEndpoint>
           <LocalPort>44</LocalPort>
-          <Name>tcpport_44_vm01</Name>
+          <Name>TCPEndpoint_chef_44</Name>
           <Port>45</Port>
           <Protocol>TCP</Protocol>
         </InputEndpoint>
         <InputEndpoint>
-          <LocalPort>55</LocalPort>
-          <Name>tcpport_55_vm01</Name>
-          <Port>55</Port>
-          <Protocol>TCP</Protocol>
-        </InputEndpoint>
-        <InputEndpoint>
           <LocalPort>65</LocalPort>
-          <Name>udpport_65_vm01</Name>
+          <Name>UDPEndpoint_chef_65</Name>
           <Port>65</Port>
           <Protocol>UDP</Protocol>
         </InputEndpoint>
         <InputEndpoint>
           <LocalPort>75</LocalPort>
-          <Name>udpport_75_vm01</Name>
+          <Name>UDPEndpoint_chef_75</Name>
           <Port>75</Port>
           <Protocol>UDP</Protocol>
         </InputEndpoint>

--- a/spec/unit/roles_create_spec.rb
+++ b/spec/unit/roles_create_spec.rb
@@ -1,6 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
-require 'pry'
 
 class Azure
   class Certificate
@@ -33,6 +32,7 @@ describe "roles" do
       end
     end
   end
+
   context 'delete a role' do
     context 'when the role is the only one in a deployment' do
       it 'should pass in correct name, verb, and body' do
@@ -43,6 +43,7 @@ describe "roles" do
       end
     end
   end
+
   context 'create a new role' do
     it 'should pass in expected body' do
       params = {
@@ -55,7 +56,7 @@ describe "roles" do
         :azure_os_disk_name=>'disk004Test',
         :azure_source_image=>'SUSE__OpenSUSE64121-03192012-en-us-15GB',
         :azure_vm_size=>'ExtraSmall',
-        :tcp_endpoints=>'44:45,55:55',
+        :tcp_endpoints => '80:80, 3389:3389, 993:993, 44: 45',
         :udp_endpoints=>'65:65,75',
         :azure_storage_account=>'storageaccount001',
         :bootstrap_proto=>'ssh',
@@ -68,6 +69,50 @@ describe "roles" do
       expect(readFile('create_role.xml')).to eq(@receivedXML)
     end
   end
+
+  describe 'assign tcp endpoint name' do
+    before do
+      @params = {
+        azure_dns_name: 'service001',
+        azure_api_host_name: 'management.core.windows.net',
+        azure_vm_name: 'vm01',
+        ssh_user: 'jetstream',
+        ssh_password: 'jetstream1!',
+        media_location_prefix: 'auxpreview104',
+        azure_source_image: 'SUSE__OpenSUSE64121-03192012-en-us-15GB',
+        azure_vm_size: 'ExtraSmall',
+        azure_storage_account: 'storageaccount001',
+        bootstrap_proto: 'ssh'
+      }
+    end
+
+    context 'tcp_endpoint 80:80' do
+      it 'assigns tcp endpoint name HTTP' do
+        @params[:tcp_endpoints] = '80:80'
+        @connection.deploys.create(@params)
+        doc = Nokogiri::XML::Document.parse(@receivedXML)
+        doc.remove_namespaces!
+        endpoints = doc.xpath('//InputEndpoints/InputEndpoint')
+        endpoints[1].children.each do |node|
+          expect(node.children.text).to eq('HTTP') if node.name == 'Name'
+        end
+      end
+    end
+
+    context 'tcp_endpoint 44:45' do
+      it 'generates tcp endpoint name as TCPEndpoint_chef_<port_number>' do
+        @params[:tcp_endpoints] = '44:45'
+        @connection.deploys.create(@params)
+        doc = Nokogiri::XML::Document.parse(@receivedXML)
+        doc.remove_namespaces!
+        endpoints = doc.xpath('//InputEndpoints/InputEndpoint')
+        endpoints[1].children.each do |node|
+          expect(node.children.text).to eq('TCPEndpoint_chef_44') if node.name == 'Name'
+        end
+      end
+    end
+  end
+
   context 'create a new deployment' do
     it 'should pass in expected body' do
       params = {


### PR DESCRIPTION
Mapped ports with names and tried to keep it similar to azure portal.
For custom ports which not listed on azure portal it will have a old naming conventions.

for e.g if --tcp-endpoints '80:80, 45:53' it will assign name HTTP for port 80 and for 45:53 it will be something like TCPEndpoint_chef_45

Fixed option azure_subnet_name typo for :long name in knife azure internal lb create