### PR TITLE
Fixed ssh tcp endpoint issue for cloud-api

### DIFF
--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -272,6 +272,11 @@ class Azure
           end
         end
 
+        if ep['Port'] == params[:port] && ep['Protocol'].downcase == 'tcp'
+          puts("Skipping tcp-endpoints: #{ep['LocalPort']} because this port is already in use by ssh/winrm endpoint in current VM.")
+          next
+        end
+
         xml.InputEndpoint {
           xml.LoadBalancedEndpointSetName ep['LoadBalancedEndpointSetName'] if ep['LoadBalancedEndpointSetName']
           xml.LocalPort ep['LocalPort']

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -272,11 +272,6 @@ class Azure
           end
         end
 
-        if ep['Port'] == params[:port] && ep['Protocol'].downcase == 'tcp'
-          puts("Skipping tcp-endpoints: #{ep['LocalPort']} because this port is already in use by ssh/winrm endpoint in current VM.")
-          next
-        end
-
         xml.InputEndpoint {
           xml.LoadBalancedEndpointSetName ep['LoadBalancedEndpointSetName'] if ep['LoadBalancedEndpointSetName']
           xml.LocalPort ep['LocalPort']

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -678,6 +678,7 @@ class Chef
             Chef::Log.fatal("server not created")
             exit 1
           end
+
           port = server.sshport
 
           print ui.color("Waiting for sshd on #{fqdn}:#{port}", :magenta)
@@ -716,7 +717,7 @@ class Chef
         bootstrap.config[:first_boot_attributes] = locate_config_value(:json_attributes) || {}
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:distro] = locate_config_value(:distro) || default_bootstrap_template
-        # setting bootstrap_template value to template_file for backward
+        # setting bootstrap_template value to template_file for backward 
         bootstrap.config[:template_file] = locate_config_value(:template_file) || locate_config_value(:bootstrap_template)
         bootstrap.config[:node_ssl_verify_mode] = locate_config_value(:node_ssl_verify_mode)
         bootstrap.config[:node_verify_api_cert] = locate_config_value(:node_verify_api_cert)
@@ -874,13 +875,13 @@ class Chef
         }
         # If user is connecting a new VM to an existing dns, then
         # the VM needs to have a unique public port. Logic below takes care of this.
-        if !is_image_windows? && locate_config_value(:bootstrap_protocol) == 'ssh'
+        if !is_image_windows? or locate_config_value(:bootstrap_protocol) == 'ssh'
           if locate_config_value(:azure_connect_to_existing_dns)
             port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000
           else
             port = locate_config_value(:ssh_port) || '22'
           end
-        elsif is_image_windows? && locate_config_value(:bootstrap_protocol) == 'winrm'
+        else
           if locate_config_value(:azure_connect_to_existing_dns)
             port = locate_config_value(:winrm_port) || Random.rand(64000) + 1000
           else

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -717,7 +717,7 @@ class Chef
         bootstrap.config[:first_boot_attributes] = locate_config_value(:json_attributes) || {}
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:distro] = locate_config_value(:distro) || default_bootstrap_template
-        # setting bootstrap_template value to template_file for backward 
+        # setting bootstrap_template value to template_file for backward
         bootstrap.config[:template_file] = locate_config_value(:template_file) || locate_config_value(:bootstrap_template)
         bootstrap.config[:node_ssl_verify_mode] = locate_config_value(:node_ssl_verify_mode)
         bootstrap.config[:node_verify_api_cert] = locate_config_value(:node_verify_api_cert)
@@ -875,17 +875,17 @@ class Chef
         }
         # If user is connecting a new VM to an existing dns, then
         # the VM needs to have a unique public port. Logic below takes care of this.
-        if !is_image_windows? or locate_config_value(:bootstrap_protocol) == 'ssh'
-          if locate_config_value(:azure_connect_to_existing_dns)
-            port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000
-          else
-            port = locate_config_value(:ssh_port) || '22'
-          end
-        else
+        if is_image_windows? && locate_config_value(:bootstrap_protocol) == 'winrm'
           if locate_config_value(:azure_connect_to_existing_dns)
             port = locate_config_value(:winrm_port) || Random.rand(64000) + 1000
           else
             port = locate_config_value(:winrm_port) || '5985'
+          end
+        elsif locate_config_value(:bootstrap_protocol) == 'ssh'
+          if locate_config_value(:azure_connect_to_existing_dns)
+            port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000
+          else
+            port = locate_config_value(:ssh_port) || '22'
           end
         end
         server_def[:port] = port

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -678,7 +678,6 @@ class Chef
             Chef::Log.fatal("server not created")
             exit 1
           end
-
           port = server.sshport
 
           print ui.color("Waiting for sshd on #{fqdn}:#{port}", :magenta)
@@ -717,7 +716,7 @@ class Chef
         bootstrap.config[:first_boot_attributes] = locate_config_value(:json_attributes) || {}
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:distro] = locate_config_value(:distro) || default_bootstrap_template
-        # setting bootstrap_template value to template_file for backward 
+        # setting bootstrap_template value to template_file for backward
         bootstrap.config[:template_file] = locate_config_value(:template_file) || locate_config_value(:bootstrap_template)
         bootstrap.config[:node_ssl_verify_mode] = locate_config_value(:node_ssl_verify_mode)
         bootstrap.config[:node_verify_api_cert] = locate_config_value(:node_verify_api_cert)
@@ -875,13 +874,13 @@ class Chef
         }
         # If user is connecting a new VM to an existing dns, then
         # the VM needs to have a unique public port. Logic below takes care of this.
-        if !is_image_windows? or locate_config_value(:bootstrap_protocol) == 'ssh'
+        if !is_image_windows? && locate_config_value(:bootstrap_protocol) == 'ssh'
           if locate_config_value(:azure_connect_to_existing_dns)
             port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000
           else
             port = locate_config_value(:ssh_port) || '22'
           end
-        else
+        elsif is_image_windows? && locate_config_value(:bootstrap_protocol) == 'winrm'
           if locate_config_value(:azure_connect_to_existing_dns)
             port = locate_config_value(:winrm_port) || Random.rand(64000) + 1000
           else

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -314,18 +314,18 @@ describe Chef::Knife::AzureServerCreate do
         expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
         expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'HTTP'
       end
-      
+
       it "re-uses existing load balanced endpoints" do
         Chef::Config[:knife][:azure_dns_name] = 'vmname'
         @server_instance.config[:tcp_endpoints] = "443:443:EXTERNAL:lb_set2:/healthcheck"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-        
+
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
         endpoints = testxml.css('InputEndpoint')
 
         expect(endpoints.count).to be  == 2
-        
+
         # Convert it to a hash as it's easier to test.
         eps = []
         endpoints.each do | ep |
@@ -605,6 +605,7 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "port should be ssh-port value specified in the option" do
+        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
         Chef::Config[:knife][:ssh_user] = 'azureuser'
         Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
         Chef::Config[:knife][:ssh_port] = '24'
@@ -614,6 +615,7 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "port should be 22 if user specified --ssh-port 22" do
+        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
         Chef::Config[:knife][:ssh_user] = 'azureuser'
         Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
         Chef::Config[:knife][:ssh_port] = '22'
@@ -795,7 +797,7 @@ describe Chef::Knife::AzureServerCreate do
     context "windows instance:" do
       before do
         Chef::Config[:knife][:forward_agent] = true
-      end  
+      end
 
       it "successful bootstrap" do
         pending "OC-8384-support ssh for windows vm's in knife-azure"

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -230,19 +230,6 @@ describe Chef::Knife::AzureServerCreate do
         end
       end
 
-      it "skip user specified tcp-endpoints if its ports already use by ssh endpoint" do
-        # Default external port for ssh endpoint is 22.
-        @server_instance.config[:tcp_endpoints] = "12:22"
-        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-        Chef::Config[:knife][:azure_dns_name] = 'vmname' # service name to be used as vm name
-        @server_instance.run
-        testxml = Nokogiri::XML(@receivedXML)
-        testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
-          # Test data in @server_instance.config[:tcp_endpoints]:=> "12:22" this endpoints external port 22 is already use by ssh endpoint. So it should skip endpoint "12:22".
-          expect(port.parent.css("LocalPort").text).to_not eq("12")
-        end
-      end
-
       it "advanced create" do
         # set all params
         Chef::Config[:knife][:azure_dns_name] = 'service001'
@@ -314,18 +301,18 @@ describe Chef::Knife::AzureServerCreate do
         expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
         expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'HTTP'
       end
-      
+
       it "re-uses existing load balanced endpoints" do
         Chef::Config[:knife][:azure_dns_name] = 'vmname'
         @server_instance.config[:tcp_endpoints] = "443:443:EXTERNAL:lb_set2:/healthcheck"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-        
+
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
         endpoints = testxml.css('InputEndpoint')
 
         expect(endpoints.count).to be  == 2
-        
+
         # Convert it to a hash as it's easier to test.
         eps = []
         endpoints.each do | ep |
@@ -795,7 +782,7 @@ describe Chef::Knife::AzureServerCreate do
     context "windows instance:" do
       before do
         Chef::Config[:knife][:forward_agent] = true
-      end  
+      end
 
       it "successful bootstrap" do
         pending "OC-8384-support ssh for windows vm's in knife-azure"

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -230,6 +230,19 @@ describe Chef::Knife::AzureServerCreate do
         end
       end
 
+      it "skip user specified tcp-endpoints if its ports already use by ssh endpoint" do
+        # Default external port for ssh endpoint is 22.
+        @server_instance.config[:tcp_endpoints] = "12:22"
+        expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
+        Chef::Config[:knife][:azure_dns_name] = 'vmname' # service name to be used as vm name
+        @server_instance.run
+        testxml = Nokogiri::XML(@receivedXML)
+        testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
+          # Test data in @server_instance.config[:tcp_endpoints]:=> "12:22" this endpoints external port 22 is already use by ssh endpoint. So it should skip endpoint "12:22".
+          expect(port.parent.css("LocalPort").text).to_not eq("12")
+        end
+      end
+
       it "advanced create" do
         # set all params
         Chef::Config[:knife][:azure_dns_name] = 'service001'
@@ -301,18 +314,18 @@ describe Chef::Knife::AzureServerCreate do
         expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
         expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'HTTP'
       end
-
+      
       it "re-uses existing load balanced endpoints" do
         Chef::Config[:knife][:azure_dns_name] = 'vmname'
         @server_instance.config[:tcp_endpoints] = "443:443:EXTERNAL:lb_set2:/healthcheck"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-
+        
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
         endpoints = testxml.css('InputEndpoint')
 
         expect(endpoints.count).to be  == 2
-
+        
         # Convert it to a hash as it's easier to test.
         eps = []
         endpoints.each do | ep |
@@ -782,7 +795,7 @@ describe Chef::Knife::AzureServerCreate do
     context "windows instance:" do
       before do
         Chef::Config[:knife][:forward_agent] = true
-      end
+      end  
 
       it "successful bootstrap" do
         pending "OC-8384-support ssh for windows vm's in knife-azure"


### PR DESCRIPTION
Fixed : When trying to bootstrap a node via the extension with --cloud-api, knife-azure refuses to add port 22 – as a result, have to manually add 22 after bootstrap in order to ssh to the new VM.