### PR TITLE
Allow using relative path for config file

### DIFF
--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -163,6 +163,7 @@ class Chef
       end
 
       def find_file(name)
+        name = ::File.expand_path(name)
         config_dir = Chef::Knife.chef_config_dir
         if File.exist? name
           file = name


### PR DESCRIPTION
The example in the readme for knife-azure doesn't actually work.

knife azure image list
ERROR: Unable to find file - ~/.azure_settings.publishsettings

Expand the provided path first so we can find the file.