### PR TITLE
Endpoint Creation. Allows specifying the load balancer probe port

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,14 @@ These options may also be configured from knife.rb, as in this example:
 #### Endpoint configuration
 
 Endpoints are configured using tcp-endpoints and udp-endpoints. This is a string in the form:
-{localPort}:{publicPort}:{load_balancer_set_name}:{load_balancer_probe_path}
+{localPort}:{publicPort}:{load_balancer_set_name}:{load_balancer_probe_path}:{load_balancer_probe_port}
 
 Examples:
 
     knife[:tcp-endpoints]='80'                            # Allow Port 80 inbound
     knife[:tcp-endpoints]='80:8080'                       # Allow Port 80 inbound and map it to local port 8080
     knife[:tcp-endpoints]='80:8080:web-set'               # Allow Port 80 and add it to the load balancing set called 'web-set'
-    knife[:tcp-endpoints]='80:8080:web-set:/healthcheck'  # Allow Port 80, add it to the load balancing set, and use an HTTP probe at path "/healthcheck"
+    knife[:tcp-endpoints]='80:8080:web-set:/healthcheck:81'  # Allow Port 80, add it to the load balancing set, and use an HTTP probe at path "/healthcheck" running on port 81.
 
 Note that the load balancing set will be created if it does not exist. If it exists within another VM in the cloud service, it will re-use those values for the probe.
 

--- a/lib/azure/role.rb
+++ b/lib/azure/role.rb
@@ -233,7 +233,7 @@ class Azure
       end
     end
 
-    # Expects endpoint_param_string to be in the form {localport}:{publicport}:{lb_set_name}:{lb_probe_path}
+    # Expects endpoint_param_string to be in the form {localport}:{publicport}:{lb_set_name}:{lb_probe_path}:{lb_probe_port}
     # Only localport is mandatory.
     def parse_endpoint_from_params(protocol, azure_vm_name, endpoint_param_string)
       fields = endpoint_param_string.split(':').map(&:strip)
@@ -251,7 +251,7 @@ class Azure
       if fields[2]
         hash['LoadBalancerProbe'] = {}
         hash['LoadBalancerProbe']['Path'] = fields[4]
-        hash['LoadBalancerProbe']['Port'] = fields[0]
+        hash['LoadBalancerProbe']['Port'] = fields[5] || fields[0]
         hash['LoadBalancerProbe']['Protocol'] = fields[4] ? 'HTTP' : protocol
       end
       hash


### PR DESCRIPTION
- Previous behaviour would assume that the load balancer healthcheck probe is running on the same port as the 'localport'
- New behaviour allows overriding this by specifying an extra field on the endpoint definition
- Updated README.md to reflect this.
