### PR TITLE
[knife azurerm] options issue

### DIFF
--- a/lib/chef/knife/azurerm_base.rb
+++ b/lib/chef/knife/azurerm_base.rb
@@ -32,37 +32,6 @@ class Chef
             require 'chef/json_compat'
           end
 
-          option :azure_subscription_id,
-            :short => "-S ID",
-            :long => "--azure-subscription-id ID",
-            :description => "Your Azure subscription ID",
-            :proc => Proc.new { |key| Chef::Config[:knife][:azure_subscription_id] = key }
-
-          option :azure_tenant_id,
-            :short => "-T ID",
-            :long => "--azure-tenant-id ID",
-            :description => "Your Azure tenant ID",
-            :proc => Proc.new { |key| Chef::Config[:knife][:azure_tenant_id] = key }
-
-          option :azure_client_id,
-            :short => "-C ID",
-            :long => "--azure-client-id ID",
-            :description => "Your Azure client ID",
-            :proc => Proc.new { |key| Chef::Config[:knife][:azure_client_id] = key }
-
-          option :azure_client_secret,
-            :short => "-S SECRET",
-            :long => "--azure-client-secret SECRET",
-            :description => "Your Azure client secret",
-            :proc => Proc.new { |key| Chef::Config[:knife][:azure_client_secret] = key }
-
-          option :azure_resource_group_name,
-            :short => "-r RESOURCE_GROUP_NAME",
-            :long => "--azure-resource-group-name RESOURCE_GROUP_NAME",
-            :description => "Required. The Resource Group name that acts as a
-                            container and holds related resources for an
-                            application in a group."
-
         end
       end
 

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -34,6 +34,14 @@ class Chef
 
       attr_accessor :initial_sleep_delay
 
+      option :azure_resource_group_name,
+        :short => "-r RESOURCE_GROUP_NAME",
+        :long => "--azure-resource-group-name RESOURCE_GROUP_NAME",
+        :description => "Required. The Resource Group name that acts as a
+                        container and holds related resources for an
+                        application in a group."
+
+
       option :ssh_user,
         :short => "-x USERNAME",
         :long => "--ssh-user USERNAME",
@@ -166,7 +174,7 @@ class Chef
         :long => "--cert-path PATH",
         :description => "SSL Certificate Path"
 
-      
+
       def run
         $stdout.sync = true
 

--- a/lib/chef/knife/azurerm_server_delete.rb
+++ b/lib/chef/knife/azurerm_server_delete.rb
@@ -32,6 +32,13 @@ class Chef
 
       banner "knife azurerm server delete SERVER [SERVER] (options)"
 
+      option :azure_resource_group_name,
+        :short => "-r RESOURCE_GROUP_NAME",
+        :long => "--azure-resource-group-name RESOURCE_GROUP_NAME",
+        :description => "Required. The Resource Group name that acts as a
+                        container and holds related resources for an
+                        application in a group."
+
       option :purge,
         :short => "-P",
         :long => "--purge",

--- a/lib/chef/knife/azurerm_server_show.rb
+++ b/lib/chef/knife/azurerm_server_show.rb
@@ -24,7 +24,14 @@ class Chef
 
       include Knife::AzurermBase
 
-      banner "knife azurerm server show SERVER (options)"  
+      banner "knife azurerm server show SERVER (options)"
+
+      option :azure_resource_group_name,
+        :short => "-r RESOURCE_GROUP_NAME",
+        :long => "--azure-resource-group-name RESOURCE_GROUP_NAME",
+        :description => "Required. The Resource Group name that acts as a
+                        container and holds related resources for an
+                        application in a group."
 
       def run
         $stdout.sync = true


### PR DESCRIPTION
1. Making azurerm config options configurable from knife.rb only
2. `resource group` option is not required for `server list` command. Hence moving it to separate commands.