### PR TITLE
Add vnet name and subnet name options to use existing vnet for vm creation

### DIFF
--- a/lib/azure/resource_management/ARM_interface.rb
+++ b/lib/azure/resource_management/ARM_interface.rb
@@ -525,7 +525,7 @@ module Azure
       def create_subnet(resource_group_name, subnet_name, virtual_network)
         promise = network_resource_client.subnets.get(resource_group_name, virtual_network.name, subnet_name)
         if promise.value!.body
-          sbn = promise.value.body
+          sbn = promise.value!.body
         else
           sbn_prop = SubnetPropertiesFormat.new
           sbn_prop.address_prefix = '10.0.1.0/24'
@@ -542,7 +542,6 @@ module Azure
             Chef::Log.debug("#{backtrace_message}")
           end
         end
-
         sbn
       end
 

--- a/lib/azure/resource_management/ARM_interface.rb
+++ b/lib/azure/resource_management/ARM_interface.rb
@@ -459,9 +459,10 @@ module Azure
         Chef::Log.info("Creating VirtualNetwork....")
         vnet = create_virtual_network(
           params[:azure_resource_group_name],
-          params[:azure_network_name],
+          params[:azure_vnet_name],
           params[:azure_service_location]
         )
+
         Chef::Log.info("VirtualNetwork creation successfull.")
         Chef::Log.info("Virtual Network name is: #{vnet.name}")
         Chef::Log.info("Virtual Network ID is: #{vnet.id}")
@@ -469,9 +470,10 @@ module Azure
         Chef::Log.info("Creating Subnet....")
         sbn = create_subnet(
           params[:azure_resource_group_name],
-          params[:azure_subnet_name],
+          params[:azure_vnet_subnet_name],
           vnet
         )
+
         Chef::Log.info("Subnet creation successfull.")
         Chef::Log.info("Subnet name is: #{sbn.name}")
         Chef::Log.info("Subnet ID is: #{sbn.id}")
@@ -493,42 +495,52 @@ module Azure
       end
 
       def create_virtual_network(resource_group_name, virtual_network_name, service_location)
-        address_space = AddressSpace.new
-        address_space.address_prefixes = ['10.0.0.0/16']
+        promise = network_resource_client.virtual_networks.get(resource_group_name, virtual_network_name)
 
-        vnet_props = VirtualNetworkPropertiesFormat.new
-        vnet_props.address_space = address_space
+        if promise.value!.body
+          vnet = promise.value!.body
+        else
+          address_space = AddressSpace.new
+          address_space.address_prefixes = ['10.0.0.0/16']
 
-        vnet_params = VirtualNetwork.new
-        vnet_params.name = virtual_network_name
-        vnet_params.location = service_location
-        vnet_params.properties = vnet_props
+          vnet_props = VirtualNetworkPropertiesFormat.new
+          vnet_props.address_space = address_space
 
-        begin
-          vnet = network_resource_client.virtual_networks.create_or_update(resource_group_name, vnet_params.name, vnet_params).value!.body
-        rescue Exception => e
-          Chef::Log.error("Failed to create the Virtual Network -- exception being rescued: #{e.to_s}")
-          backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
-          Chef::Log.debug("#{backtrace_message}")
+          vnet_params = VirtualNetwork.new
+          vnet_params.name = virtual_network_name
+          vnet_params.location = service_location
+          vnet_params.properties = vnet_props
+
+          begin
+            vnet = network_resource_client.virtual_networks.create_or_update(resource_group_name, vnet_params.name, vnet_params).value!.body
+          rescue Exception => e
+            Chef::Log.error("Failed to create the Virtual Network -- exception being rescued: #{e.to_s}")
+            backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
+            Chef::Log.debug("#{backtrace_message}")
+          end
         end
-
         vnet
       end
 
       def create_subnet(resource_group_name, subnet_name, virtual_network)
-        sbn_prop = SubnetPropertiesFormat.new
-        sbn_prop.address_prefix = '10.0.1.0/24'
+        promise = network_resource_client.subnets.get(resource_group_name, virtual_network.name, subnet_name)
+        if promise.value!.body
+          sbn = promise.value.body
+        else
+          sbn_prop = SubnetPropertiesFormat.new
+          sbn_prop.address_prefix = '10.0.1.0/24'
 
-        sbn_params = Subnet.new
-        sbn_params.name = subnet_name
-        sbn_params.properties = sbn_prop
+          sbn_params = Subnet.new
+          sbn_params.name = subnet_name
+          sbn_params.properties = sbn_prop
 
-        begin
-          sbn = network_resource_client.subnets.create_or_update(resource_group_name, virtual_network.name, sbn_params.name, sbn_params).value!.body
-        rescue Exception => e
-          Chef::Log.error("Failed to create the Subnet -- exception being rescued: #{e.to_s}")
-          backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
-          Chef::Log.debug("#{backtrace_message}")
+          begin
+            sbn = network_resource_client.subnets.create_or_update(resource_group_name, virtual_network.name, sbn_params.name, sbn_params).value!.body
+          rescue Exception => e
+            Chef::Log.error("Failed to create the Subnet -- exception being rescued: #{e.to_s}")
+            backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
+            Chef::Log.debug("#{backtrace_message}")
+          end
         end
 
         sbn

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -142,7 +142,9 @@ class Chef
 
       option :azure_vnet_name,
         :long => "--azure-vnet-name VNET_NAME",
-        :description => "Optional. Specifies the virtual network name"
+        :description => "Optional. Specifies the virtual network name
+                        If this is an existing vnet then it must exists under the current resource group identified by resource-group
+                        If this is an existing vnet then vnet-subnet-name is required"
 
       option :azure_vnet_subnet_name,
         :long => "--azure-vnet-subnet-name VNET_SUBNET_NAME",
@@ -167,24 +169,6 @@ class Chef
       option :cert_path,
         :long => "--cert-path PATH",
         :description => "SSL Certificate Path"
-
-      # option :vnet_name,
-      #   :long => "--vnet-name VNET_NAME",
-      #   :description => "the virtual network name
-      #     If this is an existing vnet then it must exists under the current resource group identified by resource-group
-      #     If this is an existing vnet then vnet-subnet-name is required
-      #     If no subnet exists with name vnet-subnet-name then a new subnet will be created
-      #     To create new subnet - vnet-subnet-address-prefix is required
-      #     A new vnet will be created if no vnet exists with name vnet-name in the current resource group
-      #     To create new vnet - vnet-address-prefix, vnet-subnet-name and vnet-subnet-address-prefix are required"
-
-      # option :vnet_subnet_name,
-      #   :long => "--vnet-subnet-name VNET_SUBNET_NAME",
-      #   :description => "the virtual network subnet name"
-
-      option :vnet_subnet_address_prefix,
-        :long => "--vnet-subnet-address-prefix VNET_SUBNET_ADDRESS_PREFIX",
-        :description => "the virtual network subnet address prefix in IPv4/CIDR format"
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -259,11 +259,11 @@ class Chef
 
       def validate_params!
         if locate_config_value(:azure_vnet_name) && !locate_config_value(:azure_vnet_subnet_name)
-          raise ArgumentError, "If this is an existing vnet then --azure-vnet-subnet-name is required."
+          raise ArgumentError,  "When a --azure-vnet-name is specified, the --azure-vnet-subnet-name must also be specified."
         end
 
         if locate_config_value(:azure_vnet_subnet_name) && !locate_config_value(:azure_vnet_name)
-          raise ArgumentError, "Provide --azure-vnet-subnet-name option along with --azure-vnet-name."
+          raise ArgumentError, "When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified."
         end
       end
 

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -195,14 +195,15 @@ class Chef
           :azure_service_location
         )
 
-        validate_params!
-
-        set_default_image_reference!
-
-        ssh_override_winrm if !is_image_windows?
-
-        Chef::Log.info("creating...")
         begin
+          validate_params!
+
+          set_default_image_reference!
+
+          ssh_override_winrm if !is_image_windows?
+
+          Chef::Log.info("creating...")
+
           vm_details = service.create_server(create_server_def)
         rescue => error
           if error.class == MsRestAzure::AzureOperationError && error.body
@@ -274,11 +275,11 @@ class Chef
 
       def validate_params!
         if locate_config_value(:azure_vnet_name) && !locate_config_value(:azure_vnet_subnet_name)
-          raise ArgumentError, "If this is an existing vnet then vnet-subnet-name is required."
+          raise ArgumentError, "If this is an existing vnet then --azure-vnet-subnet-name is required."
         end
 
         if locate_config_value(:azure_vnet_subnet_name) && !locate_config_value(:azure_vnet_name)
-          raise ArgumentError, "Provide vnet subnet name option along with vnet name."
+          raise ArgumentError, "Provide --azure-vnet-subnet-name option along with --azure-vnet-name."
         end
       end
 

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -236,8 +236,8 @@ class Chef
         server_def[:azure_os_disk_name] = locate_config_value(:azure_vm_name) if server_def[:azure_os_disk_name].nil?
         server_def[:azure_os_disk_name] = server_def[:azure_os_disk_name].gsub(/[!@#$%^&*()_-]/,'')
 
-        server_def[:azure_network_name] = locate_config_value(:azure_vm_name) if server_def[:azure_network_name].nil?
-        server_def[:azure_subnet_name] = locate_config_value(:azure_vm_name) if server_def[:azure_subnet_name].nil?
+        server_def[:azure_vnet_name] = locate_config_value(:azure_vm_name) if server_def[:azure_vnet_name].nil?
+        server_def[:azure_vnet_subnet_name] = locate_config_value(:azure_vm_name) if locate_config_value(:azure_vnet_subnet_name).nil? && locate_config_value(:azure_vnet_name).nil?
 
         server_def[:chef_extension] = get_chef_extension_name
         server_def[:chef_extension_publisher] = get_chef_extension_publisher

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -30,8 +30,8 @@ describe Chef::Knife::AzurermServerCreate do
       :azure_os_disk_name => 'azureosdiskname',
       :azure_os_disk_caching => 'azure_os_disk_caching',
       :azure_os_disk_create_option => 'azure_os_disk_create_option',
-      :azure_virtual_network_name => 'azure_virtual_network_name',
-      :azure_subnet_name => 'azure_subnet_name',
+      :azure_vnet_name => 'azure_virtual_network_name',
+      :azure_vnet_subnet_name => 'azure_subnet_name',
       :rdp_port => '3389',
       :ssh_port => '22',
       :chef_extension_publisher => 'chef_extension_publisher',
@@ -155,8 +155,8 @@ describe Chef::Knife::AzurermServerCreate do
           @storage_account_name_with_no_special_chars = 'azurestorageaccount'
           Chef::Config[:knife][:azure_os_disk_name] = 'azure_os_disk_name'
           @os_disk_name_with_no_special_chars = 'azureosdiskname'
-          Chef::Config[:knife][:azure_network_name] = 'azure_network_name'
-          Chef::Config[:knife][:azure_subnet_name] = 'azure_subnet_name'
+          Chef::Config[:knife][:azure_vnet_name] = 'azure_vnet_name'
+          Chef::Config[:knife][:azure_vnet_subnet_name] = 'azure_vnet_subnet_name'
           Chef::Config[:knife][:azure_vm_size] = 'Medium'
         end
 
@@ -172,12 +172,12 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "azure_network_name provided by user so vm_name does not get assigned to it" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_network_name]).to be == 'azure_network_name'
+          expect(@server_params[:azure_vnet_name]).to be == 'azure_vnet_name'
         end
 
         it "azure_subnet_name provided by user so vm_name does not get assigned to it" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_subnet_name]).to be == 'azure_subnet_name'
+          expect(@server_params[:azure_vnet_subnet_name]).to be == 'azure_vnet_subnet_name'
         end
 
         it "azure_vm_size provided by user so default value does not get assigned to it" do
@@ -576,10 +576,10 @@ describe Chef::Knife::AzurermServerCreate do
 
     describe "create_virtual_network" do
       it "successfully creates virtual network" do
-        expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client('NA'))
+        allow(@service).to receive(:network_resource_client).and_return(stub_network_resource_client('NA'))
         response = @service.create_virtual_network(
           @params[:azure_resource_group_name],
-          @params[:azure_virtual_network_name],
+          @params[:azure_vnet_name],
           @params[:azure_service_location])
         expect(response.name).to_not be nil
         expect(response.id).to_not be nil
@@ -591,10 +591,10 @@ describe Chef::Knife::AzurermServerCreate do
 
     describe "create_subnet" do
       it "successfully creates subnet" do
-        expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client('NA'))
+        allow(@service).to receive(:network_resource_client).and_return(stub_network_resource_client('NA'))
         response = @service.create_subnet(
           @params[:azure_resource_group_name],
-          @params[:azure_subnet_name],
+          @params[:azure_vnet_subnet_name],
           stub_virtual_network_create_response)
         expect(response.name).to_not be nil
         expect(response.id).to_not be nil

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -554,9 +554,10 @@ describe Chef::Knife::AzurermServerCreate do
       end
     end
 
-    describe "create_network_profile" do
-      context 'For non existing vent and subnet' do
+    describe 'create_network_profile' do
+      context 'vnet and subnet does not exist' do
         it 'successfully returns network profile response' do
+          # following alllow statements stubs vnet_exist? and subnet_exist? methods
           allow(@network_client).to receive_message_chain(:virtual_networks, :get).and_return(@network_promise)
           allow(@network_promise).to receive_message_chain(:value!, :body).and_return(nil)
 
@@ -579,8 +580,9 @@ describe Chef::Knife::AzurermServerCreate do
         end
       end
 
-      context 'for exisitng vnet and subnet' do
+      context 'vnet and subnet already exist' do
         it 'successfully returns network profile response' do
+          # following alllow statements stubs vnet_exist? and subnet_exist? methods
           allow(@network_client).to receive_message_chain(:virtual_networks, :get).and_return(@network_promise)
           allow(@network_promise).to receive_message_chain(:value!, :body).and_return(stub_vnet_get_response)
 

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -131,15 +131,16 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         it "azure_network_name not provided by user so vm_name gets assigned to it" do
-          Chef::Config[:knife].delete(:azure_network_name)
+          Chef::Config[:knife].delete(:azure_vnet_name)
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_network_name]).to be == 'test-vm'
+          expect(@server_params[:azure_vnet_name]).to be == 'test-vm'
         end
 
         it "azure_subnet_name not provided by user so vm_name gets assigned to it" do
-          Chef::Config[:knife].delete(:azure_subnet_name)
+          Chef::Config[:knife].delete(:azure_vnet_subnet_name)
+          Chef::Config[:knife].delete(:azure_vnet_name)
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_subnet_name]).to be == 'test-vm'
+          expect(@server_params[:azure_vnet_subnet_name]).to be == 'test-vm'
         end
 
         after do

--- a/spec/unit/query_azure_mock.rb
+++ b/spec/unit/query_azure_mock.rb
@@ -112,6 +112,14 @@ module QueryAzureMock
       :body,
       :properties,
       :security_rules).and_return(['default_security_rule'])
+    allow(network_resource_client.subnets).to receive_message_chain(
+      :get,
+      :value!,
+      :body).and_return(nil)
+    allow(network_resource_client.virtual_networks).to receive_message_chain(
+      :get,
+      :value!,
+      :body).and_return(nil)
     if platform == 'Windows'
       allow(network_resource_client.network_security_groups.get.value!.body.properties.security_rules[0]).to receive_message_chain(
         :properties,
@@ -267,7 +275,7 @@ module QueryAzureMock
 
   def stub_subnet_create_response
     subnet = OpenStruct.new
-    subnet.name = 'subnet_name'
+    subnet.name = 'azure_subnet_name'
     subnet.id = 'subnet_id'
     subnet.location = 'subnet_location'
     subnet.properties = OpenStruct.new

--- a/spec/unit/query_azure_mock.rb
+++ b/spec/unit/query_azure_mock.rb
@@ -112,10 +112,6 @@ module QueryAzureMock
       :body,
       :properties,
       :security_rules).and_return(['default_security_rule'])
-    allow(network_resource_client.subnets).to receive_message_chain(
-      :get,
-      :value!,
-      :body).and_return(nil)
     allow(network_resource_client.virtual_networks).to receive_message_chain(
       :get,
       :value!,
@@ -231,6 +227,18 @@ module QueryAzureMock
     vhd = OpenStruct.new
     vhd.uri = 'vhd_uri'
     vhd
+  end
+
+  def stub_vnet_get_response
+    vnet_response = OpenStruct.new
+    vnet_response.name = 'azure_virtual_network_name'
+    vnet_response
+  end
+
+  def stub_subnet_get_response
+    vnet_response = OpenStruct.new
+    vnet_response.name = 'azure_subnet_name'
+    vnet_response
   end
 
   def stub_image_reference_response


### PR DESCRIPTION
Added --azure-vnet-name and --azure-vnet-subnet-name options

Using this option currently user can provide existing vnet and subnet values. 
1) If this option is not given it will create default vnet and subnet with VM name.
2) User need to provide valid existing vnet name and subnet name else it will raise not found error.
3) If vnet is not belongs to same resource group it will throw error.
3) If subnet is not exist in the given vnet it will throw error.

