### PR TITLE
Public ip value empty for list and show operations

### DIFF
--- a/lib/azure/service_management/ASM_interface.rb
+++ b/lib/azure/service_management/ASM_interface.rb
@@ -55,11 +55,7 @@ module Azure
                              ui.color('ready', :green)
                            end
                          end
-          if server.publicipaddress.to_s.empty?
-            rows << @connection.query_azure("hostedservices/#{server.deployname}/deploymentslots/Production", "get").at_css('VirtualIPs VirtualIP Address').text
-          else
-            rows << server.publicipaddress.to_s
-          end
+          rows << server.publicipaddress.to_s
           rows << server.sshport.to_s
           rows << server.winrmport.to_s
         end
@@ -129,11 +125,7 @@ module Azure
               details << role.winrmport
             end
             details << ui.color('Public IP', :bold, :cyan)
-            if role.publicipaddress.to_s.empty?
-              details << @connection.query_azure("hostedservices/#{role.deployname}/deploymentslots/Production", "get").at_css('VirtualIPs VirtualIP Address').text
-            else
-              details << role.publicipaddress.to_s
-            end
+            details << role.publicipaddress.to_s
 
             unless role.thumbprint.empty?
               details << ui.color('Thumbprint', :bold, :cyan)

--- a/lib/azure/service_management/ASM_interface.rb
+++ b/lib/azure/service_management/ASM_interface.rb
@@ -55,7 +55,11 @@ module Azure
                              ui.color('ready', :green)
                            end
                          end
-          rows << server.publicipaddress.to_s
+          if server.publicipaddress.to_s.empty?
+            rows << @connection.query_azure("hostedservices/#{server.deployname}/deploymentslots/Production", "get").at_css('VirtualIPs VirtualIP Address').text
+          else
+            rows << server.publicipaddress.to_s
+          end
           rows << server.sshport.to_s
           rows << server.winrmport.to_s
         end
@@ -125,7 +129,12 @@ module Azure
               details << role.winrmport
             end
             details << ui.color('Public IP', :bold, :cyan)
-            details << role.publicipaddress
+            if role.publicipaddress.to_s.empty?
+              details << @connection.query_azure("hostedservices/#{role.deployname}/deploymentslots/Production", "get").at_css('VirtualIPs VirtualIP Address').text
+            else
+              details << role.publicipaddress.to_s
+            end
+
             unless role.thumbprint.empty?
               details << ui.color('Thumbprint', :bold, :cyan)
               details << role.thumbprint

--- a/lib/azure/service_management/deploy.rb
+++ b/lib/azure/service_management/deploy.rb
@@ -134,6 +134,9 @@ module Azure
         rolesXML.each do |roleXML|
           role = Role.new(@connection)
           role.parse(roleXML, hostedservicename, @name)
+          if role.publicipaddress.to_s.empty?
+            role.publicipaddress = xml_content(deployXML, 'VirtualIPs VirtualIP Address')
+          end
           @roles[role.name] = role
         end
         @input_endpoints = Array.new


### PR DESCRIPTION
When a VM is spawned using knife-azure and endpoint is not set, the public ip value for server listing and show shows empty value.
This issue mostly occurs when cloud-api bootstrap protocol for vm provisioning and endpoint is not specified.