### PR TITLE
Pinned the version on `listen` gem to 3.0.6

### DIFF
--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "azure_mgmt_compute", "0.2.1"
   s.add_dependency "azure_mgmt_storage", "0.2.1"
   s.add_dependency "azure_mgmt_network", "0.2.1"
+  s.add_dependency "listen", "3.0.6"
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'
   s.add_development_dependency "mixlib-config", "~> 2.0"
   s.add_development_dependency "equivalent-xml", "~> 0.2.9"


### PR DESCRIPTION
Latest version of `listen` gem requires ruby 2.2.x. Hence Travis fails for ruby `versions < 2.2.x`