### PR TITLE
Added readline gem dependency in Gemfile as knife-azure commands started failing because of this gem after updating chefdk from 0.12.0 to 0.13.21 version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'mixlib-shellout'
   gem 'activesupport'
   gem 'byebug', '~>6.0.2'
+  gem 'rb-readline'
 end


### PR DESCRIPTION
Done.