### PR TITLE
Fixed issue when bootstrap protocol is not specified during vm creation

### DIFF
--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -402,7 +402,7 @@ class Chef
 
         validate_params!
 
-        ssh_override_winrm if %w(ssh cloud-api).include?(locate_config_value(:bootstrap_protocol)) and !is_image_windows?
+        ssh_override_winrm if !is_image_windows?
 
         Chef::Log.info("creating...")
 

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -652,21 +652,21 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "successful bootstrap of windows instance" do
-        expect(@server_instance).to receive(:is_image_windows?).exactly(5).times.and_return(true)
+        expect(@server_instance).to receive(:is_image_windows?).exactly(6).times.and_return(true)
         expect(@server_instance).to receive(:wait_until_virtual_machine_ready).exactly(1).times.and_return(true)
         @server_instance.run
       end
 
       it "sets encrypted data bag secret parameter" do
         Chef::Config[:knife][:encrypted_data_bag_secret] = 'test_encrypted_data_bag_secret'
-        expect(@server_instance).to receive(:is_image_windows?).exactly(5).times.and_return(true)
+        expect(@server_instance).to receive(:is_image_windows?).exactly(6).times.and_return(true)
         @server_instance.run
         expect(@bootstrap.config[:encrypted_data_bag_secret]).to be == 'test_encrypted_data_bag_secret'
       end
 
       it "sets encrypted data bag secret file parameter" do
         Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'test_encrypted_data_bag_secret_file'
-        expect(@server_instance).to receive(:is_image_windows?).exactly(5).times.and_return(true)
+        expect(@server_instance).to receive(:is_image_windows?).exactly(6).times.and_return(true)
         @server_instance.run
         expect(@bootstrap.config[:encrypted_data_bag_secret_file]).to be == 'test_encrypted_data_bag_secret_file'
       end


### PR DESCRIPTION
knife-azure vm provisioning for linux images fails, if user doesn't pass the bootstrap-protocol option and passes  -x (winrm user)option instead of -ssh-user option