### PR TITLE
Fixed eval failure on some ruby versions and specs failure

### DIFF
--- a/lib/chef/knife/azurerm_base.rb
+++ b/lib/chef/knife/azurerm_base.rb
@@ -21,6 +21,7 @@ require 'chef/knife'
 require 'azure/resource_management/ARM_interface'
 require 'mixlib/shellout'
 require 'time'
+require 'json'
 
 class Chef
   class Knife
@@ -100,8 +101,8 @@ class Chef
       def token_details_for_linux
         home_dir = File.expand_path('~')
         file = File.read(home_dir + '/.azure/accessTokens.json')
-        file = eval(file)
-        token_details = {:tokentype => file[-1][:tokenType], :user => file[-1][:userId], :token => file[-1][:accessToken], :clientid => file[-1][:_clientId], :expiry_time => file[-1][:expiresOn], :refreshtoken => file[-1][:refreshToken]}
+        file = JSON.parse(file)
+        token_details = {:tokentype => file[-1]["tokenType"], :user => file[-1]["userId"], :token => file[-1]["accessToken"], :clientid => file[-1]["_clientId"], :expiry_time => file[-1]["expiresOn"], :refreshtoken => file[-1]["refreshToken"]}
         return token_details
       end
 

--- a/spec/unit/azurerm_base_spec.rb
+++ b/spec/unit/azurerm_base_spec.rb
@@ -80,16 +80,6 @@ describe Chef::Knife::AzurermBase do
         expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
         validate_cert()
       end
-
-      it "- should raise error if invalid publish settings provided" do
-        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureInvalid.publishsettings")
-        expect {@dummy.validate_arm_keys!}.to raise_error(SystemExit)
-      end
-
-      it "- should raise error if publish settings file does not exists" do
-        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureNotAvailable.publishsettings")
-        expect {@dummy.validate_arm_keys!}.to raise_error(SystemExit)
-      end
     end
   end
 
@@ -104,6 +94,7 @@ describe Chef::Knife::AzurermBase do
       it 'Accesstoken file exist for Linux' do
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(File).to receive(:exists?).and_return(true)
+        allow(File).to receive(:size?).and_return(4)
         expect { @arm_server_instance.validate_azure_login }.not_to raise_error(RuntimeError)
       end
 
@@ -180,16 +171,11 @@ describe Chef::Knife::AzurermBase do
       end
 
       it 'Get token details from Accesstoken file for Linux' do
-        if Chef::Platform.windows?
-          token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-          allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
-        else
-          allow(Chef::Platform).to receive(:windows?).and_return(false)
-          file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
-          allow(File).to receive(:read).and_return(file_data)
-          @authentication_details = @arm_server_instance.token_details_for_linux
-          expect(@authentication_details[:clientid]).to be ==  "dsff-8df-sd45e-34345f7b46"
-        end
+        allow(Chef::Platform).to receive(:windows?).and_return(false)
+        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
+        allow(File).to receive(:read).and_return(file_data)
+        @authentication_details = @arm_server_instance.token_details_for_linux
+        expect(@authentication_details[:clientid]).to be ==  "dsff-8df-sd45e-34345f7b46"
       end
 
       it 'Get Target name for Windows' do

--- a/spec/unit/azurerm_base_spec.rb
+++ b/spec/unit/azurerm_base_spec.rb
@@ -88,40 +88,40 @@ describe Chef::Knife::AzurermBase do
       it 'Accesstoken file doesnt exist for Linux' do
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(File).to receive(:exists?).and_return(false)
-        expect { @arm_server_instance.validate_azure_login }.to raise_error(RuntimeError)
+        expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
       end
 
       it 'Accesstoken file exist for Linux' do
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(File).to receive(:exists?).and_return(true)
         allow(File).to receive(:size?).and_return(4)
-        expect { @arm_server_instance.validate_azure_login }.not_to raise_error(RuntimeError)
+        expect { @arm_server_instance.validate_azure_login }.not_to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
       end
 
       it 'Accesstoken file contain [] value upon running azure logout command for Linux' do
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(File).to receive(:size?).and_return(2)
-        expect { @arm_server_instance.validate_azure_login }.to raise_error(RuntimeError)
+        expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
       end
 
-      it 'Token Object not presnt in windows credential manager' do
+      it 'Token Object not present in windows credential manager' do
         @xplat_creds_cmd = double(:run_command => double)
         @result = double(:stdout => "")
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         allow(Mixlib::ShellOut).to receive(:new).and_return(@xplat_creds_cmd)
         allow(@xplat_creds_cmd).to receive(:run_command).and_return(@result)
         allow(@result).to receive(:stdout).and_return("")
-        expect { @arm_server_instance.validate_azure_login }.to raise_error(RuntimeError)
+        expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
       end
 
-      it 'Token Object presnt in windows credential manager' do
+      it 'Token Object present in windows credential manager' do
         @xplat_creds_cmd = double(:run_command => double)
         @result = double(:stdout => double)
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         allow(Mixlib::ShellOut).to receive(:new).and_return(@xplat_creds_cmd)
         allow(@xplat_creds_cmd).to receive(:run_command).and_return(@result)
         allow(@result).to receive(:stdout).and_return(double)
-        expect { @arm_server_instance.validate_azure_login }.not_to raise_error(RuntimeError)
+        expect { @arm_server_instance.validate_azure_login }.not_to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
       end
 
     end
@@ -129,12 +129,12 @@ describe Chef::Knife::AzurermBase do
     context "Token Validation test cases" do
       it "Token Validity expired" do
         token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error(RuntimeError)
+        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run any XPLAT command like 'azure vm list' to get new token OR run 'azure login' command")
       end
 
       it 'Token is valid' do
         token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error(RuntimeError)
+        expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error("Token has expired. Please run any XPLAT command like 'azure vm list' to get new token OR run 'azure login' command")
       end
     end
 

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -59,18 +59,30 @@ describe Chef::Knife::AzurermServerCreate do
       end
 
       it "azure_tenant_id" do
+        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
         Chef::Config[:knife].delete(:azure_tenant_id)
+        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
+        allow(File).to receive(:read).and_return(file_data)
         expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        Chef::Config[:knife].delete(:azure_image_os_type)
       end
 
       it "azure_client_id" do
+        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
         Chef::Config[:knife].delete(:azure_client_id)
+        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
+        allow(File).to receive(:read).and_return(file_data)
         expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        Chef::Config[:knife].delete(:azure_image_os_type)
       end
 
       it "azure_client_secret" do
         Chef::Config[:knife].delete(:azure_client_secret)
+        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
+        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
+        allow(File).to receive(:read).and_return(file_data)
         expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        Chef::Config[:knife].delete(:azure_image_os_type)
       end
 
       it "azure_resource_group_name" do

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -58,33 +58,6 @@ describe Chef::Knife::AzurermServerCreate do
         expect {@arm_server_instance.run}.to raise_error(SystemExit)
       end
 
-      it "azure_tenant_id" do
-        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
-        Chef::Config[:knife].delete(:azure_tenant_id)
-        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
-        allow(File).to receive(:read).and_return(file_data)
-        expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
-        Chef::Config[:knife].delete(:azure_image_os_type)
-      end
-
-      it "azure_client_id" do
-        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
-        Chef::Config[:knife].delete(:azure_client_id)
-        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
-        allow(File).to receive(:read).and_return(file_data)
-        expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
-        Chef::Config[:knife].delete(:azure_image_os_type)
-      end
-
-      it "azure_client_secret" do
-        Chef::Config[:knife].delete(:azure_client_secret)
-        Chef::Config[:knife][:azure_image_os_type] = "ubuntu"
-        file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
-        allow(File).to receive(:read).and_return(file_data)
-        expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
-        Chef::Config[:knife].delete(:azure_image_os_type)
-      end
-
       it "azure_resource_group_name" do
         Chef::Config[:knife].delete(:azure_resource_group_name)
         expect(@arm_server_instance.ui).to receive(:error)
@@ -177,6 +150,54 @@ describe Chef::Knife::AzurermServerCreate do
           @vm_name_with_no_special_chars = 'testvm'
           Chef::Config[:knife][:ssh_password] = 'ssh_password'
           @azure_vm_size_default_value = 'Small'
+          @xplat_creds_cmd = double(:run_command => double)
+          @result = double(:stdout => "")
+          allow(Mixlib::ShellOut).to receive(:new).and_return(@xplat_creds_cmd)
+          allow(@xplat_creds_cmd).to receive(:run_command).and_return(@result)
+          allow(@result).to receive(:stdout).and_return("")
+
+        end
+
+        it "azure_tenant_id not provided for Linux platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(false)
+          Chef::Config[:knife].delete(:azure_tenant_id)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        end
+
+        it "azure_client_id not provided for Linux platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(false)
+          Chef::Config[:knife].delete(:azure_client_id)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        end
+
+        it "azure_client_secret not provided for Linux platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(false)
+          Chef::Config[:knife].delete(:azure_client_secret)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        end
+
+        it "azure_tenant_id not provided for Windows platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(true)
+          Chef::Config[:knife].delete(:azure_tenant_id)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        end
+
+        it "azure_client_id not provided for Windows platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(true)
+          Chef::Config[:knife].delete(:azure_client_id)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+        end
+
+        it "azure_client_secret not provided for windows platform" do
+          allow(Chef::Platform).to receive(:windows?).and_return(true)
+          Chef::Config[:knife].delete(:azure_client_secret)
+          allow(File).to receive(:exists?).and_return(false)
+          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_storage_account not provided by user so vm_name gets assigned to it" do


### PR DESCRIPTION
-Eval which is internally used by token authentication (for linux) fails for some versions.
-Also fixed some specs failing on travis, however the exit code is zero, hence the travis was passing

In-Progress