### PR TITLE
Update size_hash to allow non-standard VM sizes

### DIFF
--- a/lib/azure/resource_management/ARM_base.rb
+++ b/lib/azure/resource_management/ARM_base.rb
@@ -23,7 +23,7 @@ module Azure::ARM
         size_hash = { "ExtraSmall" => "Standard_A0", "Small" => "Standard_A1",
                       "Medium" => "Standard_A2", "Large" => "Standard_A3",
                       "ExtraLarge" => "Standard_A4" }
-        size_hash[size_name]
+        size_hash[size_name].nil? ? size_name : size_hash[size_name]
       end
     end
 end


### PR DESCRIPTION
Currently ARMBase restricts allowed VM sizes to an arbitrary set of default sizes.  If a users specifies a custom but valid raw size, (e.g. "Standard_DS3_v2") as their parameter, there's no reason we can't at least try to pass that through directly.