### PR TITLE
[MSYS-576] : Fixed Auto-Generated Storage Account Name issue

### DIFF
--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -230,9 +230,10 @@ class Chef
           :server_count => locate_config_value(:server_count)
         }
 
-        if locate_config_value(:tcp_endpoints)
-          server_def[:tcp_endpoints] = locate_config_value(:tcp_endpoints)
-        end
+        server_def[:tcp_endpoints] = locate_config_value(:tcp_endpoints) if locate_config_value(:tcp_endpoints)
+
+        # We assign azure_vm_name to chef_node_name If node name is nill because storage account name is combination of hash value and node name.
+        config[:chef_node_name] ||= locate_config_value(:azure_vm_name)
         
         server_def[:azure_storage_account] = locate_config_value(:azure_vm_name) if server_def[:azure_storage_account].nil?
         server_def[:azure_storage_account] = server_def[:azure_storage_account].gsub(/[!@#$%^&*()_-]/,'')


### PR DESCRIPTION
https://github.com/chef/knife-azure/issues/434 - Added feature if user not pass node-name, It will assign azure-vm-name to chef-node-name.