### PR TITLE
[MSYS-577] :  Fixed '--node-ssl-verify-mode' value in client.rb

### DIFF
--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -49,6 +49,10 @@ class Chef
         :long => "--ssh-port PORT",
         :description => "The ssh port. Default is 22."
 
+      option :node_ssl_verify_mode,
+        :long        => "--node-ssl-verify-mode [peer|none]",
+        :description => "Whether or not to verify the SSL cert for all HTTPS requests."
+
       option :winrm_user,
         :short => "-x USERNAME",
         :long => "--winrm-user USERNAME",
@@ -290,47 +294,6 @@ class Chef
             raise ArgumentError, "Ohai Hint name #{hint} passed is not supported. Please run the command help to see the list of supported values."
           end
         end
-      end
-
-      def validate_params!
-        if locate_config_value(:azure_vnet_subnet_name) && !locate_config_value(:azure_vnet_name)
-          raise ArgumentError, "When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified."
-        end
-
-        if locate_config_value(:azure_vnet_subnet_name) == 'GatewaySubnet'
-          raise ArgumentError, 'GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.'
-        end
-
-        if is_image_windows?
-          if locate_config_value(:winrm_user).nil? ||  locate_config_value(:winrm_password).nil?
-            raise ArgumentError, "Please provide --winrm-user and --winrm-password options for Windows option."
-          end
-        end
-
-        if !is_image_windows?
-          if (locate_config_value(:azure_vm_name).match /^(?=.*[a-zA-Z-])([a-zA-z0-9-]{1,64})$/).nil?
-            raise ArgumentError, "VM name can only contain alphanumeric and hyphen(-) characters and maximun length cannot exceed 64 charachters."
-          end
-        elsif (locate_config_value(:azure_vm_name).match /^(?=.*[a-zA-Z-])([a-zA-z0-9-]{1,15})$/).nil?
-          raise ArgumentError, "VM name can only contain alphanumeric and hyphen(-) characters and maximun length cannot exceed 15 charachters."
-        end
-
-        if locate_config_value(:server_count).to_i > 5
-          raise ArgumentError, "Maximum allowed value of --server-count is 5."
-        end
-
-        if locate_config_value(:daemon)
-          unless is_image_windows?
-            raise ArgumentError, "The daemon option is only support for Windows nodes."
-          end
-
-          unless %w{none service task}.include?(locate_config_value(:daemon))
-            raise ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
-          end
-        end
-
-        config[:ohai_hints] = format_ohai_hints(locate_config_value(:ohai_hints))
-        validate_ohai_hints if ! locate_config_value(:ohai_hints).casecmp('default').zero?
       end
 
       private

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -111,7 +111,7 @@ describe Chef::Knife::AzurermServerCreate do
         expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
       end
 
-     it "vm name validation failure for name containing more than 64 characters for Linux" do
+      it "vm name validation failure for name containing more than 64 characters for Linux" do
         Chef::Config[:knife][:azure_vm_name] = 'testvm123123123123123123123123123123123123123123123123123123123123123123123123123123123123123'
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(false)
         expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
@@ -302,6 +302,18 @@ describe Chef::Knife::AzurermServerCreate do
           it "raises error" do
             expect { @arm_server_instance.validate_params! }.to raise_error(
               ArgumentError, 'When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified.'
+            )
+          end
+        end
+
+        context 'raise node_ssl_verify_mode error for wrong value' do
+          before do
+            Chef::Config[:knife][:node_ssl_verify_mode] = 'MyValue'
+          end
+
+          it "raises error" do
+            expect { @arm_server_instance.validate_params! }.to raise_error(
+              ArgumentError, "Invalid value '#{Chef::Config[:knife][:node_ssl_verify_mode]}' for --node-ssl-verify-mode. Use Valid values i.e 'none', 'peer'."
             )
           end
         end


### PR DESCRIPTION
https://github.com/chef/knife-azure/issues/435 - Added feature to pass '--node-ssl-verify-mode' appropriate value to resulting client.rb