### PR TITLE
[MSYS-777] Added Azure CLI 2.0 support.

### DIFF
--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -192,7 +192,8 @@ class Chef
 
       def run
         $stdout.sync = true
-
+        # check azure cli version due to azure changed `azure` to `az` in azure-cli2.0
+        get_azure_cli_version
         validate_arm_keys!(
           :azure_resource_group_name,
           :azure_vm_name,
@@ -201,11 +202,8 @@ class Chef
 
         begin
           validate_params!
-
           set_default_image_reference!
-
           ssh_override_winrm if !is_image_windows?
-
           vm_details = service.create_server(create_server_def)
         rescue => error
           service.common_arm_rescue_block(error)

--- a/lib/chef/knife/azurerm_server_list.rb
+++ b/lib/chef/knife/azurerm_server_list.rb
@@ -1,3 +1,21 @@
+#
+# Author:: Adam Jacob (<adam@chef.io>)
+# Copyright:: Copyright 2009-2018, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require File.expand_path('../azurerm_base', __FILE__)
 
 class Chef
@@ -10,6 +28,8 @@ class Chef
 
       def run
         $stdout.sync = true
+        # check azure cli version due to azure changed `azure` to `az` in azure-cli2.0
+        get_azure_cli_version
         validate_arm_keys!
         begin
           service.list_servers(locate_config_value(:azure_resource_group_name))

--- a/lib/chef/knife/azurerm_server_show.rb
+++ b/lib/chef/knife/azurerm_server_show.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Meera Navale (meera.navale@msystechnologies.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,8 @@ class Chef
 
       def run
         $stdout.sync = true
+        # check azure cli version due to azure changed `azure` to `az` in azure-cli2.0
+        get_azure_cli_version
         validate_arm_keys!(:azure_resource_group_name)
         begin
           service.show_server(@name_args[0], locate_config_value(:azure_resource_group_name))

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -53,11 +53,11 @@ describe Chef::Knife::AzurermServerCreate do
       }
     }
 
-
     allow(@service.ui).to receive(:log)
     allow(Chef::Log).to receive(:info)
     allow(File).to receive(:exist?).and_return(true)
     allow(File).to receive(:read).and_return('foo')
+    allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
   end
 
   describe "parameter test:" do
@@ -166,7 +166,7 @@ describe Chef::Knife::AzurermServerCreate do
           allow(Mixlib::ShellOut).to receive(:new).and_return(@xplat_creds_cmd)
           allow(@xplat_creds_cmd).to receive(:run_command).and_return(@result)
           allow(@result).to receive(:stdout).and_return("")
-
+          @arm_server_instance.instance_variable_set(:@azure_prefix, "azure")
         end
 
         it "azure_tenant_id not provided for Linux platform" do
@@ -192,7 +192,6 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "azure_tenant_id not provided for Windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
-          expect(@arm_server_instance).to receive_message_chain(:shell_out!, :stdout)
           Chef::Config[:knife].delete(:azure_tenant_id)
           allow(File).to receive(:exists?).and_return(false)
           expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
@@ -200,7 +199,6 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "azure_client_id not provided for Windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
-          expect(@arm_server_instance).to receive_message_chain(:shell_out!, :stdout)
           Chef::Config[:knife].delete(:azure_client_id)
           allow(File).to receive(:exists?).and_return(false)
           expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
@@ -208,7 +206,6 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "azure_client_secret not provided for windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
-          expect(@arm_server_instance).to receive_message_chain(:shell_out!, :stdout)
           Chef::Config[:knife].delete(:azure_client_secret)
           allow(File).to receive(:exists?).and_return(false)
           expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")

--- a/spec/unit/azurerm_server_delete_spec.rb
+++ b/spec/unit/azurerm_server_delete_spec.rb
@@ -19,6 +19,7 @@ describe Chef::Knife::AzurermServerDelete do
       @server_detail = double('server', :name => "VM001", :hardware_profile => double, :storage_profile => double(:os_disk => double))
       allow(@server_detail.hardware_profile).to receive(:vm_size).and_return("10")
       allow(@server_detail.storage_profile.os_disk).to receive(:os_type).and_return("Linux")
+      allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
     end
 
     it "deletes server" do
@@ -68,6 +69,7 @@ describe Chef::Knife::AzurermServerDelete do
     before do
       @arm_server_instance = create_arm_instance(Chef::Knife::AzurermServerDelete)
       allow(@arm_server_instance.service.ui).to receive(:confirm).and_return (true)
+      allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
       @resource_client = double("ResourceManagementClient")
       @service = @arm_server_instance.service
 

--- a/spec/unit/azurerm_server_list_spec.rb
+++ b/spec/unit/azurerm_server_list_spec.rb
@@ -34,6 +34,7 @@ describe Chef::Knife::AzurermServerList do
 
     allow(@arm_server_instance.service).to receive(
       :compute_management_client).and_return(@compute_client)
+    allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
   end
 
   context "resource_group_name is not given" do

--- a/spec/unit/azurerm_server_show_spec.rb
+++ b/spec/unit/azurerm_server_show_spec.rb
@@ -13,6 +13,7 @@ describe Chef::Knife::AzurermServerShow do
     @network_client = double("NetworkManagementClient")
     allow(@arm_server_instance.service).to receive(:compute_management_client).and_return(@compute_client)
     allow(@arm_server_instance.service).to receive(:network_resource_client).and_return(@network_client)
+    allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
   end
 
   it "raises error if there is no server with the given name" do


### PR DESCRIPTION
**Description:**
Added Azure CLI 2.0 support and re-factor code for following.
- Update azurerm server create
- Update azurerm server list
- Update azurerm server show
- Update azurerm server delete

**Reason:**
Microsoft recently released the Azure CLI 2.0 and the commands start with “az” instead of “azure” like Azure CLI 1.0.
Ref: https://buildazure.com/2017/05/16/azure-cli-1-0-vs-2-0-compared-installation-and-usage/

**Tested:**
- Verified azurerm server create command on both Azure CLI 1.0 and Azure CLI 2.0
- Verified azurerm server list command on both Azure CLI 1.0 and Azure CLI 2.0
- Verified azurerm server show command on both Azure CLI 1.0 and Azure CLI 2.0
- Verified azurerm server delete command on both Azure CLI 1.0 and Azure CLI 2.0

**Resolved Issue:**
knife azurerm command returns "azure: not recognized as an internal or external command".
Ref: https://github.com/chef/knife-azure/issues/466

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>