### PR TITLE
[MSYS-770] - fix runlist execution

### DIFF
--- a/lib/chef/knife/bootstrap/bootstrapper.rb
+++ b/lib/chef/knife/bootstrap/bootstrapper.rb
@@ -158,6 +158,7 @@ class Chef
           bootstrap.config[:bootstrap_vault_file] = locate_config_value(:bootstrap_vault_file)
           bootstrap.config[:bootstrap_vault_json] = locate_config_value(:bootstrap_vault_json)
           bootstrap.config[:bootstrap_vault_item] = locate_config_value(:bootstrap_vault_item)
+          bootstrap.config[:environment] = locate_config_value(:environment)
 
           load_cloud_attributes_in_hints(server)
           bootstrap
@@ -212,7 +213,6 @@ class Chef
           bootstrap.config[:chef_node_name] = locate_config_value(:chef_node_name) || server.name
           bootstrap.config[:use_sudo] = true unless locate_config_value(:ssh_user) == 'root'
           bootstrap.config[:use_sudo_password] = true if bootstrap.config[:use_sudo]
-          bootstrap.config[:environment] = locate_config_value(:environment)
           # may be needed for vpc_mode
           bootstrap.config[:host_key_verify] = config[:host_key_verify]
           Chef::Config[:knife][:secret] = config[:encrypted_data_bag_secret] if config[:encrypted_data_bag_secret]

--- a/lib/chef/knife/bootstrap/common_bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/common_bootstrap_options.rb
@@ -53,7 +53,7 @@ class Chef
             option :environment,
               :short        => "-E ENVIRONMENT",
               :long         => "--environment ENVIRONMENT",
-              :description  => "Set the Chef Environment on the node",
+              :description  => "Set the Chef environment (except for in searches, where this will be flagrantly ignored)",
               :default      => "_default"
 
             option :json_attributes,

--- a/lib/chef/knife/bootstrap/common_bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/common_bootstrap_options.rb
@@ -50,6 +50,12 @@ class Chef
               :proc => lambda { |o| o.split(/[\s,]+/) },
               :default => []
 
+            option :environment,
+              :short        => "-E ENVIRONMENT",
+              :long         => "--environment ENVIRONMENT",
+              :description  => "Set the Chef Environment on the node",
+              :default      => "_default"
+
             option :json_attributes,
               :short => "-j JSON",
               :long => "--json-attributes JSON",

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -40,7 +40,7 @@ describe Chef::Knife::AzurermServerCreate do
       :latest_chef_extension_version => '1210.12',
       :chef_extension_public_param => {
         :hints => ['vm_name', 'public_fqdn', 'platform'],
-        :bootstrap_options => { :bootstrap_version => '12.8.1'}
+        :bootstrap_options => { :bootstrap_version => '12.8.1' }
       },
       :vnet_config => {
         :virtualNetworkName => 'vnet1',
@@ -894,7 +894,7 @@ describe Chef::Knife::AzurermServerCreate do
       context "get_chef_extension_public_params" do
         it "sets bootstrapVersion variable in public_config" do
           @arm_server_instance.config[:bootstrap_version] = '12.4.2'
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :bootstrap_version=>"12.4.2"}}
+          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :bootstrap_version=>"12.4.2", :environment=> "_default"}}
 
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
@@ -902,7 +902,7 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "should set extendedLogs flag to true" do
           @arm_server_instance.config[:extended_logs] = true
-          public_config = {client_rb: "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", runlist: "\"getting-started\"", extendedLogs: "true", custom_json_attr: {}, :hints=>["vm_name", "public_fqdn", "platform"], bootstrap_options: {chef_server_url: "https://localhost:443", validation_client_name: "chef-validator"}}
+          public_config = {client_rb: "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", runlist: "\"getting-started\"", extendedLogs: "true", custom_json_attr: {}, :hints=>["vm_name", "public_fqdn", "platform"], bootstrap_options: {chef_server_url: "https://localhost:443", validation_client_name: "chef-validator", :environment=> "_default"}}
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
         end
@@ -927,7 +927,7 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "sets chefServiceInterval variable in public_config" do
           @arm_server_instance.config[:chef_daemon_interval] = '0'
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :chef_daemon_interval=>'0', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator"}}
+          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :chef_daemon_interval=>'0', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :environment=> "_default"}}
 
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
@@ -936,7 +936,7 @@ describe Chef::Knife::AzurermServerCreate do
         it "sets daemon variable in public config" do
           @arm_server_instance.config[:daemon] = 'service'
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :daemon=>'service', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator"}}   
+          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :daemon=>'service', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :environment=> "_default"}}
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
         end

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -907,6 +907,20 @@ describe Chef::Knife::AzurermServerCreate do
           expect(response).to be == public_config
         end
 
+        it "sets environment to _default if not provided by user" do
+          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :environment=> "_default"}}
+          response = @arm_server_instance.get_chef_extension_public_params
+          expect(response).to be == public_config
+        end
+
+        it "sets environment variable in public_config" do
+          @arm_server_instance.config[:environment] = 'development'
+          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :environment=> "development"}}
+          response = @arm_server_instance.get_chef_extension_public_params
+          expect(response).to be == public_config
+        end
+
+
         context 'service is an instance_of ARM' do
           it 'invokes ohai_hints method' do
             expect(@arm_server_instance).to receive(:ohai_hints)


### PR DESCRIPTION
**Issue :** Unable to execute chef cookbooks in azure ARM VM

**Ref    :** https://github.com/chef/knife-azure/issues/465

**Reason:**
`:environment option` was not being set as parameter if we don't provide in CLI in azure-chef-extension  at https://github.com/chef-partners/azure-chef-extension/blob/master/lib/chef/azure/commands/enable.rb#L259  while executing `chef-client`. So due to this cookbooks passed as parameter was unable to execute on node. 

Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>