### PR TITLE
[MSYS-805] Fix for error uniniitalized constant Chef::Knife::AzurermBase

### DIFF
--- a/lib/chef/knife/azurerm_server_delete.rb
+++ b/lib/chef/knife/azurerm_server_delete.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path('../azurerm_base', __FILE__)
 
 # These two are needed for the '--purge' deletion case
 require 'chef/node'


### PR DESCRIPTION
While running bundle exec knife azurerm server create --help I am getting error `unintialized constant Chef::Knife::AzurermBase`. Resolved by requiring azurerm_base file instead of arure_base file. Tested with knife azurerm server delete command.

Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>