### PR TITLE
MSYS-789 - Fixed azure server create fail for cloud-api.

### DIFF
--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -124,7 +124,77 @@ class Chef
       end
 
       # validate command pre-requisites (cli options)
+      # (locate_config_value(:winrm_password).length <= 6 && locate_config_value(:winrm_password).length >= 72)
       def validate_params!
+        if locate_config_value(:winrm_password) && !locate_config_value(:winrm_password).strip.size.between?(6, 72)
+          ui.error("The supplied password must be 6-72 characters long and meet password complexity requirements")
+          exit 1
+        end
+
+        if locate_config_value(:ssh_password) && !locate_config_value(:ssh_password).empty? && !locate_config_value(:ssh_password).strip.size.between?(6, 72)
+          ui.error("The supplied ssh password must be 6-72 characters long and meet password complexity requirements")
+          exit 1
+        end
+
+        if locate_config_value(:azure_connect_to_existing_dns) && locate_config_value(:azure_vm_name).nil?
+          ui.error("Specify the VM name using --azure-vm-name option, since you are connecting to existing dns")
+          exit 1
+        end
+
+        if locate_config_value(:azure_service_location) && locate_config_value(:azure_affinity_group)
+          ui.error("Cannot specify both --azure-service-location and --azure-affinity-group, use one or the other.")
+          exit 1
+        elsif locate_config_value(:azure_service_location).nil? && locate_config_value(:azure_affinity_group).nil?
+          ui.error("Must specify either --azure-service-location or --azure-affinity-group.")
+          exit 1
+        end
+
+        if locate_config_value(:winrm_authentication_protocol) && ! %w{basic negotiate kerberos}.include?(locate_config_value(:winrm_authentication_protocol).downcase)
+          ui.error("Invalid value for --winrm-authentication-protocol option. Use valid protocol values i.e [basic, negotiate, kerberos]")
+          exit 1
+        end
+
+        if !(service.valid_image?(locate_config_value(:azure_source_image)))
+          ui.error("Image '#{locate_config_value(:azure_source_image)}' is invalid")
+          exit 1
+        end
+
+        # Validate join domain requirements.
+        if locate_config_value(:azure_domain_name) || locate_config_value(:azure_domain_user)
+          if locate_config_value(:azure_domain_user).nil? || locate_config_value(:azure_domain_passwd).nil?
+            ui.error("Must specify both --azure-domain-user and --azure-domain-passwd.")
+            exit 1
+          end
+        end
+
+        if locate_config_value(:winrm_transport) == "ssl" && locate_config_value(:thumbprint).nil? && ( locate_config_value(:winrm_ssl_verify_mode).nil? || locate_config_value(:winrm_ssl_verify_mode) == :verify_peer )
+          ui.error("The SSL transport was specified without the --thumbprint option. Specify a thumbprint, or alternatively set the --winrm-ssl-verify-mode option to 'verify_none' to skip verification.")
+          exit 1
+        end
+
+        if locate_config_value(:extended_logs) && locate_config_value(:bootstrap_protocol) != 'cloud-api'
+          ui.error("--extended-logs option only works with --bootstrap-protocol cloud-api")
+          exit 1
+        end
+
+        if locate_config_value(:bootstrap_protocol) == 'cloud-api' && locate_config_value(:azure_vm_name).nil? && locate_config_value(:azure_dns_name).nil?
+          ui.error("Specifying the DNS name using --azure-dns-name or VM name using --azure-vm-name option is required with --bootstrap-protocol cloud-api")
+          exit 1
+        end
+
+        if locate_config_value(:daemon)
+          unless is_image_windows?
+            raise ArgumentError, "The daemon option is only supported for Windows nodes."
+          end
+
+          unless  locate_config_value(:bootstrap_protocol) == 'cloud-api'
+            raise ArgumentError, "The --daemon option requires the use of --bootstrap-protocol cloud-api"
+          end
+
+          unless %w{none service task}.include?(locate_config_value(:daemon).downcase)
+            raise ArgumentError, "Invalid value for --daemon option. Valid values are 'none', 'service' and 'task'."
+          end
+        end
       end
 
       # validates keys

--- a/lib/chef/knife/azurerm_base.rb
+++ b/lib/chef/knife/azurerm_base.rb
@@ -335,6 +335,7 @@ class Chef
       end
 
       def is_old_xplat?
+        return true unless @azure_version
         Gem::Version.new(@azure_version) < Gem::Version.new(XPLAT_VERSION_WITH_WCM_DEPRECATED)
       end
 

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -95,6 +95,13 @@ describe Chef::Knife::AzureServerCreate do
         expect {@server_instance.run}.to raise_error(SystemExit)
       end
 
+      it "raises an error if neither --azure-dns-name or --azure-vm-name are provided" do
+        Chef::Config[:knife].delete(:azure_dns_name)
+        Chef::Config[:knife].delete(:azure_vm_name)
+        expect(@server_instance.ui).to receive(:error)
+        expect {@server_instance.run}.to raise_error(SystemExit)
+      end
+
       context "when winrm authentication protocol invalid" do
         it "raise error" do
           Chef::Config[:knife][:winrm_authentication_protocol] = "invalide"
@@ -117,7 +124,7 @@ describe Chef::Knife::AzureServerCreate do
       it "raise error if daemon option is not provided for windows node" do
         Chef::Config[:knife][:daemon] = "service"
         expect {@server_instance.run}.to raise_error(
-          ArgumentError, "The daemon option is only support for Windows nodes.")
+          ArgumentError, "The daemon option is only supported for Windows nodes.")
       end
 
       it "raises error if invalid value is provided for daemon option" do
@@ -125,7 +132,7 @@ describe Chef::Knife::AzureServerCreate do
         Chef::Config[:knife][:daemon] = "foo"
         Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
         expect {@server_instance.run}.to raise_error(
-          ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
+          ArgumentError, "Invalid value for --daemon option. Valid values are 'none', 'service' and 'task'."
           )
       end
 
@@ -133,7 +140,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "service"
         expect {@server_instance.run}.to raise_error(
-          ArgumentError, "--daemon option works with --bootstrap-protocol cloud-api"
+          ArgumentError, "The --daemon option requires the use of --bootstrap-protocol cloud-api"
         )
       end
 
@@ -183,8 +190,8 @@ describe Chef::Knife::AzureServerCreate do
     context "server create options" do
       before do
         Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
         Chef::Config[:knife][:ssh_user] = 'ssh_user'
+        Chef::Config[:knife][:ssh_password] = 'ssh_password'
         Chef::Config[:knife].delete(:azure_vm_name)
         Chef::Config[:knife].delete(:azure_storage_account)
         @bootstrap = Chef::Knife::Bootstrap.new
@@ -764,16 +771,16 @@ describe Chef::Knife::AzureServerCreate do
 
     context "linux instance" do
       before do
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
         Chef::Config[:knife][:ssh_user] = 'ssh_user'
+        Chef::Config[:knife][:ssh_password] = 'ssh_password'
       end
 
       it "check if all server params are set correctly" do
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).and_return(false)
         @server_params = @server_instance.create_server_def
         expect(@server_params[:os_type]).to be == 'Linux'
-        expect(@server_params[:ssh_password]).to be == 'ssh_password'
         expect(@server_params[:ssh_user]).to be == 'ssh_user'
+        expect(@server_params[:ssh_password]).to be == 'ssh_password'
         expect(@server_params[:bootstrap_proto]).to be == 'ssh'
         expect(@server_params[:azure_dns_name]).to be == 'service001'
         expect(@server_params[:azure_vm_name]).to be == 'vm002'


### PR DESCRIPTION
**Description:** 
Azure server create failed if user using `--bootstrap-protocol = 'cloud-api' ` but not provided node name `--node-name`.

**Covered Point:**
1: Added validation if user not specify the DNS name using `--azure-dns-name` or VM name using `--azure-vm-name` options.
2: Fixed issue if VM name exist but not node name then we assign VM name value to NODE name.
3: Added rspec for the same.

**Issue:** reference https://github.com/chef/knife-azure/issues/441

Fixes  https://github.com/chef/knife-azure/issues/441

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>