### PR TITLE
Remove require on highline as knife does this

### DIFF
--- a/lib/chef/knife/azure_ag_list.rb
+++ b/lib/chef/knife/azure_ag_list.rb
@@ -23,8 +23,6 @@ class Chef
     class AzureAgList < Knife
       include Knife::AzureBase
 
-      deps { require 'highline' }
-
       banner 'knife azure ag list (options)'
 
       def run

--- a/lib/chef/knife/azure_internal-lb_list.rb
+++ b/lib/chef/knife/azure_internal-lb_list.rb
@@ -23,8 +23,6 @@ class Chef
     class AzureInternalLbList < Knife
       include Knife::AzureBase
 
-      deps { require 'highline' }
-
       banner 'knife azure internal lb list (options)'
 
       def run

--- a/lib/chef/knife/azure_vnet_list.rb
+++ b/lib/chef/knife/azure_vnet_list.rb
@@ -23,8 +23,6 @@ class Chef
     class AzureVnetList < Knife
       include Knife::AzureBase
 
-      deps { require 'highline' }
-
       banner 'knife azure vnet list (options)'
 
       def run


### PR DESCRIPTION
Highline isn't used directly in this plugin and chef/knife/core/ui provides it already

Signed-off-by: Tim Smith <tsmith@chef.io>