### PR TITLE
Require Ruby 2.3+ and fix Chefstyle offenses

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,6 +17,9 @@ github:
   minor_bump_labels:
     - "Expeditor: Bump Minor Version"
 
+changelog:
+  rollup_header: Changes not yet released to rubygems.org
+
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,87 @@
+Layout/DefEndAlignment:
+  Exclude:
+    - 'lib/azure/custom_errors.rb'
+    - 'lib/azure/service_management/ASM_interface.rb'
+
+Layout/EndAlignment:
+  Exclude:
+    - 'lib/azure/resource_management/ARM_interface.rb'
+    - 'lib/azure/resource_management/windows_credentials.rb'
+    - 'lib/azure/service_management/role.rb'
+    - 'lib/chef/knife/azure_server_delete.rb'
+    - 'spec/unit/azure_base_spec.rb'
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'lib/azure/service_management/rest.rb'
+
+Lint/AmbiguousRegexpLiteral:
+  Exclude:
+    - 'lib/chef/knife/azurerm_base.rb'
+
+Lint/DuplicateMethods:
+  Exclude:
+    - 'lib/azure/service_management/storageaccount.rb'
+
+Lint/Loop:
+  Exclude:
+    - 'lib/azure/resource_management/ARM_interface.rb'
+    - 'lib/azure/service_management/certificate.rb'
+    - 'lib/chef/knife/azure_server_create.rb'
+
+Lint/ParenthesesAsGroupedExpression:
+  Exclude:
+    - 'lib/azure/resource_management/ARM_deployment_template.rb'
+    - 'lib/azure/service_management/certificate.rb'
+    - 'lib/azure/service_management/deploy.rb'
+    - 'lib/chef/knife/bootstrap/bootstrapper.rb'
+    - 'spec/unit/ags_spec.rb'
+    - 'spec/unit/azure_server_create_spec.rb'
+    - 'spec/unit/azurerm_base_spec.rb'
+    - 'spec/unit/azurerm_server_delete_spec.rb'
+    - 'spec/unit/deploys_list_spec.rb'
+    - 'spec/unit/disks_spec.rb'
+    - 'spec/unit/hosts_spec.rb'
+    - 'spec/unit/roles_create_spec.rb'
+    - 'spec/unit/roles_list_spec.rb'
+    - 'spec/unit/storageaccount_spec.rb'
+    - 'spec/unit/vnet_spec.rb'
+
+Lint/UselessAssignment:
+  Enabled: false
+
+Naming/VariableName:
+  Exclude:
+    - 'lib/azure/resource_management/ARM_deployment_template.rb'
+    - 'lib/azure/service_management/deploy.rb'
+    - 'lib/azure/service_management/host.rb'
+    - 'lib/azure/service_management/loadbalancer.rb'
+    - 'lib/azure/service_management/role.rb'
+    - 'lib/azure/service_management/storageaccount.rb'
+    - 'spec/functional/host_test.rb'
+    - 'spec/unit/images_spec.rb'
+    - 'spec/unit/query_azure_mock.rb'
+
+Performance/RedundantMatch:
+  Exclude:
+    - 'spec/unit/query_azure_mock.rb'
+
+Style/For:
+  Exclude:
+    - 'lib/azure/resource_management/ARM_deployment_template.rb'
+    - 'lib/azure/service_management/certificate.rb'
+    - 'lib/azure/service_management/role.rb'
+
+Style/NonNilCheck:
+  Exclude:
+    - 'lib/azure/service_management/deploy.rb'
+    - 'lib/chef/knife/azure_base.rb'
+    - 'lib/chef/knife/azure_server_create.rb'
+    - 'lib/chef/knife/bootstrap_azure.rb'
+
+Style/NumericPredicate:
+  Exclude:
+    - 'spec/**/*'
+    - 'lib/azure/service_management/role.rb'
+    - 'lib/chef/knife/azurerm_base.rb'
+    - 'lib/chef/knife/bootstrap/bootstrapper.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
+sudo: false
 language: ruby
 cache: bundler
-dist: trusty
-sudo: false
-rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - ruby-head
 
 matrix:
+  include:
+    - rvm: 2.3.7
+    - rvm: 2.4.4
+    - rvm: 2.5.1
+    - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
+
 branches:
   only:
   - master
-script: bundle exec rake spec
+
+bundler_args: --jobs 7 --without docs debug
+
+script: bundle exec rake

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,36 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
-group :development do
-  gem 'rspec', '>= 3.0'
-  gem 'guard-rspec'
-  gem 'rspec_junit_formatter'
-  gem 'rake'
-  gem 'mixlib-shellout'
-  gem 'activesupport', '4.2.6'
-  gem 'rb-readline'
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
 end
+
+group :test do
+  gem "activesupport", "4.2.6"
+  gem "chef", ">= 13.0"
+  gem "chefstyle", "= 0.10.0"
+  gem "equivalent-xml", "~> 0.2.9"
+  gem "guard-rspec"
+  gem "knife-cloud", ">= 1.0.0"
+  gem "mixlib-config", "~> 2.0"
+  gem "mixlib-shellout"
+  gem "rake"
+  gem "rb-readline"
+  gem "rspec", ">= 3.0"
+  gem "rspec_junit_formatter"
+end
+
+group :docs do
+  gem "github-markup"
+  gem "redcarpet"
+  gem "yard"
+end
+
+instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/Guardfile
+++ b/Guardfile
@@ -1,8 +1,8 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard :rspec, :version => 2 do
+guard :rspec, version: 2 do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})    # { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+  watch(%r{^lib/(.+)\.rb$}) # { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch("spec/spec_helper.rb") { "spec" }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,62 +1,56 @@
-# encoding: utf-8
-
-require 'rubygems'
-require 'bundler'
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
+  warn e.message
+  warn "Run `bundle install` to install missing gems"
   exit e.status_code
 end
-require 'rake'
-GEM_NAME = "knife-azure"
 
-spec = eval(File.read("knife-azure.gemspec"))
+Bundler::GemHelper.install_tasks
 
-require 'rubygems/package_task'
-
-Gem::PackageTask.new(spec) do |pkg|
-  pkg.gem_spec = spec
-end
-
-require 'rspec/core'
-require 'rspec/core/rake_task'
+desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|
-  spec.pattern = FileList['spec/unit/**/*_spec.rb'].to_a
+  spec.pattern = FileList["spec/unit/**/*_spec.rb"].to_a
 end
 
 RSpec::Core::RakeTask.new(:functional) do |spec|
-  spec.pattern = FileList['spec/functional/**/*_test.rb'].to_a
+  spec.pattern = FileList["spec/functional/**/*_test.rb"].to_a
 end
 
 RSpec::Core::RakeTask.new(:integration) do |spec|
-  spec.pattern = FileList['spec/integration/**/*_test.rb'].to_a
+  spec.pattern = FileList["spec/integration/**/*_test.rb"].to_a
 end
 
 RSpec::Core::RakeTask.new(:rcov) do |spec|
-  spec.pattern = 'spec/unit|functional/*_spec.rb'
+  spec.pattern = "spec/unit|functional/*_spec.rb"
   spec.rcov = true
 end
 
-task :default => :spec
-
-task :install => :package do
-  sh %{gem install pkg/#{GEM_NAME}-#{Knife::Azure::VERSION} --no-rdoc --no-ri}
+begin
+  require "chefstyle"
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new(:style) do |task|
+    task.options += ["--display-cop-names", "--no-color"]
+  end
+rescue LoadError
+  puts "chefstyle/rubocop is not available. bundle install first to make sure all dependencies are installed."
 end
 
-task :uninstall do
-  sh %{gem uninstall #{GEM_NAME} -x -v #{Knife::Azure::VERSION} }
+begin
+  require "yard"
+  YARD::Rake::YardocTask.new(:docs)
+rescue LoadError
+  puts "yard is not available. bundle install first to make sure all dependencies are installed."
 end
 
-require 'rdoc/task'
-Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "knife-azure #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+task :console do
+  require "irb"
+  require "irb/completion"
+  ARGV.clear
+  IRB.start
 end
+
+task default: %i{style spec}

--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -1,5 +1,5 @@
-$:.unshift(File.dirname(__FILE__) + '/lib')
-require 'knife-azure/version'
+$:.unshift(File.dirname(__FILE__) + "/lib")
+require "knife-azure/version"
 
 Gem::Specification.new do |s|
   s.name = "knife-azure"
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [
     "LICENSE"
   ]
-  s.files = %w(LICENSE README.md) + Dir.glob("lib/**/*")
+  s.files = %w{LICENSE README.md} + Dir.glob("lib/**/*")
   s.homepage = "https://github.com/chef/knife-azure"
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "nokogiri", ">= 1.5.5"
   s.add_dependency "knife-windows", "~> 1.0"
@@ -28,8 +28,4 @@ Gem::Specification.new do |s|
   s.add_dependency "listen", "~> 3.0"
   s.add_dependency "ipaddress"
   s.add_dependency "ffi"
-  s.add_development_dependency 'chef',  '>= 12.2.1'
-  s.add_development_dependency "mixlib-config", "~> 2.0"
-  s.add_development_dependency "equivalent-xml", "~> 0.2.9"
-  s.add_development_dependency "knife-cloud", ">= 1.0.0"
 end

--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -1,4 +1,4 @@
-$:.unshift(File.dirname(__FILE__) + "/lib")
+$LOAD_PATH.unshift(File.dirname(__FILE__) + "/lib")
 require "knife-azure/version"
 
 Gem::Specification.new do |s|
@@ -19,13 +19,13 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3"
 
-  s.add_dependency "nokogiri", ">= 1.5.5"
-  s.add_dependency "knife-windows", "~> 1.0"
-  s.add_dependency "azure_mgmt_resources", "0.9.0"
   s.add_dependency "azure_mgmt_compute", "0.9.0"
-  s.add_dependency "azure_mgmt_storage", "0.9.0"
   s.add_dependency "azure_mgmt_network", "0.9.0"
-  s.add_dependency "listen", "~> 3.0"
-  s.add_dependency "ipaddress"
+  s.add_dependency "azure_mgmt_resources", "0.9.0"
+  s.add_dependency "azure_mgmt_storage", "0.9.0"
   s.add_dependency "ffi"
+  s.add_dependency "ipaddress"
+  s.add_dependency "knife-windows", "~> 1.0"
+  s.add_dependency "listen", "~> 3.0"
+  s.add_dependency "nokogiri", ">= 1.5.5"
 end

--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [
     "LICENSE"
   ]
-  s.files = %w{LICENSE README.md} + Dir.glob("lib/**/*")
+  s.files = %w{LICENSE} + Dir.glob("lib/**/*")
   s.homepage = "https://github.com/chef/knife-azure"
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3"

--- a/lib/azure/azure_interface.rb
+++ b/lib/azure/azure_interface.rb
@@ -16,9 +16,8 @@
 # limitations under the License.
 #
 
-require 'azure/custom_errors'
-require 'azure/helpers'
-
+require "azure/custom_errors"
+require "azure/helpers"
 
 module Azure
   class AzureInterface

--- a/lib/azure/azure_interface.rb
+++ b/lib/azure/azure_interface.rb
@@ -1,6 +1,5 @@
 #
-# Author::
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/custom_errors.rb
+++ b/lib/azure/custom_errors.rb
@@ -26,10 +26,10 @@ module CustomErrors
   end
 
   module Methods
-     def api_not_implemented(klass)
-      caller.first.match(/in \`(.+)\'/)
+    def api_not_implemented(klass)
+      caller.first =~ /in \`(.+)\'/
       method_name = $1
-      raise CustomErrors::InterfaceNotImplementedError.new("#{klass.class.name} needs to implement '#{method_name}' for interface #{self.name}!")
-    end
+      raise CustomErrors::InterfaceNotImplementedError.new("#{klass.class.name} needs to implement '#{method_name}' for interface #{name}!")
+   end
   end
 end

--- a/lib/azure/custom_errors.rb
+++ b/lib/azure/custom_errors.rb
@@ -1,6 +1,5 @@
 #
-# Author::
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/helpers.rb
+++ b/lib/azure/helpers.rb
@@ -1,6 +1,6 @@
 #
 # Author:: vasundhara.jagdale@clogeny.com
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/helpers.rb
+++ b/lib/azure/helpers.rb
@@ -18,24 +18,23 @@
 
 module Azure
   module Helpers
-
-    def random_string(len=10)
-      (0...len).map{65.+(rand(25)).chr}.join
+    def random_string(len = 10)
+      (0...len).map { 65.+(rand(25)).chr }.join
     end
 
     def strip_non_ascii(string)
-      string.gsub(/[^0-9a-z ]/i, '')
+      string.gsub(/[^0-9a-z ]/i, "")
     end
 
-    def display_list(ui=nil, columns=[], rows=[])
-      columns = columns.map{ |col| ui.color(col, :bold) }
+    def display_list(ui = nil, columns = [], rows = [])
+      columns = columns.map { |col| ui.color(col, :bold) }
       count = columns.count
       rows = columns.concat(rows)
-      puts ''
+      puts ""
       puts ui.list(rows, :uneven_columns_across, count)
     end
 
-    def msg_pair(ui=nil, label=nil, value=nil, color=:cyan)
+    def msg_pair(ui = nil, label = nil, value = nil, color = :cyan)
       if value && !value.to_s.empty?
         puts "#{ui.color(label, color)}: #{value}"
       end

--- a/lib/azure/resource_management/ARM_base.rb
+++ b/lib/azure/resource_management/ARM_base.rb
@@ -17,13 +17,12 @@
 #
 
 module Azure::ARM
-    module ARMBase
-
-      def get_vm_size(size_name)
-        size_hash = { "ExtraSmall" => "Standard_A0", "Small" => "Standard_A1",
-                      "Medium" => "Standard_A2", "Large" => "Standard_A3",
-                      "ExtraLarge" => "Standard_A4" }
-        size_hash[size_name]
-      end
+  module ARMBase
+    def get_vm_size(size_name)
+      size_hash = { "ExtraSmall" => "Standard_A0", "Small" => "Standard_A1",
+                    "Medium" => "Standard_A2", "Large" => "Standard_A3",
+                    "ExtraLarge" => "Standard_A4" }
+      size_hash[size_name]
     end
+  end
 end

--- a/lib/azure/resource_management/ARM_base.rb
+++ b/lib/azure/resource_management/ARM_base.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
-# Copyright:: Copyright (c) 2015-2016 Opscode, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/resource_management/ARM_deployment_template.rb
+++ b/lib/azure/resource_management/ARM_deployment_template.rb
@@ -18,18 +18,17 @@
 
 module Azure::ARM
   module ARMDeploymentTemplate
-
     def ohai_hints(hint_names, resource_ids)
       hints_json = {}
 
       hint_names.each do |hint_name|
         case hint_name
-        when 'vm_name'
-          hints_json['vm_name'] = "[reference(#{resource_ids['vmId']}).osProfile.computerName]" if !hints_json.has_key? 'vm_name'
-        when 'public_fqdn'
-          hints_json['public_fqdn'] = "[reference(#{resource_ids['pubId']}).dnsSettings.fqdn]" if !hints_json.has_key? 'public_fqdn'
-        when 'platform'
-          hints_json['platform'] = "[concat(reference(#{resource_ids['vmId']}).storageProfile.imageReference.offer, concat(' ', reference(#{resource_ids['vmId']}).storageProfile.imageReference.sku))]" if !hints_json.has_key? 'platform'
+        when "vm_name"
+          hints_json["vm_name"] = "[reference(#{resource_ids['vmId']}).osProfile.computerName]" if !hints_json.has_key? "vm_name"
+        when "public_fqdn"
+          hints_json["public_fqdn"] = "[reference(#{resource_ids['pubId']}).dnsSettings.fqdn]" if !hints_json.has_key? "public_fqdn"
+        when "platform"
+          hints_json["platform"] = "[concat(reference(#{resource_ids['vmId']}).storageProfile.imageReference.offer, concat(' ', reference(#{resource_ids['vmId']}).storageProfile.imageReference.sku))]" if !hints_json.has_key? "platform"
         end
       end
 
@@ -38,50 +37,48 @@ module Azure::ARM
 
     def tcp_ports(tcp_ports, vm_name)
       tcp_ports = tcp_ports.split(",")
-      sec_grp_json = 
+      sec_grp_json =
         {
           "apiVersion" => "[variables('apiVersion')]",
           "type" => "Microsoft.Network/networkSecurityGroups",
           "name" => "[variables('secgrpname')]",
           "location" => "[resourceGroup().location]",
           "properties" => {
-          "securityRules" => [
-          ]
-        }
-      }
-      #Security Rule priority can be set between 100 and 4096
-      rule_no = 300
-      incremental=0
-      for port in tcp_ports
-        rule_no  = rule_no + 2
-        sec_grp_json["properties"]["securityRules"].push(
-        {
-          "name" => vm_name + '_rule_' + incremental.to_s,
-          "properties"=> {
-          "description" => "Port Provided by user",
-          "protocol" => "Tcp",
-          "sourcePortRange" => "*",
-          "destinationPortRange" => port,
-          "sourceAddressPrefix" => "*",
-          "destinationAddressPrefix" => "*",
-          "access" => "Allow",
-          "priority" => rule_no,
-          "direction" => "Inbound"
+            "securityRules" => [
+            ]
           }
         }
+      # Security Rule priority can be set between 100 and 4096
+      rule_no = 300
+      incremental = 0
+      for port in tcp_ports
+        rule_no += 2
+        sec_grp_json["properties"]["securityRules"].push(
+          "name" => vm_name + "_rule_" + incremental.to_s,
+          "properties" => {
+            "description" => "Port Provided by user",
+            "protocol" => "Tcp",
+            "sourcePortRange" => "*",
+            "destinationPortRange" => port,
+            "sourceAddressPrefix" => "*",
+            "destinationAddressPrefix" => "*",
+            "access" => "Allow",
+            "priority" => rule_no,
+            "direction" => "Inbound"
+          }
         )
-        incremental=incremental+1
+        incremental += 1
       end
       sec_grp_json
     end
-    
+
     def create_deployment_template(params)
       if params[:chef_extension_public_param][:bootstrap_options][:chef_node_name]
         chef_node_name = "[concat(parameters('chef_node_name'),copyIndex())]"
-        chef_node_name = "[parameters('chef_node_name')]" if params[:server_count].to_i==1
+        chef_node_name = "[parameters('chef_node_name')]" if params[:server_count].to_i == 1
       end
 
-      if(params[:server_count].to_i > 1)
+      if params[:server_count].to_i > 1
         # publicIPAddresses Resource Variables
         publicIPAddressName = "[concat(variables('publicIPAddressName'),copyIndex())]"
         domainNameLabel = "[concat(parameters('dnsLabelPrefix'), copyIndex())]"
@@ -94,7 +91,7 @@ module Azure::ARM
         # virtualMachines Resource Variables
         vmName = "[concat(variables('vmName'),copyIndex())]"
         vmId = "[resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))]"
-        depVm2="[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
+        depVm2 = "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
         computerName = "[concat(variables('vmName'),copyIndex())]"
         uri = "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',concat(variables('vmName'),copyIndex()),'.vhd')]"
         netid = "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'), copyIndex()))]"
@@ -116,7 +113,7 @@ module Azure::ARM
         # virtualMachines Resource Variables
         vmName = "[variables('vmName')]"
         vmId = "[resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))]"
-        depVm2="[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        depVm2 = "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
         computerName = "[variables('vmName')]"
         uri = "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'.vhd')]"
         netid = "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
@@ -126,7 +123,7 @@ module Azure::ARM
         depExt = "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       end
 
-      # NetworkSecurityGroups Resource Variables 
+      # NetworkSecurityGroups Resource Variables
       sec_grp_name = "[variables('secgrpname')]"
       sec_grp = "[concat('Microsoft.Network/networkSecurityGroups/', variables('secgrpname'))]"
       sec_grp_id = "[resourceId('Microsoft.Network/networkSecurityGroups/', variables('secgrpname'))]"
@@ -136,39 +133,39 @@ module Azure::ARM
 
       hint_names.each do |hint_name|
         case hint_name
-        when 'public_fqdn'
-          resource_ids['pubId'] = pubId.gsub('[','').gsub(']','') if !resource_ids.has_key? 'pubId'
-        when 'vm_name', 'platform'
-          resource_ids['vmId'] = vmId.gsub('[','').gsub(']','') if !resource_ids.has_key? 'vmId'
+        when "public_fqdn"
+          resource_ids["pubId"] = pubId.delete("[").delete("]") unless resource_ids.key? "pubId"
+        when "vm_name", "platform"
+          resource_ids["vmId"] = vmId.delete("[").delete("]") unless resource_ids.key? "vmId"
         end
       end
 
       hints_json = ohai_hints(hint_names, resource_ids)
 
       template = {
-        "$schema"=> "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-        "contentVersion"=> "1.0.0.0",
-        "parameters"=> {
-          "adminUserName"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "User name for the Virtual Machine."
+        "$schema" => "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "contentVersion" => "1.0.0.0",
+        "parameters" => {
+          "adminUserName" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "User name for the Virtual Machine."
             }
           },
-          "adminPassword"=> {
-            "type"=> "securestring",
-            "metadata"=> {
-              "description"=> "Password for the Virtual Machine."
+          "adminPassword" => {
+            "type" => "securestring",
+            "metadata" => {
+              "description" => "Password for the Virtual Machine."
             }
           },
           "availabilitySetName" => {
             "type" => "string"
           },
           "availabilitySetPlatformFaultDomainCount" => {
-              "type" => "string"
+            "type" => "string"
           },
           "availabilitySetPlatformUpdateDomainCount" => {
-              "type" => "string"
+            "type" => "string"
           },
           "numberOfInstances" => {
             "type" => "int",
@@ -177,74 +174,74 @@ module Azure::ARM
               "description" => "Number of VM instances to create. Default is 1"
             }
           },
-          "dnsLabelPrefix"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Unique DNS Name for the Public IP used to access the Virtual Machine."
+          "dnsLabelPrefix" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
           },
-          "imageSKU"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Version of the image"
+          "imageSKU" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Version of the image"
             }
           },
           "imageVersion" => {
-            "type"=> "string",
+            "type" => "string",
             "defaultValue" => "latest",
             "metadata" => {
               "description" => "Azure image reference version."
             }
           },
           "validation_key" => {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "JSON Escaped Validation Key"
+            "type" => "string",
+            "metadata" => {
+              "description" => "JSON Escaped Validation Key"
             }
           },
-          
+
           "chef_server_crt" => {
-             "type"=> "string",
-            "metadata"=> {
-              "description"=> "Optional. SSL cerificate provided by user."
+            "type" => "string",
+            "metadata" => {
+              "description" => "Optional. SSL cerificate provided by user."
             }
           },
-          "chef_server_url"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Organization URL for the Chef Server. Example https://ChefServerDnsName.cloudapp.net/organizations/Orgname"
+          "chef_server_url" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Organization URL for the Chef Server. Example https://ChefServerDnsName.cloudapp.net/organizations/Orgname"
             }
           },
-          "validation_client_name"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Validator key name for the organization. Example : MyOrg-validator"
+          "validation_client_name" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Validator key name for the organization. Example : MyOrg-validator"
             }
           },
-          "runlist"=> {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Optional Run List to Execute"
+          "runlist" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Optional Run List to Execute"
             }
           },
-          "environment"=> {
-           "type"=> "string",
-            "metadata"=> {
-              "description"=> "Chef environment for the node (VM) in the Chef Organization"
+          "environment" => {
+            "type" => "string",
+            "metadata" => {
+              "description" => "Chef environment for the node (VM) in the Chef Organization"
             }
           },
-           "chef_node_name" => {
+          "chef_node_name" => {
             "type" => "string",
             "metadata" => {
               "description" => "The name for the node (VM) in the Chef Organization"
             }
           },
           "validation_key_format" => {
-            "type"=> "string",
-            "allowedValues"=> ["plaintext", "base64encoded"],
-            "defaultValue"=> "plaintext",
+            "type" => "string",
+            "allowedValues" => %w{plaintext base64encoded},
+            "defaultValue" => "plaintext",
             "metadata" => {
-              "description"=> "Format in which Validation Key is given. e.g. plaintext, base64encoded"
+              "description" => "Format in which Validation Key is given. e.g. plaintext, base64encoded"
             }
           },
           "client_rb" => {
@@ -302,45 +299,45 @@ module Azure::ARM
             }
           }
         },
-        "variables"=> {
-          "storageAccountName"=> "[concat(uniquestring(resourceGroup().id), '#{params[:azure_storage_account]}')]",
-          "imagePublisher"=> "#{params[:azure_image_reference_publisher]}",
-          "imageOffer"=> "#{params[:azure_image_reference_offer]}",
-          "OSDiskName"=> "#{params[:azure_os_disk_name]}",
-          "nicName"=> "#{params[:azure_vm_name]}",
-          "subnetName"=> "#{params[:azure_vnet_subnet_name]}",
-          "storageAccountType"=> "#{params[:azure_storage_account_type]}",
-          "publicIPAddressName"=> "#{params[:azure_vm_name]}",
-          "publicIPAddressType"=> "Dynamic",
-          "vmStorageAccountContainerName"=> "#{params[:azure_vm_name]}",
-          "vmName"=> "#{params[:azure_vm_name]}",
-          "vmSize"=> "#{params[:vm_size]}",
-          "virtualNetworkName"=> "#{params[:vnet_config][:virtualNetworkName]}",
+        "variables" => {
+          "storageAccountName" => "[concat(uniquestring(resourceGroup().id), '#{params[:azure_storage_account]}')]",
+          "imagePublisher" => "#{params[:azure_image_reference_publisher]}",
+          "imageOffer" => "#{params[:azure_image_reference_offer]}",
+          "OSDiskName" => "#{params[:azure_os_disk_name]}",
+          "nicName" => "#{params[:azure_vm_name]}",
+          "subnetName" => "#{params[:azure_vnet_subnet_name]}",
+          "storageAccountType" => "#{params[:azure_storage_account_type]}",
+          "publicIPAddressName" => "#{params[:azure_vm_name]}",
+          "publicIPAddressType" => "Dynamic",
+          "vmStorageAccountContainerName" => "#{params[:azure_vm_name]}",
+          "vmName" => "#{params[:azure_vm_name]}",
+          "vmSize" => "#{params[:vm_size]}",
+          "virtualNetworkName" => "#{params[:vnet_config][:virtualNetworkName]}",
           "secgrpname" => "#{params[:azure_sec_group_name]}",
-          "vnetID"=> "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-          "subnetRef"=> "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-          "apiVersion"=> "2015-06-15",
-          "vmExtensionName"=> "#{params[:chef_extension]}",
+          "vnetID" => "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+          "subnetRef" => "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+          "apiVersion" => "2015-06-15",
+          "vmExtensionName" => "#{params[:chef_extension]}",
           "sshKeyPath" => "[concat('/home/',parameters('adminUserName'),'/.ssh/authorized_keys')]"
         },
-        "resources"=> [
+        "resources" => [
           {
-            "type"=> "Microsoft.Storage/storageAccounts",
-            "name"=> "[variables('storageAccountName')]",
-            "apiVersion"=> "[variables('apiVersion')]",
-            "location"=> "[resourceGroup().location]",
-            "properties"=> {
-              "accountType"=> "[variables('storageAccountType')]"
+            "type" => "Microsoft.Storage/storageAccounts",
+            "name" => "[variables('storageAccountName')]",
+            "apiVersion" => "[variables('apiVersion')]",
+            "location" => "[resourceGroup().location]",
+            "properties" => {
+              "accountType" => "[variables('storageAccountType')]"
             }
           },
           {
-            "apiVersion"=> "[variables('apiVersion')]",
+            "apiVersion" => "[variables('apiVersion')]",
             "type" => "Microsoft.Network/publicIPAddresses",
             "name" => publicIPAddressName,
-            "location"=> "[resourceGroup().location]",
-            "copy"=> {
+            "location" => "[resourceGroup().location]",
+            "copy" => {
               "name" => "publicIPLoop",
-              "count"=> "[parameters('numberOfInstances')]"
+              "count" => "[parameters('numberOfInstances')]"
             },
             "properties" => {
               "publicIPAllocationMethod" => "[variables('publicIPAddressType')]",
@@ -350,22 +347,22 @@ module Azure::ARM
             }
           },
           {
-            "apiVersion"=> "[variables('apiVersion')]",
-            "type"=> "Microsoft.Network/virtualNetworks",
-            "name"=> "[variables('virtualNetworkName')]",
-            "location"=> "[resourceGroup().location]",
-            "properties"=> {
-              "addressSpace"=> {
-                "addressPrefixes"=> params[:vnet_config][:addressPrefixes]
+            "apiVersion" => "[variables('apiVersion')]",
+            "type" => "Microsoft.Network/virtualNetworks",
+            "name" => "[variables('virtualNetworkName')]",
+            "location" => "[resourceGroup().location]",
+            "properties" => {
+              "addressSpace" => {
+                "addressPrefixes" => params[:vnet_config][:addressPrefixes]
               },
-              "subnets"=> params[:vnet_config][:subnets]
+              "subnets" => params[:vnet_config][:subnets]
             }
           },
           {
-            "apiVersion"=> "[variables('apiVersion')]",
-            "type"=> "Microsoft.Network/networkInterfaces",
-            "name"=> nicName,
-            "location"=> "[resourceGroup().location]",
+            "apiVersion" => "[variables('apiVersion')]",
+            "type" => "Microsoft.Network/networkInterfaces",
+            "name" => nicName,
+            "location" => "[resourceGroup().location]",
             "copy" => {
               "name" => "nicLoop",
               "count" => "[parameters('numberOfInstances')]"
@@ -374,17 +371,17 @@ module Azure::ARM
               depNic1,
               "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
             ],
-            "properties"=> {
-              "ipConfigurations"=> [
+            "properties" => {
+              "ipConfigurations" => [
                 {
-                  "name"=> "ipconfig1",
-                  "properties"=> {
-                    "privateIPAllocationMethod"=> "Dynamic",
-                    "publicIPAddress"=> {
-                      "id"=> pubId
+                  "name" => "ipconfig1",
+                  "properties" => {
+                    "privateIPAllocationMethod" => "Dynamic",
+                    "publicIPAddress" => {
+                      "id" => pubId
                     },
-                    "subnet"=> {
-                      "id"=> "[variables('subnetRef')]"
+                    "subnet" => {
+                      "id" => "[variables('subnetRef')]"
                     }
                   }
                 }
@@ -392,27 +389,28 @@ module Azure::ARM
             }
           },
           {
-            "apiVersion"=> "[variables('apiVersion')]",
-            "type"=> "Microsoft.Compute/virtualMachines",
-            "name"=> vmName,
-            "location"=> "[resourceGroup().location]",
+            "apiVersion" => "[variables('apiVersion')]",
+            "type" => "Microsoft.Compute/virtualMachines",
+            "name" => vmName,
+            "location" => "[resourceGroup().location]",
             "copy" => {
               "name" => "vmLoop",
               "count" => "[parameters('numberOfInstances')]"
             },
-            "dependsOn"=> [
+            "dependsOn" => [
               "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
               depVm2,
             ],
-            "properties"=> {
-              "hardwareProfile"=> {
-                "vmSize"=> "[variables('vmSize')]"
+            "properties" => {
+              "hardwareProfile" => {
+                "vmSize" => "[variables('vmSize')]"
               },
-              "osProfile"=> {
-                "computerName"=> computerName,
-                "adminUserName"=> "[parameters('adminUserName')]",
-                "adminPassword"=> "[parameters('adminPassword')]",
-                "linuxConfiguration" => ( {
+              "osProfile" => {
+                "computerName" => computerName,
+                "adminUserName" => "[parameters('adminUserName')]",
+                "adminPassword" => "[parameters('adminPassword')]",
+                "linuxConfiguration" => ( if params[:disablePasswordAuthentication] == "true"
+                                            {
                   "disablePasswordAuthentication" => "[parameters('disablePasswordAuthentication')]",
                   "ssh" => {
                     "publicKeys" => [ {
@@ -420,34 +418,35 @@ module Azure::ARM
                     "keyData" => "[parameters('sshKeyData')]"
                     } ]
                   }
-                } if params[:disablePasswordAuthentication] == "true")
+                }
+                                          end)
               },
-              "storageProfile"=> {
-                "imageReference"=> {
-                  "publisher"=> "[variables('imagePublisher')]",
-                  "offer"=> "[variables('imageOffer')]",
-                  "sku"=> "[parameters('imageSKU')]",
-                  "version"=> "[parameters('imageVersion')]"
+              "storageProfile" => {
+                "imageReference" => {
+                  "publisher" => "[variables('imagePublisher')]",
+                  "offer" => "[variables('imageOffer')]",
+                  "sku" => "[parameters('imageSKU')]",
+                  "version" => "[parameters('imageVersion')]"
                 },
-                "osDisk"=> {
-                  "name"=> "[variables('OSDiskName')]",
-                  "vhd"=> {
-                    "uri"=> uri                  },
-                  "caching"=> "ReadWrite",
-                  "createOption"=> "FromImage"
+                "osDisk" => {
+                  "name" => "[variables('OSDiskName')]",
+                  "vhd" => {
+                    "uri" => uri },
+                  "caching" => "ReadWrite",
+                  "createOption" => "FromImage"
                 }
               },
-              "networkProfile"=> {
-                "networkInterfaces"=> [
+              "networkProfile" => {
+                "networkInterfaces" => [
                   {
-                    "id"=> netid
+                    "id" => netid
                   }
                 ]
               },
-              "diagnosticsProfile"=> {
-                "bootDiagnostics"=> {
-                  "enabled"=> "true",
-                  "storageUri"=> "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+              "diagnosticsProfile" => {
+                "bootDiagnostics" => {
+                  "enabled" => "true",
+                  "storageUri" => "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
                 }
               }
             }
@@ -508,69 +507,69 @@ module Azure::ARM
             }
           }
 
-        length = template['resources'].length.to_i - 1
+        length = template["resources"].length.to_i - 1
         for i in 0..length do
-          if template['resources'][i]['type'] == "Microsoft.Compute/virtualMachines"
-            template['resources'][i]['dependsOn'] << "[concat('Microsoft.Compute/availabilitySets/', parameters('availabilitySetName'))]"
-            template['resources'][i]['properties'].merge!({"availabilitySet" => { "id" => "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"}})
+          if template["resources"][i]["type"] == "Microsoft.Compute/virtualMachines"
+            template["resources"][i]["dependsOn"] << "[concat('Microsoft.Compute/availabilitySets/', parameters('availabilitySetName'))]"
+            template["resources"][i]["properties"]["availabilitySet"] = { "id" => "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]" }
           end
         end
-        template['resources'].insert(length, set_val)
+        template["resources"].insert(length, set_val)
       end
 
       if params[:tcp_endpoints]
         sec_grp_json = tcp_ports(params[:tcp_endpoints], params[:azure_vm_name])
-        template['resources'].insert(1,sec_grp_json)
-        length = template['resources'].length.to_i - 1
+        template["resources"].insert(1, sec_grp_json)
+        length = template["resources"].length.to_i - 1
         for i in 0..length do
-          if template['resources'][i]['type'] == "Microsoft.Network/virtualNetworks"
-            template['resources'][i] = template['resources'][i].merge({"dependsOn" => [sec_grp]})
+          if template["resources"][i]["type"] == "Microsoft.Network/virtualNetworks"
+            template["resources"][i] = template["resources"][i].merge({ "dependsOn" => [sec_grp] })
           end
-          if template['resources'][i]['type'] == "Microsoft.Network/networkInterfaces"
-            template['resources'][i]['properties'] = template['resources'][i]['properties'].merge({"networkSecurityGroup" => {"id" => sec_grp_id}})
+          if template["resources"][i]["type"] == "Microsoft.Network/networkInterfaces"
+            template["resources"][i]["properties"] = template["resources"][i]["properties"].merge({ "networkSecurityGroup" => { "id" => sec_grp_id } })
           end
         end
       end
 
       if params[:chef_extension_public_param][:extendedLogs] == "true"
-        template['resources'].each do |resource|
-          if resource['type'] == 'Microsoft.Compute/virtualMachines/extensions'
-            resource['properties']['settings']['extendedLogs'] = params[:chef_extension_public_param][:extendedLogs]
+        template["resources"].each do |resource|
+          if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
+            resource["properties"]["settings"]["extendedLogs"] = params[:chef_extension_public_param][:extendedLogs]
           end
         end
       end
 
       if params[:chef_extension_public_param][:chef_daemon_interval]
-        template['resources'].each do |resource|
-          if resource['type'] == 'Microsoft.Compute/virtualMachines/extensions'
-            resource['properties']['settings']['chef_daemon_interval'] = params[:chef_extension_public_param][:chef_daemon_interval]
+        template["resources"].each do |resource|
+          if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
+            resource["properties"]["settings"]["chef_daemon_interval"] = params[:chef_extension_public_param][:chef_daemon_interval]
           end
         end
       end
 
       if params[:chef_extension_public_param][:daemon]
-        template['resources'].each do |resource|
-          if resource['type'] == 'Microsoft.Compute/virtualMachines/extensions'
-            resource['properties']['settings']['daemon'] = params[:chef_extension_public_param][:daemon]
+        template["resources"].each do |resource|
+          if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
+            resource["properties"]["settings"]["daemon"] = params[:chef_extension_public_param][:daemon]
           end
         end
       end
       if params[:server_count].to_i > 1 && params[:chef_extension_private_param][:validation_key].nil?
         template["resources"].last["properties"]["protectedSettings"]["client_pem"] = "[parameters(concat('client_pem',copyIndex()))]"
-        0.upto (params[:server_count].to_i-1) do |count|
+        0.upto (params[:server_count].to_i - 1) do |count|
           template["parameters"]["client_pem" + count.to_s] = {
-              "type"=> "string",
-              "metadata"=> {
-                "description"=> "Required for validtorless bootstrap."
+              "type" => "string",
+              "metadata" => {
+                "description" => "Required for validtorless bootstrap."
               }
             }
         end
       else
         template["resources"].last["properties"]["protectedSettings"]["client_pem"] = "[parameters('client_pem')]"
         template["parameters"]["client_pem"] = {
-            "type"=> "string",
-            "metadata"=> {
-              "description"=> "Required for validtorless bootstrap."
+            "type" => "string",
+            "metadata" => {
+              "description" => "Required for validtorless bootstrap."
             }
           }
       end
@@ -578,7 +577,7 @@ module Azure::ARM
     end
 
     def create_deployment_parameters(params, platform)
-      if platform == 'Windows'
+      if platform == "Windows"
         admin_user = params[:winrm_user]
         admin_password = params[:admin_password]
       else
@@ -590,8 +589,8 @@ module Azure::ARM
         "adminUserName" => {
           "value" => "#{admin_user}"
         },
-        "adminPassword"=> {
-          "value"=> "#{admin_password}"
+        "adminPassword" => {
+          "value" => "#{admin_password}"
         },
         "availabilitySetName" => {
             "value" => "#{params[:azure_availability_set]}"
@@ -602,30 +601,30 @@ module Azure::ARM
         "availabilitySetPlatformUpdateDomainCount" => {
             "value" => "5"
         },
-        "dnsLabelPrefix"=> {
-          "value"=> "#{params[:azure_vm_name]}"
+        "dnsLabelPrefix" => {
+          "value" => "#{params[:azure_vm_name]}"
         },
-        "imageSKU"=> {
-          "value"=> "#{params[:azure_image_reference_sku]}"
+        "imageSKU" => {
+          "value" => "#{params[:azure_image_reference_sku]}"
         },
         "numberOfInstances" => {
           "value" => "#{params[:server_count]}".to_i
         },
-        "validation_key"=> {
-          "value"=> "#{params[:chef_extension_private_param][:validation_key]}"
+        "validation_key" => {
+          "value" => "#{params[:chef_extension_private_param][:validation_key]}"
         },
-        
+
         "chef_server_crt" => {
           "value" => "#{params[:chef_extension_private_param][:chef_server_crt]}"
         },
         "encrypted_data_bag_secret" => {
           "value" => "#{params[:chef_extension_private_param][:encrypted_data_bag_secret]}"
         },
-        "chef_server_url"=> {
+        "chef_server_url" => {
           "value" => "#{params[:chef_extension_public_param][:bootstrap_options][:chef_server_url]}"
         },
-        "validation_client_name"=> {
-          "value"=> "#{params[:chef_extension_public_param][:bootstrap_options][:validation_client_name]}"
+        "validation_client_name" => {
+          "value" => "#{params[:chef_extension_public_param][:bootstrap_options][:validation_client_name]}"
         },
         "node_ssl_verify_mode" => {
           "value" => "#{params[:chef_extension_public_param][:bootstrap_options][:node_ssl_verify_mode]}"
@@ -643,7 +642,7 @@ module Azure::ARM
           "value" => "#{params[:chef_extension_public_param][:bootstrap_options][:environment]}"
         },
         "chef_node_name" => {
-          "value"=> "#{params[:chef_extension_public_param][:bootstrap_options][:chef_node_name]}"
+          "value" => "#{params[:chef_extension_public_param][:bootstrap_options][:chef_node_name]}"
         },
         "client_rb" => {
           "value" => "#{params[:chef_extension_public_param][:client_rb]}"
@@ -662,8 +661,8 @@ module Azure::ARM
         }
       }
       if params[:server_count].to_i > 1 && params[:chef_extension_private_param][:validation_key].nil?
-        0.upto (params[:server_count].to_i-1) do |count|
-          parameters["client_pem#{count.to_s}"] = {
+        0.upto (params[:server_count].to_i - 1) do |count|
+          parameters["client_pem#{count}"] = {
               "value" => "#{params[:chef_extension_private_param][("client_pem" + count.to_s).to_sym]}"
             }
         end

--- a/lib/azure/resource_management/ARM_deployment_template.rb
+++ b/lib/azure/resource_management/ARM_deployment_template.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (nimisha.sharad@clogeny.com)
-# Copyright:: Copyright (c) 2015-2016 Opscode, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/resource_management/ARM_interface.rb
+++ b/lib/azure/resource_management/ARM_interface.rb
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 
-require 'azure/azure_interface'
-require 'azure/resource_management/ARM_base'
-require 'azure/resource_management/ARM_deployment_template'
-require 'azure/resource_management/vnet_config'
-require 'azure_mgmt_resources'
-require 'azure_mgmt_compute'
-require 'azure_mgmt_storage'
-require 'azure_mgmt_network'
+require "azure/azure_interface"
+require "azure/resource_management/ARM_base"
+require "azure/resource_management/ARM_deployment_template"
+require "azure/resource_management/vnet_config"
+require "azure_mgmt_resources"
+require "azure_mgmt_compute"
+require "azure_mgmt_storage"
+require "azure_mgmt_network"
 
 module Azure
   class ResourceManagement
@@ -47,7 +47,7 @@ module Azure
         if params[:azure_client_secret]
           token_provider = MsRestAzure::ApplicationTokenProvider.new(params[:azure_tenant_id], params[:azure_client_id], params[:azure_client_secret])
         else
-          token_provider = MsRest::StringTokenProvider.new(params[:token],params[:tokentype])
+          token_provider = MsRest::StringTokenProvider.new(params[:token], params[:tokentype])
         end
         @credentials = MsRest::TokenCredentials.new(token_provider)
         @azure_subscription_id = params[:azure_subscription_id]
@@ -64,9 +64,9 @@ module Azure
 
       def compute_management_client
         @compute_management_client ||= begin
-           compute_management_client = ComputeManagementClient.new(@credentials)
-           compute_management_client.subscription_id = @azure_subscription_id
-           compute_management_client
+          compute_management_client = ComputeManagementClient.new(@credentials)
+          compute_management_client.subscription_id = @azure_subscription_id
+          compute_management_client
         end
       end
 
@@ -96,19 +96,19 @@ module Azure
           servers = compute_management_client.virtual_machines.list(resource_group_name)
         end
 
-        cols = ['VM Name', 'Resource Group Name', 'Location', 'Provisioning State', 'OS Type']
-        rows =  []
+        cols = ["VM Name", "Resource Group Name", "Location", "Provisioning State", "OS Type"]
+        rows = []
 
         servers.each do |server|
           rows << server.name.to_s
-          rows << server.id.split('/')[4].downcase
+          rows << server.id.split("/")[4].downcase
           rows << server.location.to_s
           rows << begin
                            state = server.provisioning_state.to_s.downcase
                            case state
-                           when 'failed'
+                           when "failed"
                              ui.color(state, :red)
-                           when 'succeeded'
+                           when "succeeded"
                              ui.color(state, :green)
                            else
                              ui.color(state, :yellow)
@@ -123,19 +123,19 @@ module Azure
         server = compute_management_client.virtual_machines.get(resource_group_name, vm_name)
         if server && server.name == vm_name
           puts "\n\n"
-          msg_pair(ui, 'VM Name', server.name)
-          msg_pair(ui, 'VM Size', server.hardware_profile.vm_size)
-          msg_pair(ui, 'VM OS', server.storage_profile.os_disk.os_type)
+          msg_pair(ui, "VM Name", server.name)
+          msg_pair(ui, "VM Size", server.hardware_profile.vm_size)
+          msg_pair(ui, "VM OS", server.storage_profile.os_disk.os_type)
           puts "\n"
 
           begin
-            ui.confirm('Do you really want to delete this server')
+            ui.confirm("Do you really want to delete this server")
           rescue SystemExit   # Need to handle this as confirming with N/n raises SystemExit exception
             server = nil      # Cleanup is implicitly performed in other cloud plugins
             exit!
           end
 
-          ui.info 'Deleting ..'
+          ui.info "Deleting .."
 
           begin
             server_detail = compute_management_client.virtual_machines.delete(resource_group_name, vm_name)
@@ -149,56 +149,56 @@ module Azure
       def show_server(name, resource_group)
         server = find_server(resource_group, name)
         if server
-          network_interface_name = server.network_profile.network_interfaces[0].id.split('/')[-1]
+          network_interface_name = server.network_profile.network_interfaces[0].id.split("/")[-1]
           network_interface_data = network_resource_client.network_interfaces.get(resource_group, network_interface_name)
           public_ip_id_data = network_interface_data.ip_configurations[0].public_ipaddress
           unless public_ip_id_data.nil?
-            public_ip_name = public_ip_id_data.id.split('/')[-1]
+            public_ip_name = public_ip_id_data.id.split("/")[-1]
             public_ip_data = network_resource_client.public_ipaddresses.get(resource_group, public_ip_name)
           else
             public_ip_data = nil
           end
 
           details = Array.new
-          details << ui.color('Server Name', :bold, :cyan)
+          details << ui.color("Server Name", :bold, :cyan)
           details << server.name
 
-          details << ui.color('Size', :bold, :cyan)
+          details << ui.color("Size", :bold, :cyan)
           details << server.hardware_profile.vm_size
 
-          details << ui.color('Provisioning State', :bold, :cyan)
+          details << ui.color("Provisioning State", :bold, :cyan)
           details << server.provisioning_state
 
-          details << ui.color('Location', :bold, :cyan)
+          details << ui.color("Location", :bold, :cyan)
           details << server.location
 
-          details << ui.color('Publisher', :bold, :cyan)
+          details << ui.color("Publisher", :bold, :cyan)
           details << server.storage_profile.image_reference.publisher
 
-          details << ui.color('Offer', :bold, :cyan)
+          details << ui.color("Offer", :bold, :cyan)
           details << server.storage_profile.image_reference.offer
 
-          details << ui.color('Sku', :bold, :cyan)
+          details << ui.color("Sku", :bold, :cyan)
           details << server.storage_profile.image_reference.sku
 
-          details << ui.color('Version', :bold, :cyan)
+          details << ui.color("Version", :bold, :cyan)
           details << server.storage_profile.image_reference.version
 
-          details << ui.color('OS Type', :bold, :cyan)
+          details << ui.color("OS Type", :bold, :cyan)
           details << server.storage_profile.os_disk.os_type
 
-          details << ui.color('Public IP address', :bold, :cyan)
+          details << ui.color("Public IP address", :bold, :cyan)
           unless public_ip_data.nil?
             details << public_ip_data.ip_address
           else
-            details << ' -- '
+            details << " -- "
           end
 
-          details << ui.color('FQDN', :bold, :cyan)
-          unless public_ip_data.nil? or public_ip_data.dns_settings.nil?
+          details << ui.color("FQDN", :bold, :cyan)
+          unless public_ip_data.nil? || public_ip_data.dns_settings.nil?
             details << public_ip_data.dns_settings.fqdn
           else
-            details << ' -- '
+            details << " -- "
           end
 
           puts ui.list(details, :columns_across, 2)
@@ -210,33 +210,29 @@ module Azure
       end
 
       def virtual_machine_exist?(resource_group_name, vm_name)
-        begin
-          compute_management_client.virtual_machines.get(resource_group_name, vm_name)
-          return true
-        rescue MsRestAzure::AzureOperationError => error
-          if error.body
-            err_json = JSON.parse(error.response.body)
-            if err_json['error']['code'] == "ResourceNotFound"
-              return false
-            else
-              raise error
-            end
+        compute_management_client.virtual_machines.get(resource_group_name, vm_name)
+        true
+      rescue MsRestAzure::AzureOperationError => error
+        if error.body
+          err_json = JSON.parse(error.response.body)
+          if err_json["error"]["code"] == "ResourceNotFound"
+            return false
+          else
+            raise error
           end
         end
       end
 
       def security_group_exist?(resource_group_name, security_group_name)
-        begin
-          network_resource_client.network_security_groups.get(resource_group_name, security_group_name)
-          return true
-        rescue MsRestAzure::AzureOperationError => error
-          if error.body
-            err_json = JSON.parse(error.response.body)
-            if err_json['error']['code'] == "ResourceNotFound"
-              return false
-            else
-              raise error
-            end
+        network_resource_client.network_security_groups.get(resource_group_name, security_group_name)
+        true
+      rescue MsRestAzure::AzureOperationError => error
+        if error.body
+          err_json = JSON.parse(error.response.body)
+          if err_json["error"]["code"] == "ResourceNotFound"
+            return false
+          else
+            raise error
           end
         end
       end
@@ -248,16 +244,16 @@ module Azure
       def platform(image_reference)
         @platform ||= begin
           if image_reference =~ /WindowsServer.*/
-            platform = 'Windows'
+            platform = "Windows"
           else
-            platform = 'Linux'
+            platform = "Linux"
           end
           platform
         end
       end
 
       def parse_substatus_code(code, index)
-        code.split('/')[index]
+        code.split("/")[index]
       end
 
       def fetch_substatus(resource_group_name, virtual_machine_name, chef_extension_name)
@@ -265,18 +261,18 @@ module Azure
           resource_group_name,
           virtual_machine_name,
           chef_extension_name,
-          'instanceView'
+          "instanceView"
         ).instance_view.substatuses
 
         return nil if substatuses.nil?
 
         substatuses.each do |substatus|
-          if parse_substatus_code(substatus.code, 1) == 'Chef Client run logs'
+          if parse_substatus_code(substatus.code, 1) == "Chef Client run logs"
             return substatus
           end
         end
 
-        return nil
+        nil
       end
 
       def fetch_chef_client_logs(resource_group_name, virtual_machine_name, chef_extension_name, fetch_process_start_time, fetch_process_wait_timeout = 30)
@@ -291,20 +287,20 @@ module Azure
           puts "\n\n******** Please find the chef-client run details below ********\n\n"
           print "----> chef-client run status: "
           case status
-            when 'succeeded'
+            when "succeeded"
               ## chef-client run succeeded ##
               color = :green
-            when 'failed'
+            when "failed"
               ## chef-client run failed ##
               color = :red
-            when 'transitioning'
+            when "transitioning"
               ## chef-client run did not complete within maximum timeout of 30 minutes ##
               ## fetch whatever logs available under the chef-client.log file ##
               color = :yellow
             end
-            puts "#{ui.color(status, color, :bold)}"
-            puts "----> chef-client run logs: "
-            puts "\n#{message}\n"  ## message field of substatus contains the chef-client run logs ##
+          puts "#{ui.color(status, color, :bold)}"
+          puts "----> chef-client run logs: "
+          puts "\n#{message}\n" ## message field of substatus contains the chef-client run logs ##
         else
           ## unavailability of the substatus field indicates that chef-client run is not completed yet on the server ##
           fetch_process_wait_time = ((Time.now - fetch_process_start_time) / 60).round
@@ -345,16 +341,16 @@ module Azure
             params[:azure_vnet_subnet_name]
           )
           if params[:tcp_endpoints]
-            if @platform == 'Windows'
+            if @platform == "Windows"
               params[:tcp_endpoints] = params[:tcp_endpoints] + ",3389"
             else
               params[:tcp_endpoints] = params[:tcp_endpoints] + ",22,16001"
             end
             random_no = rand(100..1000)
-            params[:azure_sec_group_name] = params[:azure_vm_name] + '_sec_grp_' + random_no.to_s
+            params[:azure_sec_group_name] = params[:azure_vm_name] + "_sec_grp_" + random_no.to_s
             if security_group_exist?(params[:azure_resource_group_name], params[:azure_sec_group_name])
               random_no = rand(100..1000)
-              params[:azure_sec_group_name] = params[:azure_vm_name] + '_sec_grp_' + random_no.to_s
+              params[:azure_sec_group_name] = params[:azure_vm_name] + "_sec_grp_" + random_no.to_s
             end
           end
 
@@ -409,7 +405,7 @@ module Azure
         begin
           resource_group = resource_management_client.resource_groups.create_or_update(resource_group.name, resource_group)
         rescue Exception => e
-          Chef::Log.error("Failed to create the Resource Group -- exception being rescued: #{e.to_s}")
+          Chef::Log.error("Failed to create the Resource Group -- exception being rescued: #{e}")
           common_arm_rescue_block(e)
         end
 
@@ -423,7 +419,7 @@ module Azure
         deploy_prop = DeploymentProperties.new
         deploy_prop.template = template
         deploy_prop.parameters = parameters
-        deploy_prop.mode = 'Incremental'
+        deploy_prop.mode = "Incremental"
 
         deploy_params = Deployment.new
         deploy_params.properties = deploy_prop
@@ -458,9 +454,11 @@ module Azure
       end
 
       def extension_already_installed?(server)
-        server.resources.each do |extension|
-          return true if (extension.virtual_machine_extension_type == "ChefClient" || extension.virtual_machine_extension_type == "LinuxChefClient")
-        end if server.resources
+        if server.resources
+          server.resources.each do |extension|
+            return true if extension.virtual_machine_extension_type == "ChefClient" || extension.virtual_machine_extension_type == "LinuxChefClient"
+          end
+        end
         false
       end
 
@@ -475,8 +473,8 @@ module Azure
       end
 
       def delete_resource_group(resource_group_name)
-        ui.info 'Resource group deletion takes some time. Please wait ...'
-        
+        ui.info "Resource group deletion takes some time. Please wait ..."
+
         begin
           server = resource_management_client.resource_groups.delete(resource_group_name)
         end until server.nil?

--- a/lib/azure/resource_management/ARM_interface.rb
+++ b/lib/azure/resource_management/ARM_interface.rb
@@ -1,3 +1,5 @@
+#
+# Copyright:: Copyright 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/resource_management/vnet_config.rb
+++ b/lib/azure/resource_management/vnet_config.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
 #
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/resource_management/vnet_config.rb
+++ b/lib/azure/resource_management/vnet_config.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require 'ipaddress'
+require "ipaddress"
 
 module Azure::ARM
   module VnetConfig
@@ -37,16 +37,14 @@ module Azure::ARM
     end
 
     def get_vnet(resource_group_name, vnet_name)
-      begin
-        network_resource_client.virtual_networks.get(resource_group_name, vnet_name)
-      rescue MsRestAzure::AzureOperationError => error
-        if error.body
-          err_json = JSON.parse(error.response.body)
-          if err_json['error']['code'] == "ResourceNotFound"
-            return false
-          else
-            raise error
-          end
+      network_resource_client.virtual_networks.get(resource_group_name, vnet_name)
+    rescue MsRestAzure::AzureOperationError => error
+      if error.body
+        err_json = JSON.parse(error.response.body)
+        if err_json["error"]["code"] == "ResourceNotFound"
+          return false
+        else
+          raise error
         end
       end
     end
@@ -60,9 +58,9 @@ module Azure::ARM
     ## single subnet body creation to be added in template ##
     def subnet(subnet_name, subnet_prefix)
       {
-        'name'=> subnet_name,
-        'properties'=> {
-          'addressPrefix'=> subnet_prefix
+        "name" => subnet_name,
+        "properties" => {
+          "addressPrefix" => subnet_prefix
         }
       }
     end
@@ -81,7 +79,7 @@ module Azure::ARM
     ## IP address to allocate the network for the new subnet to be added in the
     ## existing virtual network ##
     def sort_available_networks(available_networks)
-      available_networks.sort_by { |nwrk| nwrk.network.address.split('.').map(&:to_i) }
+      available_networks.sort_by { |nwrk| nwrk.network.address.split(".").map(&:to_i) }
     end
 
     ## sort existing subnets in ascending order based on their cidr prefix or
@@ -99,12 +97,12 @@ module Azure::ARM
 
     ## return the cidr prefix or netmask of the given subnet ##
     def subnet_cidr_prefix(subnet)
-      subnet_address_prefix(subnet).split('/')[1].to_i
+      subnet_address_prefix(subnet).split("/")[1].to_i
     end
 
     ## method to invoke respective sort methods for the network pools ##
     def sort_pools(available_networks_pool, used_networks_pool)
-      return sort_available_networks(available_networks_pool), sort_used_networks_by_hosts_size(used_networks_pool)
+      [sort_available_networks(available_networks_pool), sort_used_networks_by_hosts_size(used_networks_pool)]
     end
 
     ## when a address space in an existing virtual network is not used at all
@@ -116,28 +114,28 @@ module Azure::ARM
 
       case network_address.count
       when 4097..65536
-        prefix = '20'
+        prefix = "20"
       when 256..4096
-        prefix = '24'
+        prefix = "24"
       end
 
       ## if the given network is small then do not divide it else divide using
       ## the prefix value calculated above ##
-      prefix.nil? ? address_prefix : network_address.network.address.concat('/' + prefix)
+      prefix.nil? ? address_prefix : network_address.network.address.concat("/" + prefix)
     end
 
     ## check if the available_network is part of the subnet_network or vice-versa ##
     def in_use_network?(subnet_network, available_network)
       (subnet_network.include? available_network) ||
-      (available_network.include? subnet_network)
+        (available_network.include? subnet_network)
     end
 
     ## calculate and return address_prefix for the new subnet to be added in the
     ## existing virtual network ##
     def new_subnet_address_prefix(vnet_address_prefix, subnets)
-      if subnets.empty?  ## no subnets exist in the given address space of the virtual network, so divide the network into smaller subnets (based on the network size) and allocate space for the new subnet to be added ##
+      if subnets.empty? ## no subnets exist in the given address space of the virtual network, so divide the network into smaller subnets (based on the network size) and allocate space for the new subnet to be added ##
         divide_network(vnet_address_prefix)
-      else  ## subnets exist in vnet, calculate new address_prefix for the new subnet based on the space taken by these existing subnets under the given address space of the virtual network ##
+      else ## subnets exist in vnet, calculate new address_prefix for the new subnet based on the space taken by these existing subnets under the given address space of the virtual network ##
         vnet_network_address = IPAddress(vnet_address_prefix)
         subnets = sort_subnets_by_cidr_prefix(subnets)
         available_networks_pool = Array.new
@@ -153,7 +151,7 @@ module Azure::ARM
           ## cidr prefix value) into the available_networks_pool ##
           available_networks_pool.push(
             vnet_network_address.subnet(subnet_cidr_prefix(subnet))
-          ).flatten!.uniq! { |nwrk| [ nwrk.network.address, nwrk.prefix ].join(':') }
+          ).flatten!.uniq! { |nwrk| [ nwrk.network.address, nwrk.prefix ].join(":") }
 
           ## add current subnet into the used_networks_pool ##
           used_networks_pool.push(
@@ -167,9 +165,9 @@ module Azure::ARM
           ## trim the available_networks_pool based on the networks already
           ## allocated to the existing subnets ##
           used_networks_pool.each do |subnet_network|
-            available_networks_pool.delete_if {
-              |available_network| in_use_network?(subnet_network, available_network)
-            }
+            available_networks_pool.delete_if do |available_network|
+              in_use_network?(subnet_network, available_network)
+            end
           end
 
           ## sort both the network pools after trimming the available_networks_pool ##
@@ -180,7 +178,7 @@ module Azure::ARM
         ## space available in the vnet_address_prefix network for the new subnet ##
         if !available_networks_pool.empty? && available_networks_pool.first.network?
           available_networks_pool.first.network.address.concat("/" + available_networks_pool.first.prefix.to_s)
-        else  ## space not available in the vnet_address_prefix network for the new subnet ##
+        else ## space not available in the vnet_address_prefix network for the new subnet ##
           nil
         end
       end
@@ -200,24 +198,24 @@ module Azure::ARM
             vnet_address_space[vnet_address_prefix_count], subnets
           )
         )
-        vnet_address_prefix_count = vnet_address_prefix_count + 1
+        vnet_address_prefix_count += 1
       end
 
-      if new_subnet_prefix  ## found space for new subnet ##
+      if new_subnet_prefix ## found space for new subnet ##
         vnet_config[:subnets].push(
           subnet(subnet_name, new_subnet_prefix)
         )
-      else  ## no space available in the virtual network for the new subnet ##
+      else ## no space available in the virtual network for the new subnet ##
         raise "Unable to add subnet #{subnet_name} into the virtual network #{vnet_config[:virtualNetworkName]}, no address space available !!!"
       end
 
       vnet_config
     end
 
-    ## virtual network configuration creation for the new vnet creation or to 
+    ## virtual network configuration creation for the new vnet creation or to
     ## handle existing vnet ##
     def create_vnet_config(resource_group_name, vnet_name, vnet_subnet_name)
-      raise ArgumentError, 'GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.' if vnet_subnet_name == 'GatewaySubnet'
+      raise ArgumentError, "GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways." if vnet_subnet_name == "GatewaySubnet"
 
       vnet_config = {}
       subnets = nil
@@ -225,18 +223,20 @@ module Azure::ARM
       ## check whether user passed or default named virtual network exist or not ##
       vnet = get_vnet(resource_group_name, vnet_name)
       vnet_config[:virtualNetworkName] = vnet_name
-      if vnet  ## handle resources in the existing virtual network ##
+      if vnet ## handle resources in the existing virtual network ##
         vnet_config[:addressPrefixes] = vnet_address_spaces(vnet)
         vnet_config[:subnets] = Array.new
         subnets = subnets_list(resource_group_name, vnet_name)
-        subnets.each do |subnet|
-          flag = false if subnet.name == vnet_subnet_name  ## given subnet already exist in the virtual network ##
-          ## preserve the existing subnet resources ##
-          vnet_config[:subnets].push(
-            subnet(subnet.name, subnet_address_prefix(subnet))
-          )
-        end if subnets
-      else  ## create config for new vnet ##
+        if subnets
+          subnets.each do |subnet|
+            flag = false if subnet.name == vnet_subnet_name ## given subnet already exist in the virtual network ##
+            ## preserve the existing subnet resources ##
+            vnet_config[:subnets].push(
+              subnet(subnet.name, subnet_address_prefix(subnet))
+            )
+          end
+        end
+      else ## create config for new vnet ##
         vnet_config[:addressPrefixes] = [ "10.0.0.0/16" ]
         vnet_config[:subnets] = Array.new
         vnet_config[:subnets].push(

--- a/lib/azure/resource_management/windows_credentials.rb
+++ b/lib/azure/resource_management/windows_credentials.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (nimisha.sharad@clogeny.com)
-# Copyright:: Copyright (c) 2015-2016 Opscode, Inc.
+# Copyright:: Copyright 2015-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/resource_management/windows_credentials.rb
+++ b/lib/azure/resource_management/windows_credentials.rb
@@ -18,167 +18,164 @@
 
 # XPLAT stores the access token and other information in windows credential manager.
 # Using FFI to call CredRead function
-require 'chef'
-require 'mixlib/shellout'
-require 'ffi'
+require "chef"
+require "mixlib/shellout"
+require "ffi"
 require "chef/win32/api"
 
 module Azure::ARM
 
-    module ReadCred
+  module ReadCred
 
-      extend Chef::ReservedNames::Win32::API
-      extend FFI::Library
+    extend Chef::ReservedNames::Win32::API
+    extend FFI::Library
 
-      ffi_lib 'Advapi32'
+    ffi_lib "Advapi32"
 
-      CRED_TYPE_GENERIC = 1
-      CRED_TYPE_DOMAIN_PASSWORD = 2
-      CRED_TYPE_DOMAIN_CERTIFICATE = 3
-      CRED_TYPE_DOMAIN_VISIBLE_PASSWORD = 4
+    CRED_TYPE_GENERIC = 1
+    CRED_TYPE_DOMAIN_PASSWORD = 2
+    CRED_TYPE_DOMAIN_CERTIFICATE = 3
+    CRED_TYPE_DOMAIN_VISIBLE_PASSWORD = 4
 
-      # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
-      class FILETIME < FFI::Struct
-        layout :dwLowDateTime, :DWORD,
-               :dwHighDateTime, :DWORD
-      end
-
-      # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374790(v=vs.85).aspx
-      class CREDENTIAL_ATTRIBUTE < FFI::Struct
-        layout :Keyword, :LPTSTR,
-               :Flags, :DWORD,
-               :ValueSize, :DWORD,
-               :Value, :LPBYTE
-      end
-
-      # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374788(v=vs.85).aspx
-      class CREDENTIAL_OBJECT < FFI::Struct
-          layout :Flags, :DWORD,
-                 :Type, :DWORD,
-                 :TargetName, :LPTSTR,
-                 :Comment, :LPTSTR,
-                 :LastWritten, FILETIME,
-                 :CredentialBlobSize, :DWORD,
-                 :CredentialBlob, :LPBYTE,
-                 :Persist, :DWORD,
-                 :AttributeCount, :DWORD,
-                 :Attributes, CREDENTIAL_ATTRIBUTE,
-                 :TargetAlias, :LPTSTR,
-                 :UserName, :LPTSTR
-        end
-
-      # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374804(v=vs.85).aspx
-      safe_attach_function :CredReadW, [:LPCTSTR, :DWORD, :DWORD, :pointer], :BOOL
+    # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
+    class FILETIME < FFI::Struct
+      layout :dwLowDateTime, :DWORD,
+             :dwHighDateTime, :DWORD
     end
 
+    # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374790(v=vs.85).aspx
+    class CREDENTIAL_ATTRIBUTE < FFI::Struct
+      layout :Keyword, :LPTSTR,
+             :Flags, :DWORD,
+             :ValueSize, :DWORD,
+             :Value, :LPBYTE
+    end
 
-    module WindowsCredentials
-
-      include Chef::Mixin::WideString
-      include ReadCred
-
-      def token_details_from_WCM
-        begin
-          target = target_name
-
-          if target && !target.empty?
-            target_pointer = wstring(target)
-            info_ptr = FFI::MemoryPointer.new(:pointer)
-            cred = CREDENTIAL_OBJECT.new info_ptr
-            cred_result = CredReadW(target_pointer, CRED_TYPE_GENERIC, 0, cred)
-            translated_cred = CREDENTIAL_OBJECT.new(info_ptr.read_pointer)
-
-            target_obj = translated_cred[:TargetName].read_wstring.split("::") if translated_cred[:TargetName].read_wstring
-            cred_blob = translated_cred[:CredentialBlob].get_bytes(0, translated_cred[:CredentialBlobSize]).split("::")
-
-            tokentype = target_obj.select { |obj| obj.include? "tokenType" }
-            user = target_obj.select { |obj| obj.include? "userId" }
-            clientid = target_obj.select { |obj| obj.include? "clientId" }
-            expiry_time = target_obj.select { |obj| obj.include? "expiresOn" }
-            access_token = cred_blob.select { |obj| obj.include? "a:" }
-            refresh_token = cred_blob.select { |obj| obj.include? "r:" }
-
-            credential = {}
-            credential[:tokentype] = tokentype[0].split(":")[1]
-            credential[:user] = user[0].split(":")[1]
-            credential[:token] = access_token[0].split(":")[1]
-            #Todo: refresh_token is not complete currently
-            # target_name method needs to be modified for that
-            credential[:refresh_token] = refresh_token[0].split(":")[1]
-            credential[:clientid] = clientid[0].split(":")[1]
-            credential[:expiry_time] = expiry_time[0].split("expiresOn:")[1].gsub("\\","")
-
-            # Free memory pointed by info_ptr
-            info_ptr.free
-          else
-            raise "TargetName Not Found"
-          end
-          credential
-        rescue => error
-          ui.error("#{error.message}")
-          Chef::Log.debug("#{error.backtrace.join("\n")}")
-          exit
-        end
+    # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374788(v=vs.85).aspx
+    class CREDENTIAL_OBJECT < FFI::Struct
+      layout :Flags, :DWORD,
+             :Type, :DWORD,
+             :TargetName, :LPTSTR,
+             :Comment, :LPTSTR,
+             :LastWritten, FILETIME,
+             :CredentialBlobSize, :DWORD,
+             :CredentialBlob, :LPBYTE,
+             :Persist, :DWORD,
+             :AttributeCount, :DWORD,
+             :Attributes, CREDENTIAL_ATTRIBUTE,
+             :TargetAlias, :LPTSTR,
+             :UserName, :LPTSTR
       end
 
-      #Todo: For getting the complete refreshToken, both credentials (ending with --0-2 and --1-2) have to be read
-      def target_name
-        # cmdkey command is used for accessing windows credential manager.
-        # Multiple credentials get created in windows credential manager for a single Azure account in xplat-cli
-        # One of them is for common tanent id, which can't be used
-        # Others end with --0-x,--1-x,--2-x etc, where x represents the total no. of credentails across which the token is divided
-        # The one ending with --0-x has the complete accessToken in the credentialBlob.
-        # Refresh Token is split across both credentials (ending with --0-x and --1-x).
-        # Xplat splits the credentials based on the number of bytes of the tokens.
-        # Hence the access token is always found in the one which start with --0-
-        # So selecting the credential on the basis of --0-
-        xplat_creds_cmd = Mixlib::ShellOut.new('cmdkey /list | findstr AzureXplatCli | findstr \--0- | findstr -v common')
+    # Ref: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374804(v=vs.85).aspx
+    safe_attach_function :CredReadW, [:LPCTSTR, :DWORD, :DWORD, :pointer], :BOOL
+  end
+
+  module WindowsCredentials
+
+    include Chef::Mixin::WideString
+    include ReadCred
+
+    def token_details_from_WCM
+      target = target_name
+
+      if target && !target.empty?
+        target_pointer = wstring(target)
+        info_ptr = FFI::MemoryPointer.new(:pointer)
+        cred = CREDENTIAL_OBJECT.new info_ptr
+        cred_result = CredReadW(target_pointer, CRED_TYPE_GENERIC, 0, cred)
+        translated_cred = CREDENTIAL_OBJECT.new(info_ptr.read_pointer)
+
+        target_obj = translated_cred[:TargetName].read_wstring.split("::") if translated_cred[:TargetName].read_wstring
+        cred_blob = translated_cred[:CredentialBlob].get_bytes(0, translated_cred[:CredentialBlobSize]).split("::")
+
+        tokentype = target_obj.select { |obj| obj.include? "tokenType" }
+        user = target_obj.select { |obj| obj.include? "userId" }
+        clientid = target_obj.select { |obj| obj.include? "clientId" }
+        expiry_time = target_obj.select { |obj| obj.include? "expiresOn" }
+        access_token = cred_blob.select { |obj| obj.include? "a:" }
+        refresh_token = cred_blob.select { |obj| obj.include? "r:" }
+
+        credential = {}
+        credential[:tokentype] = tokentype[0].split(":")[1]
+        credential[:user] = user[0].split(":")[1]
+        credential[:token] = access_token[0].split(":")[1]
+        #Todo: refresh_token is not complete currently
+        # target_name method needs to be modified for that
+        credential[:refresh_token] = refresh_token[0].split(":")[1]
+        credential[:clientid] = clientid[0].split(":")[1]
+        credential[:expiry_time] = expiry_time[0].split("expiresOn:")[1].delete("\\")
+
+        # Free memory pointed by info_ptr
+        info_ptr.free
+      else
+        raise "TargetName Not Found"
+      end
+      credential
+    rescue => error
+      ui.error("#{error.message}")
+      Chef::Log.debug("#{error.backtrace.join("\n")}")
+      exit
+    end
+
+    #Todo: For getting the complete refreshToken, both credentials (ending with --0-2 and --1-2) have to be read
+    def target_name
+      # cmdkey command is used for accessing windows credential manager.
+      # Multiple credentials get created in windows credential manager for a single Azure account in xplat-cli
+      # One of them is for common tanent id, which can't be used
+      # Others end with --0-x,--1-x,--2-x etc, where x represents the total no. of credentails across which the token is divided
+      # The one ending with --0-x has the complete accessToken in the credentialBlob.
+      # Refresh Token is split across both credentials (ending with --0-x and --1-x).
+      # Xplat splits the credentials based on the number of bytes of the tokens.
+      # Hence the access token is always found in the one which start with --0-
+      # So selecting the credential on the basis of --0-
+      xplat_creds_cmd = Mixlib::ShellOut.new('cmdkey /list | findstr AzureXplatCli | findstr \--0- | findstr -v common')
+      result = xplat_creds_cmd.run_command
+      target_names = []
+
+      if result.stdout.empty?
+        Chef::Log.debug("Unable to find a credential with --0- and falling back to looking for any credential.")
+        xplat_creds_cmd = Mixlib::ShellOut.new("cmdkey /list | findstr AzureXplatCli | findstr -v common")
         result = xplat_creds_cmd.run_command
-        target_names = []
 
         if result.stdout.empty?
-          Chef::Log.debug("Unable to find a credential with --0- and falling back to looking for any credential.")
-          xplat_creds_cmd = Mixlib::ShellOut.new('cmdkey /list | findstr AzureXplatCli | findstr -v common')
-          result = xplat_creds_cmd.run_command
-
-          if result.stdout.empty?
-            raise "Azure Credentials not found. Please run xplat's 'azure login' command"
-          else
-            target_names = result.stdout.split("\n")
-          end
+          raise "Azure Credentials not found. Please run xplat's 'azure login' command"
         else
           target_names = result.stdout.split("\n")
         end
-
-        # If "azure login" is run for multiple users, there will be multiple credentials
-        # Picking up the latest logged in user's credentials
-        latest_target = latest_credential_target target_names
-        latest_target
+      else
+        target_names = result.stdout.split("\n")
       end
 
-      def latest_credential_target targets
-        case targets.size
-        when 0
-          raise "No Target was found for windows credentials"
-        when 1
-          return targets.first.gsub("Target:","").strip
-        else
-          latest_target = ""
-          max_expiry_time = Time.new(0)
+      # If "azure login" is run for multiple users, there will be multiple credentials
+      # Picking up the latest logged in user's credentials
+      latest_target = latest_credential_target target_names
+      latest_target
+    end
 
-          # Using expiry_time to determine the latest credential
-          targets.each do |target|
-            target_obj = target.split("::")
-            expiry_time_obj = target_obj.select { |obj| obj.include? "expiresOn" }
-            expiry_time = expiry_time_obj[0].split("expiresOn:")[1].gsub("\\","")
-            if Time.parse(expiry_time) > max_expiry_time
-              latest_target = target
-              max_expiry_time = Time.parse(expiry_time)
-            end
+    def latest_credential_target(targets)
+      case targets.size
+      when 0
+        raise "No Target was found for windows credentials"
+      when 1
+        targets.first.gsub("Target:", "").strip
+      else
+        latest_target = ""
+        max_expiry_time = Time.new(0)
+
+        # Using expiry_time to determine the latest credential
+        targets.each do |target|
+          target_obj = target.split("::")
+          expiry_time_obj = target_obj.select { |obj| obj.include? "expiresOn" }
+          expiry_time = expiry_time_obj[0].split("expiresOn:")[1].delete("\\")
+          if Time.parse(expiry_time) > max_expiry_time
+            latest_target = target
+            max_expiry_time = Time.parse(expiry_time)
           end
-
-          return latest_target.gsub("Target:","").strip
         end
+
+        latest_target.gsub("Target:", "").strip
       end
     end
+  end
 end

--- a/lib/azure/service_management/ASM_interface.rb
+++ b/lib/azure/service_management/ASM_interface.rb
@@ -1,6 +1,5 @@
 #
-# Author::
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/ASM_interface.rb
+++ b/lib/azure/service_management/ASM_interface.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require 'azure/azure_interface'
-require 'azure/service_management/rest'
-require 'azure/service_management/connection'
+require "azure/azure_interface"
+require "azure/service_management/rest"
+require "azure/service_management/connection"
 
 module Azure
   class ServiceManagement
@@ -39,20 +39,20 @@ module Azure
 
       def list_servers
         servers = connection.roles.all
-        cols = ['DNS Name', 'VM Name', 'Status', 'IP Address', 'SSH Port', 'WinRM Port', 'RDP Port']
+        cols = ["DNS Name", "VM Name", "Status", "IP Address", "SSH Port", "WinRM Port", "RDP Port"]
         rows = []
         servers.each do |server|
-          rows << server.hostedservicename.to_s+".cloudapp.net"  # Info about the DNS name at http://msdn.microsoft.com/en-us/library/ee460806.aspx
+          rows << server.hostedservicename.to_s + ".cloudapp.net" # Info about the DNS name at http://msdn.microsoft.com/en-us/library/ee460806.aspx
           rows << server.name.to_s
           rows << begin
                            state = server.status.to_s.downcase
                            case state
-                           when 'shutting-down','terminated','stopping','stopped'
+                           when "shutting-down", "terminated", "stopping", "stopped"
                              ui.color(state, :red)
-                           when 'pending'
+                           when "pending"
                              ui.color(state, :yellow)
                            else
-                             ui.color('ready', :green)
+                             ui.color("ready", :green)
                            end
                          end
           rows << server.publicipaddress.to_s
@@ -66,16 +66,16 @@ module Azure
 
       def rdp_port(arr_ports)
         if !arr_ports
-          return ''
+          return ""
         end
         if arr_ports.length > 0
           arr_ports.each do |port|
-            if port['Name'] == "Remote Desktop"
-              return port['PublicPort']
+            if port["Name"] == "Remote Desktop"
+              return port["PublicPort"]
             end
           end
         end
-        return ''
+        ""
       end
 
       def find_server(params = {})
@@ -83,7 +83,7 @@ module Azure
       end
 
       def delete_server(params = {})
-        server = find_server({name: params[:name], azure_dns_name: params[:azure_dns_name]})
+        server = find_server({ name: params[:name], azure_dns_name: params[:azure_dns_name] })
 
         unless server
           puts "\n"
@@ -92,14 +92,14 @@ module Azure
         end
 
         puts "\n"
-        msg_pair(ui, 'DNS Name', server.hostedservicename + ".cloudapp.net")
-        msg_pair(ui, 'VM Name', server.name)
-        msg_pair(ui, 'Size', server.size)
-        msg_pair(ui, 'Public Ip Address', server.publicipaddress)
+        msg_pair(ui, "DNS Name", server.hostedservicename + ".cloudapp.net")
+        msg_pair(ui, "VM Name", server.name)
+        msg_pair(ui, "Size", server.size)
+        msg_pair(ui, "Public Ip Address", server.publicipaddress)
         puts "\n"
 
         begin
-          ui.confirm('Do you really want to delete this server')
+          ui.confirm("Do you really want to delete this server")
         rescue SystemExit   # Need to handle this as confirming with N/n raises SystemExit exception
           server = nil      # Cleanup is implicitly performed in other cloud plugins
           exit!
@@ -114,72 +114,69 @@ module Azure
       end
 
       def show_server(name)
-        begin
-          role = connection.roles.find name
+        role = connection.roles.find name
 
-          puts ''
-          if (role)
-            details = Array.new
-            details << ui.color('Role name', :bold, :cyan)
-            details << role.name
-            details << ui.color('Status', :bold, :cyan)
-            details << role.status
-            details << ui.color('Size', :bold, :cyan)
-            details << role.size
-            details << ui.color('Hosted service name', :bold, :cyan)
-            details << role.hostedservicename
-            details << ui.color('Deployment name', :bold, :cyan)
-            details << role.deployname
-            details << ui.color('Host name', :bold, :cyan)
-            details << role.hostname
-            unless role.sshport.nil?
-              details << ui.color('SSH port', :bold, :cyan)
-              details << role.sshport
-            end
-            unless role.winrmport.nil?
-              details << ui.color('WinRM port', :bold, :cyan)
-              details << role.winrmport
-            end
-            details << ui.color('Public IP', :bold, :cyan)
-            details << role.publicipaddress.to_s
-
-            unless role.thumbprint.empty?
-              details << ui.color('Thumbprint', :bold, :cyan)
-              details << role.thumbprint
-            end
-            puts ui.list(details, :columns_across, 2)
-            if role.tcpports.length > 0 || role.udpports.length > 0
-              details.clear
-              details << ui.color('Ports open', :bold, :cyan)
-              details << ui.color('Local port', :bold, :cyan)
-              details << ui.color('IP', :bold, :cyan)
-              details << ui.color('Public port', :bold, :cyan)
-              if role.tcpports.length > 0
-                role.tcpports.each do |port|
-                  details << 'tcp'
-                  details << port['LocalPort']
-                  details << port['Vip']
-                  details << port['PublicPort']
-                end
-              end
-              if role.udpports.length > 0
-                role.udpports.each do |port|
-                  details << 'udp'
-                  details << port['LocalPort']
-                  details << port['Vip']
-                  details << port['PublicPort']
-                end
-              end
-              puts ui.list(details, :columns_across, 4)
-            end
-          else
-            puts "No VM found"
+        puts ""
+        if role
+          details = Array.new
+          details << ui.color("Role name", :bold, :cyan)
+          details << role.name
+          details << ui.color("Status", :bold, :cyan)
+          details << role.status
+          details << ui.color("Size", :bold, :cyan)
+          details << role.size
+          details << ui.color("Hosted service name", :bold, :cyan)
+          details << role.hostedservicename
+          details << ui.color("Deployment name", :bold, :cyan)
+          details << role.deployname
+          details << ui.color("Host name", :bold, :cyan)
+          details << role.hostname
+          unless role.sshport.nil?
+            details << ui.color("SSH port", :bold, :cyan)
+            details << role.sshport
           end
+          unless role.winrmport.nil?
+            details << ui.color("WinRM port", :bold, :cyan)
+            details << role.winrmport
+          end
+          details << ui.color("Public IP", :bold, :cyan)
+          details << role.publicipaddress.to_s
 
-        rescue => error
-          puts "#{error.class} and #{error.message}"
+          unless role.thumbprint.empty?
+            details << ui.color("Thumbprint", :bold, :cyan)
+            details << role.thumbprint
+          end
+          puts ui.list(details, :columns_across, 2)
+          if role.tcpports.length > 0 || role.udpports.length > 0
+            details.clear
+            details << ui.color("Ports open", :bold, :cyan)
+            details << ui.color("Local port", :bold, :cyan)
+            details << ui.color("IP", :bold, :cyan)
+            details << ui.color("Public port", :bold, :cyan)
+            if role.tcpports.length > 0
+              role.tcpports.each do |port|
+                details << "tcp"
+                details << port["LocalPort"]
+                details << port["Vip"]
+                details << port["PublicPort"]
+              end
+            end
+            if role.udpports.length > 0
+              role.udpports.each do |port|
+                details << "udp"
+                details << port["LocalPort"]
+                details << port["Vip"]
+                details << port["PublicPort"]
+              end
+            end
+            puts ui.list(details, :columns_across, 4)
+          end
+        else
+          puts "No VM found"
         end
 
+      rescue => error
+        puts "#{error.class} and #{error.message}"
       end
 
       def list_internal_lb
@@ -198,10 +195,10 @@ module Azure
 
       def list_vnets
         vnets = connection.vnets.all
-        cols = ['Name', 'Affinity Group', 'State']
+        cols = ["Name", "Affinity Group", "State"]
         rows = []
         vnets.each do |vnet|
-          %w(name affinity_group state).each{ |col| rows << vnet.send(col).to_s }
+          %w{name affinity_group state}.each { |col| rows << vnet.send(col).to_s }
         end
         display_list(ui, cols, rows)
       end
@@ -252,12 +249,11 @@ module Azure
         begin
           connection.deploys.create(params)
         rescue Exception => e
-          Chef::Log.error("Failed to create the server -- exception being rescued: #{e.to_s}")
+          Chef::Log.error("Failed to create the server -- exception being rescued: #{e}")
           backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
           Chef::Log.debug("#{backtrace_message}")
           cleanup_and_exit(remove_hosted_service_on_failure, remove_storage_service_on_failure)
         end
-
       end
 
       def cleanup_and_exit(remove_hosted_service_on_failure, remove_storage_service_on_failure)
@@ -275,10 +271,10 @@ module Azure
         exit 1
       end
 
-       def get_role_server(dns_name, vm_name)
+      def get_role_server(dns_name, vm_name)
         deploy = connection.deploys.queryDeploy(dns_name)
         deploy.find_role(vm_name)
-      end
+     end
 
       def get_extension(name, publisher)
         connection.query_azure("resourceextensions/#{publisher}/#{name}")
@@ -301,17 +297,14 @@ module Azure
       end
 
       def add_extension(name, params = {})
-        begin
-          ui.info "Started with Chef Extension deployment on the server #{name}..."
-          connection.roles.update(name, params)
-          ui.info "\nSuccessfully deployed Chef Extension on the server #{name}."
-        rescue Exception => e
-          Chef::Log.error("Failed to add extension to the server -- exception being rescued: #{e.to_s}")
-          backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
-          Chef::Log.debug("#{backtrace_message}")
-        end
+        ui.info "Started with Chef Extension deployment on the server #{name}..."
+        connection.roles.update(name, params)
+        ui.info "\nSuccessfully deployed Chef Extension on the server #{name}."
+      rescue Exception => e
+        Chef::Log.error("Failed to add extension to the server -- exception being rescued: #{e}")
+        backtrace_message = "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
+        Chef::Log.debug("#{backtrace_message}")
       end
     end
   end
 end
-

--- a/lib/azure/service_management/ag.rb
+++ b/lib/azure/service_management/ag.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/ag.rb
+++ b/lib/azure/service_management/ag.rb
@@ -25,13 +25,13 @@ module Azure
     def load
       @ags ||= begin
         @ags = {}
-        response = @connection.query_azure('affinitygroups',
-                                           'get',
-                                           '',
-                                           '',
+        response = @connection.query_azure("affinitygroups",
+                                           "get",
+                                           "",
+                                           "",
                                            true,
                                            false)
-        response.css('AffinityGroup').each do |ag|
+        response.css("AffinityGroup").each do |ag|
           item = AG.new(@connection).parse(ag)
           @ags[item.name] = item
         end
@@ -67,18 +67,18 @@ module Azure
     end
 
     def parse(image)
-      @name = image.at_css('Name').content
-      @label = image.at_css('Label').content
-      @description = image.at_css('Description').content if
-        image.at_css('Description')
-      @location = image.at_css('Location').content if image.at_css('Location')
+      @name = image.at_css("Name").content
+      @label = image.at_css("Label").content
+      @description = image.at_css("Description").content if
+        image.at_css("Description")
+      @location = image.at_css("Location").content if image.at_css("Location")
       self
     end
 
     def create(params)
-      builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
+      builder = Nokogiri::XML::Builder.new(encoding: "utf-8") do |xml|
         xml.CreateAffinityGroup(
-          xmlns: 'http://schemas.microsoft.com/windowsazure'
+          xmlns: "http://schemas.microsoft.com/windowsazure"
         ) do
           xml.Name params[:azure_ag_name]
           xml.Label Base64.strict_encode64(params[:azure_ag_name])
@@ -88,10 +88,10 @@ module Azure
           xml.Location params[:azure_location]
         end
       end
-      @connection.query_azure('affinitygroups',
-                              'post',
+      @connection.query_azure("affinitygroups",
+                              "post",
                               builder.to_xml,
-                              '',
+                              "",
                               true,
                               false)
     end

--- a/lib/azure/service_management/certificate.rb
+++ b/lib/azure/service_management/certificate.rb
@@ -19,7 +19,7 @@
 module Azure
   class Certificates
     def initialize(connection)
-      @connection=connection
+      @connection = connection
     end
 
     def create(params)
@@ -33,7 +33,7 @@ module Azure
     end
 
     def create_ssl_certificate(azure_dns_name)
-      cert_params = { output_file: 'winrm', key_length: 2048, cert_validity: 24,
+      cert_params = { output_file: "winrm", key_length: 2048, cert_validity: 24,
                       azure_dns_name: azure_dns_name }
       certificate = Certificate.new(@connection)
       thumbprint = certificate.create_ssl_certificate(cert_params)
@@ -58,15 +58,15 @@ module Azure
     def create(params)
       # If RSA private key has been specified, then generate an x 509 certificate from the
       # public part of the key
-      @cert_data = generate_public_key_certificate_data({:ssh_key => params[:identity_file],
-                                             :ssh_key_passphrase => params[:identity_file_passphrase]})
-      add_certificate @cert_data, 'knifeazure', 'pfx', params[:azure_dns_name]
+      @cert_data = generate_public_key_certificate_data({ :ssh_key => params[:identity_file],
+                                                          :ssh_key_passphrase => params[:identity_file_passphrase] })
+      add_certificate @cert_data, "knifeazure", "pfx", params[:azure_dns_name]
 
       # Return the fingerprint to be used while adding role
       @fingerprint
     end
 
-    def generate_public_key_certificate_data (params)
+    def generate_public_key_certificate_data(params)
       # Generate OpenSSL RSA key from the mentioned ssh key path (and passphrase)
       key = OpenSSL::PKey::RSA.new(File.read(params[:ssh_key]), params[:ssh_key_passphrase])
       # Generate X 509 certificate
@@ -81,28 +81,28 @@ module Azure
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = ca
       ef.issuer_certificate = ca
-      ca.add_extension(ef.create_extension("basicConstraints","CA:TRUE",true))
-      ca.add_extension(ef.create_extension("keyUsage","keyCertSign, cRLSign", true))
-      ca.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
-      ca.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
+      ca.add_extension(ef.create_extension("basicConstraints", "CA:TRUE", true))
+      ca.add_extension(ef.create_extension("keyUsage", "keyCertSign, cRLSign", true))
+      ca.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
+      ca.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
       ca.sign(key, OpenSSL::Digest::SHA256.new)
       # Generate the SHA1 fingerprint of the der format of the X 509 certificate
-      @fingerprint =  OpenSSL::Digest::SHA1.new(ca.to_der)
+      @fingerprint = OpenSSL::Digest::SHA1.new(ca.to_der)
       # Create the pfx format of the certificate
-      pfx = OpenSSL::PKCS12.create('knifeazure', 'knife-azure-pfx',  key,  ca)
+      pfx = OpenSSL::PKCS12.create("knifeazure", "knife-azure-pfx", key, ca)
       # Encode the pfx format - upload this certificate
       Base64.strict_encode64(pfx.to_der)
     end
 
-    def add_certificate certificate_data, certificate_password, certificate_format, dns_name
+    def add_certificate(certificate_data, certificate_password, certificate_format, dns_name)
       # Generate XML to call the API
       # Add certificate to the hosted service
       builder = Nokogiri::XML::Builder.new do |xml|
-       xml.CertificateFile('xmlns'=>'http://schemas.microsoft.com/windowsazure') {
-       xml.Data certificate_data
-       xml.CertificateFormat certificate_format
-       xml.Password certificate_password
-       }
+        xml.CertificateFile("xmlns" => "http://schemas.microsoft.com/windowsazure") do
+          xml.Data certificate_data
+          xml.CertificateFormat certificate_format
+          xml.Password certificate_password
+        end
       end
       # Windows Azure API call
       @connection.query_azure("hostedservices/#{dns_name}/certificates", "post", builder.to_xml)
@@ -125,8 +125,8 @@ module Azure
     end
 
     ########   SSL certificate generation for knife-azure ssl bootstrap ######
-    def create_ssl_certificate cert_params
-      file_path = cert_params[:output_file].sub(/\.(\w+)$/,'')
+    def create_ssl_certificate(cert_params)
+      file_path = cert_params[:output_file].sub(/\.(\w+)$/, "")
       path = prompt_for_file_path
       file_path = File.join(path, file_path) unless path.empty?
       cert_params[:domain] = prompt_for_domain
@@ -134,21 +134,21 @@ module Azure
       rsa_key = generate_keypair cert_params[:key_length]
       cert = generate_certificate(rsa_key, cert_params)
       write_certificate_to_file cert, file_path, rsa_key, cert_params
-      puts "*"*70
+      puts "*" * 70
       puts "Generated Certificates:"
       puts "- #{file_path}.pfx - PKCS12 format keypair. Contains both the public and private keys, usually used on the server."
       puts "- #{file_path}.b64 - Base64 encoded PKCS12 keypair. Contains both the public and private keys, for upload to the Azure REST API."
       puts "- #{file_path}.pem - Base64 encoded public certificate only. Required by the client to connect to the server."
       puts "Certificate Thumbprint: #{@thumbprint.to_s.upcase}"
-      puts "*"*70
+      puts "*" * 70
 
       Chef::Config[:knife][:ca_trust_file] = file_path + ".pem" if Chef::Config[:knife][:ca_trust_file].nil?
       cert_data = File.read (file_path + ".b64")
-      add_certificate cert_data, @winrm_cert_passphrase, 'pfx', cert_params[:azure_dns_name]
+      add_certificate cert_data, @winrm_cert_passphrase, "pfx", cert_params[:azure_dns_name]
       @thumbprint
     end
 
-    def generate_keypair key_length
+    def generate_keypair(key_length)
       OpenSSL::PKey::RSA.new(key_length.to_i)
     end
 
@@ -166,7 +166,7 @@ module Azure
     end
 
     def prompt_for_file_path
-      file_path = ''
+      file_path = ""
       counter = 0
       begin
         print "Invalid location! \n" unless file_path.empty?
@@ -183,7 +183,7 @@ module Azure
     def prompt_for_domain
       counter = 0
       begin
-        print 'Enter the domain (mandatory):'
+        print "Enter the domain (mandatory):"
         domain = STDIN.gets
         domain = domain.strip
         counter += 1
@@ -211,15 +211,15 @@ module Azure
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = cert
       ef.issuer_certificate = cert
-      cert.add_extension(ef.create_extension("subjectKeyIdentifier","hash",false))
-      cert.add_extension(ef.create_extension("authorityKeyIdentifier","keyid:always",false))
+      cert.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
+      cert.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always", false))
       cert.add_extension(ef.create_extension("extendedKeyUsage", "1.3.6.1.5.5.7.3.1", false))
       cert.sign(rsa_key, OpenSSL::Digest::SHA1.new)
       @thumbprint = OpenSSL::Digest::SHA1.new(cert.to_der)
       cert
     end
 
-    def write_certificate_to_file cert, file_path, rsa_key, cert_params
+    def write_certificate_to_file(cert, file_path, rsa_key, cert_params)
       File.open(file_path + ".pem", "wb") { |f| f.print cert.to_pem }
       @winrm_cert_passphrase = prompt_for_passphrase unless @winrm_cert_passphrase
       pfx = OpenSSL::PKCS12.create("#{cert_params[:winrm_cert_passphrase]}", "winrmcert", rsa_key, cert)
@@ -228,7 +228,6 @@ module Azure
     end
 
     ##########   SSL certificate generation ends ###########
-
 
   end
 end

--- a/lib/azure/service_management/certificate.rb
+++ b/lib/azure/service_management/certificate.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Mukta Aphale (mukta.aphale@clogeny.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/connection.rb
+++ b/lib/azure/service_management/connection.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/connection.rb
+++ b/lib/azure/service_management/connection.rb
@@ -16,17 +16,17 @@
 # limitations under the License.
 #
 
-require 'azure/service_management/image'
-require 'azure/service_management/role'
-require 'azure/service_management/deploy'
-require 'azure/service_management/host'
-require 'azure/service_management/loadbalancer'
-require 'azure/service_management/vnet'
-require 'azure/service_management/utility'
-require 'azure/service_management/ag'
-require 'azure/service_management/storageaccount'
-require 'azure/service_management/certificate'
-require 'azure/service_management/disk'
+require "azure/service_management/image"
+require "azure/service_management/role"
+require "azure/service_management/deploy"
+require "azure/service_management/host"
+require "azure/service_management/loadbalancer"
+require "azure/service_management/vnet"
+require "azure/service_management/utility"
+require "azure/service_management/ag"
+require "azure/service_management/storageaccount"
+require "azure/service_management/certificate"
+require "azure/service_management/disk"
 
 module Azure
   class ServiceManagement
@@ -37,7 +37,7 @@ module Azure
       def initialize(rest)
         @images = Images.new(self)
         @roles = Roles.new(self)
-        @deploys  = Deploys.new(self)
+        @deploys = Deploys.new(self)
         @hosts = Hosts.new(self)
         @rest = rest
         @lbs = Loadbalancer.new(self)
@@ -49,19 +49,19 @@ module Azure
       end
 
       def query_azure(service_name,
-                      verb = 'get',
-                      body = '',
-                      params = '',
+                      verb = "get",
+                      body = "",
+                      params = "",
                       wait = true,
                       services = true,
                       content_type = nil)
-        Chef::Log.info 'calling ' + verb + ' ' + service_name + (wait ? " synchronously" : " asynchronously")
-        Chef::Log.debug body unless body == ''
+        Chef::Log.info "calling " + verb + " " + service_name + (wait ? " synchronously" : " asynchronously")
+        Chef::Log.debug body unless body == ""
         response = @rest.query_azure(service_name, verb, body, params, services, content_type)
         if response.code.to_i == 200
           ret_val = Nokogiri::XML response.body
         elsif !wait && response.code.to_i == 202
-          Chef::Log.debug 'Request accepted in asynchronous mode'
+          Chef::Log.debug "Request accepted in asynchronous mode"
           ret_val = Nokogiri::XML response.body
         elsif response.code.to_i >= 201 && response.code.to_i <= 299
           ret_val = wait_for_completion()
@@ -70,29 +70,29 @@ module Azure
             ret_val = Nokogiri::XML response.body
             Chef::Log.debug ret_val.to_xml
             error_code, error_message = error_from_response_xml(ret_val)
-            Chef::Log.debug error_code + ' : ' + error_message if error_code.length > 0
+            Chef::Log.debug error_code + " : " + error_message if error_code.length > 0
           else
-            Chef::Log.warn 'http error: ' + response.code
+            Chef::Log.warn "http error: " + response.code
           end
         end
         ret_val
       end
 
-      def wait_for_completion()
-        status = 'InProgress'
-        Chef::Log.info 'Waiting while status returns InProgress'
-        while status == 'InProgress'
+      def wait_for_completion
+        status = "InProgress"
+        Chef::Log.info "Waiting while status returns InProgress"
+        while status == "InProgress"
           response = @rest.query_for_completion()
           ret_val = Nokogiri::XML response.body
-          status = xml_content(ret_val,'Status')
-          if status == 'InProgress'
-            print '.'
+          status = xml_content(ret_val, "Status")
+          if status == "InProgress"
+            print "."
             sleep(0.5)
-          elsif status == 'Succeeded'
-            Chef::Log.debug 'not InProgress : ' + ret_val.to_xml
+          elsif status == "Succeeded"
+            Chef::Log.debug "not InProgress : " + ret_val.to_xml
           else
             error_code, error_message = error_from_response_xml(ret_val)
-            Chef::Log.debug status + error_code + ' : ' + error_message if error_code.length > 0
+            Chef::Log.debug status + error_code + " : " + error_message if error_code.length > 0
           end
         end
         ret_val

--- a/lib/azure/service_management/deploy.rb
+++ b/lib/azure/service_management/deploy.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/disk.rb
+++ b/lib/azure/service_management/disk.rb
@@ -19,33 +19,37 @@
 module Azure
   class Disks
     def initialize(connection)
-      @connection=connection
+      @connection = connection
     end
+
     def all
       disks = Array.new
-      response = @connection.query_azure('disks')
-      founddisks = response.css('Disk')
+      response = @connection.query_azure("disks")
+      founddisks = response.css("Disk")
       founddisks.each do |disk|
         item = Disk.new(disk)
         disks << item
       end
       disks
     end
+
     def find(name)
       founddisk = nil
-      self.all.each do |disk|
+      all.each do |disk|
         next unless disk.name == name
         founddisk = disk
       end
       founddisk
     end
+
     def exists(name)
-      find(name) != nil
+      !find(name).nil?
     end
+
     def clear_unattached
-      self.all.each do |disk|
+      all.each do |disk|
         next unless disk.attached == false
-        @connection.query_azure('disks/' + disk.name, 'delete')
+        @connection.query_azure("disks/" + disk.name, "delete")
       end
     end
   end
@@ -55,8 +59,8 @@ module Azure
   class Disk
     attr_accessor :name, :attached
     def initialize(disk)
-      @name = disk.at_css('Name').content
-      @attached = disk.at_css('AttachedTo') != nil
+      @name = disk.at_css("Name").content
+      @attached = !disk.at_css("AttachedTo").nil?
     end
   end
 end

--- a/lib/azure/service_management/disk.rb
+++ b/lib/azure/service_management/disk.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/host.rb
+++ b/lib/azure/service_management/host.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/image.rb
+++ b/lib/azure/service_management/image.rb
@@ -19,29 +19,30 @@
 module Azure
   class Images
     def initialize(connection)
-      @connection=connection
+      @connection = connection
     end
+
     def load
       @images ||= begin
-        osimages = self.get_images("OSImage")   #get OSImages
-        vmimages = self.get_images("VMImage")   #get VMImages
+        osimages = get_images("OSImage")   #get OSImages
+        vmimages = get_images("VMImage")   #get VMImages
 
         all_images = osimages.merge(vmimages)
       end
     end
 
     def all
-      self.load.values
+      load.values
     end
 
     # img_type = OSImages or VMImage
     def get_images(img_type)
       images = Hash.new
 
-      if(img_type == "OSImage")
-        response = @connection.query_azure('images')
-      elsif(img_type == "VMImage")
-        response = @connection.query_azure('vmimages')
+      if img_type == "OSImage"
+        response = @connection.query_azure("images")
+      elsif img_type == "VMImage"
+        response = @connection.query_azure("vmimages")
       end
 
       unless response.to_s.empty?
@@ -57,21 +58,21 @@ module Azure
     end
 
     def is_os_image(image_name)
-      os_images = self.get_images("OSImage").values
-      os_images.detect {|img| img.name == image_name} ? true : false
+      os_images = get_images("OSImage").values
+      os_images.detect { |img| img.name == image_name } ? true : false
     end
 
     def is_vm_image(image_name)
-      vm_images = self.get_images("VMImage").values
-      vm_images.detect {|img| img.name == image_name} ? true : false
+      vm_images = get_images("VMImage").values
+      vm_images.detect { |img| img.name == image_name } ? true : false
     end
 
     def exists?(name)
-      self.all.detect {|img| img.name == name} ? true : false
+      all.detect { |img| img.name == name } ? true : false
     end
 
     def find(name)
-      self.load[name]
+      load[name]
     end
   end
 end
@@ -81,13 +82,13 @@ module Azure
     attr_accessor :category, :label
     attr_accessor :name, :os, :eula, :description, :location
     def initialize(image)
-      @category = image.at_css('Category').content
-      @label = image.at_css('Label').content
-      @name = image.at_css('Name').content
-      @os = image.at_css('OS').content
-      @location = image.at_css('Location').content.gsub(";", ", ") if image.at_css('Location')
-      @eula = image.at_css('Eula').content if image.at_css('Eula')
-      @description = image.at_css('Description').content if image.at_css('Description')
+      @category = image.at_css("Category").content
+      @label = image.at_css("Label").content
+      @name = image.at_css("Name").content
+      @os = image.at_css("OS").content
+      @location = image.at_css("Location").content.gsub(";", ", ") if image.at_css("Location")
+      @eula = image.at_css("Eula").content if image.at_css("Eula")
+      @description = image.at_css("Description").content if image.at_css("Description")
     end
   end
 end

--- a/lib/azure/service_management/image.rb
+++ b/lib/azure/service_management/image.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/loadbalancer.rb
+++ b/lib/azure/service_management/loadbalancer.rb
@@ -48,27 +48,27 @@ module Azure
     end
 
     def parse(lbXML, hostedservicename)
-      @name = xml_content(lbXML, 'Name')
-      ip_configXML = lbXML.css('FrontendIpConfiguration')
-      @subnet = xml_content(ip_configXML, 'SubnetName')
-      @vip = xml_content(ip_configXML, 'StaticVirtualNetworkIPAddress')
+      @name = xml_content(lbXML, "Name")
+      ip_configXML = lbXML.css("FrontendIpConfiguration")
+      @subnet = xml_content(ip_configXML, "SubnetName")
+      @vip = xml_content(ip_configXML, "StaticVirtualNetworkIPAddress")
       @service = hostedservicename
       self
     end
 
     def create(params)
       if params[:azure_lb_static_vip] && !params[:azure_subnet_name]
-        Chef::Log.fatal 'Unable to create Loadbalancer, :azure_subnet_name needs to be set if :azure_lb_static_vip is set'
+        Chef::Log.fatal "Unable to create Loadbalancer, :azure_subnet_name needs to be set if :azure_lb_static_vip is set"
       end
-      builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
-        xml.LoadBalancer(xmlns: 'http://schemas.microsoft.com/windowsazure') {
+      builder = Nokogiri::XML::Builder.new(encoding: "utf-8") do |xml|
+        xml.LoadBalancer(xmlns: "http://schemas.microsoft.com/windowsazure") do
           xml.Name params[:azure_load_balancer]
-          xml.FrontendIpConfiguration {
-            xml.Type 'Private'
+          xml.FrontendIpConfiguration do
+            xml.Type "Private"
             xml.SubnetName params[:azure_subnet_name] if params[:azure_subnet_name]
             xml.StaticVirtualNetworkIPAddress params[:azure_lb_static_vip] if params[:azure_lb_static_vip]
-          }
-        }
+          end
+        end
       end
       deploy_name = @connection.deploys.get_deploy_name_for_hostedservice(params[:azure_dns_name])
       servicecall = "hostedservices/#{params[:azure_dns_name]}/deployments/#{deploy_name}/loadbalancers"

--- a/lib/azure/service_management/loadbalancer.rb
+++ b/lib/azure/service_management/loadbalancer.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aiman Alsari (aiman.alsari@gmail.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/rest.rb
+++ b/lib/azure/service_management/rest.rb
@@ -30,22 +30,22 @@ module AzureAPI
     end
 
     def query_azure(service_name,
-                    verb = 'get',
-                    body = '',
-                    params = '',
+                    verb = "get",
+                    body = "",
+                    params = "",
                     services = true,
                     content_type = nil)
-      svc_str = services ? '/services' : ''
+      svc_str = services ? "/services" : ""
       uri = URI.parse("#{@host_name}/#{@subscription_id}#{svc_str}/#{service_name}")
       scheme = !uri.scheme ? "https://" : ""
       request_url = "#{scheme}#{@host_name}/#{@subscription_id}#{svc_str}/#{service_name}"
-      print '.'
+      print "."
       response = http_query(request_url, verb, body, params, content_type)
       if response.code.to_i == 307
         Chef::Log.debug "Redirect to #{response['Location']}"
-        response = http_query(response['Location'], verb, body, params, content_type)
+        response = http_query(response["Location"], verb, body, params, content_type)
       end
-      @last_request_id = response['x-ms-request-id']
+      @last_request_id = response["x-ms-request-id"]
       response
     end
 
@@ -55,18 +55,18 @@ module AzureAPI
       http = http_setup(uri)
       request = request_setup(uri, verb, body, content_type)
       response = http.request(request)
-      @last_request_id = response['x-ms-request-id']
+      @last_request_id = response["x-ms-request-id"]
       response
     end
 
-    def query_for_completion()
+    def query_for_completion
       uri = URI.parse("#{@host_name}/#{@subscription_id}/operations/#{@last_request_id}")
       scheme = !uri.scheme ? "https://" : ""
       request_url = "#{scheme}#{@host_name}/#{@subscription_id}/operations/#{@last_request_id}"
-      response = http_query(request_url, 'get', '', '')
+      response = http_query(request_url, "get", "", "")
       if response.code.to_i == 307
         Chef::Log.debug "Redirect to #{response['Location']}"
-        response = http_query(response['Location'], 'get', '', '')
+        response = http_query(response["Location"], "get", "", "")
       end
       response
     end
@@ -87,20 +87,21 @@ module AzureAPI
       rescue OpenSSL::X509::CertificateError => err
         raise "Invalid Azure Certificate pem file. Error: #{err}"
       end
-        http.key = OpenSSL::PKey::RSA.new(@pem_file)
+      http.key = OpenSSL::PKey::RSA.new(@pem_file)
       http
     end
+
     def request_setup(uri, verb, body, content_type)
-      if verb == 'get'
+      if verb == "get"
         request = Net::HTTP::Get.new(uri.request_uri)
-      elsif verb == 'post'
+      elsif verb == "post"
         request = Net::HTTP::Post.new(uri.request_uri)
-      elsif verb == 'delete'
+      elsif verb == "delete"
         request = Net::HTTP::Delete.new(uri.request_uri)
-      elsif verb == 'put'
+      elsif verb == "put"
         request = Net::HTTP::Put.new(uri.request_uri)
       end
-      text = verb == 'put' && content_type.nil?
+      text = verb == "put" && content_type.nil?
       request["x-ms-version"] = "2014-05-01"
       request["content-type"] = text ? "text/plain" : "application/xml"
       request["accept"] = "application/xml"
@@ -117,7 +118,7 @@ module AzureAPI
       puts "=== response.inspect ==="
       puts response.inspect
       puts "=== all of the headers ==="
-      puts response.each_header { |h, j| puts h.inspect + ' : ' + j.inspect}
+      puts response.each_header { |h, j| puts h.inspect + " : " + j.inspect }
     end
   end
 end

--- a/lib/azure/service_management/rest.rb
+++ b/lib/azure/service_management/rest.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/role.rb
+++ b/lib/azure/service_management/role.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/role.rb
+++ b/lib/azure/service_management/role.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require 'securerandom'
-require 'azure/service_management/utility'
+require "securerandom"
+require "azure/service_management/utility"
 
 module Azure
   class Roles
@@ -26,6 +26,7 @@ module Azure
       @connection = connection
       @roles = nil
     end
+
     # do not use this unless you want a list of all roles(vms) in your subscription
     def all
       @roles = Array.new
@@ -48,16 +49,16 @@ module Azure
       host.find_role(role_name)
     end
 
-    def find(role_name, params= nil)
+    def find(role_name, params = nil)
       if params && params[:azure_dns_name]
         return find_in_hosted_service(role_name, params[:azure_dns_name])
       end
 
-      all if @roles == nil
+      all if @roles.nil?
 
       # TODO - optimize this lookup
       @roles.each do |role|
-        if(role.name == role_name)
+        if role.name == role_name
           return role
         end
       end
@@ -69,7 +70,7 @@ module Azure
       if roles && roles.length > 1
         return false
       end
-      return true
+      true
     end
 
     def exists?(name)
@@ -78,19 +79,19 @@ module Azure
 
     def delete(params)
       role = find(params[:name])
-      if role != nil
+      if !role.nil?
         roleXML = nil
         roleXML = @connection.query_azure("hostedservices/#{role.hostedservicename}", "get", "", "embed-detail=true")
-        osdisk = roleXML.css(roleXML, 'OSVirtualHardDisk')
-        disk_name = xml_content(osdisk, 'DiskName')
-        storage_account_name = xml_content(osdisk, 'MediaLink').gsub("http://", "").gsub(/.blob(.*)$/, "")
+        osdisk = roleXML.css(roleXML, "OSVirtualHardDisk")
+        disk_name = xml_content(osdisk, "DiskName")
+        storage_account_name = xml_content(osdisk, "MediaLink").gsub("http://", "").gsub(/.blob(.*)$/, "")
 
         if !params[:preserve_azure_os_disk] && !params[:preserve_azure_vhd] && !params[:wait]
           # default compmedia = true. So, it deletes role and associated resources
           check_and_delete_role_and_resources(params, role)
         else
           # compmedia = false. So, it deletes only role and not associated resources
-          check_and_delete_role_and_resources(params, role, compmedia=false)
+          check_and_delete_role_and_resources(params, role, compmedia = false)
           check_and_delete_disks(params, disk_name)
           check_and_delete_service(params)
         end
@@ -98,7 +99,7 @@ module Azure
       end
     end
 
-    def check_and_delete_role_and_resources(params, role, compmedia=true)
+    def check_and_delete_role_and_resources(params, role, compmedia = true)
       if alone_on_hostedservice(role)
         if !params[:preserve_azure_dns_name] && compmedia
           servicecall = "hostedservices/#{role.hostedservicename}"
@@ -107,10 +108,10 @@ module Azure
         end
       else
         servicecall = "hostedservices/#{role.hostedservicename}/deployments" +
-        "/#{role.deployname}/roles/#{role.name}"
+          "/#{role.deployname}/roles/#{role.name}"
       end
       if compmedia
-        @connection.query_azure(servicecall, "delete", "", "comp=media", wait=params[:wait])
+        @connection.query_azure(servicecall, "delete", "", "comp=media", wait = params[:wait])
       else
         @connection.query_azure(servicecall, "delete")
       end
@@ -127,13 +128,13 @@ module Azure
         # So Iteratively check for disk detachment from the VM while waiting for 5 minutes ,
         # exit otherwise after 12 attempts.
         for attempt in 0..12
-           break if @connection.query_azure(servicecall, "get").search("AttachedTo").text == ""
-           if attempt == 12 then puts "The associated disk could not be deleted due to time out." else sleep 25 end
+          break if @connection.query_azure(servicecall, "get").search("AttachedTo").text == ""
+          attempt == 12 ? (puts "The associated disk could not be deleted due to time out.") : (sleep 25)
         end
         unless params[:preserve_azure_vhd]
-          @connection.query_azure(servicecall, 'delete', '', 'comp=media', wait=params[:wait])
+          @connection.query_azure(servicecall, "delete", "", "comp=media", wait = params[:wait])
         else
-          @connection.query_azure(servicecall, 'delete')
+          @connection.query_azure(servicecall, "delete")
         end
       end
     end
@@ -151,11 +152,11 @@ module Azure
     end
 
     def check_and_delete_storage(params, disk_name, storage_account_name)
-     if params[:delete_azure_storage_account]
-        # Iteratively check for disk deletion
+      if params[:delete_azure_storage_account]
+         # Iteratively check for disk deletion
         for attempt in 0..12
-           break unless @connection.query_azure("disks").search("Name").text.include?(disk_name)
-           if attempt == 12 then puts "The associated disk could not be deleted due to time out." else sleep 25 end
+          break unless @connection.query_azure("disks").search("Name").text.include?(disk_name)
+          attempt == 12 ? (puts "The associated disk could not be deleted due to time out.") : (sleep 25)
         end
         begin
           @connection.query_azure("storageservices/#{storage_account_name}", "delete")
@@ -163,7 +164,7 @@ module Azure
           ui.warn("#{ex.message}")
           ui.warn("#{ex.backtrace.join("\n")}")
         end
-      end
+       end
     end
 
     def update(name, params)
@@ -184,55 +185,55 @@ module Azure
     attr_accessor :hostname, :tcpports, :udpports
     attr_accessor :role_xml, :os_type, :os_version
 
-      TCP_ENDPOINTS_MAPPING = { '3389' => 'Remote Desktop',
-                              '5986' => 'PowerShell',
-                              '22' => 'SSH',
-                              '21' => 'FTP',
-                              '25' => 'SMTP',
-                              '53' => 'DNS',
-                              '80' => 'HTTP',
-                              '110' => 'POP3',
-                              '143' => 'IMAP',
-                              '389' => 'LDAP',
-                              '443' => 'HTTPs',
-                              '587' => 'SMTPS',
-                              '995' => 'POP3S',
-                              '993' => 'IMAPS',
-                              '1433' => 'MSSQL',
-                              '3306' => 'MySQL'
-                              }
+    TCP_ENDPOINTS_MAPPING = { "3389" => "Remote Desktop",
+                              "5986" => "PowerShell",
+                              "22" => "SSH",
+                              "21" => "FTP",
+                              "25" => "SMTP",
+                              "53" => "DNS",
+                              "80" => "HTTP",
+                              "110" => "POP3",
+                              "143" => "IMAP",
+                              "389" => "LDAP",
+                              "443" => "HTTPs",
+                              "587" => "SMTPS",
+                              "995" => "POP3S",
+                              "993" => "IMAPS",
+                              "1433" => "MSSQL",
+                              "3306" => "MySQL"
+                            }
 
     def initialize(connection)
       @connection = connection
     end
 
     def parse(roleXML, hostedservicename, deployname)
-      @name = xml_content(roleXML, 'RoleName')
-      @status = xml_content(roleXML, 'InstanceStatus')
-      @size = xml_content(roleXML, 'InstanceSize')
-      @ipaddress = xml_content(roleXML, 'IpAddress')
-      @hostname = xml_content(roleXML, 'HostName')
+      @name = xml_content(roleXML, "RoleName")
+      @status = xml_content(roleXML, "InstanceStatus")
+      @size = xml_content(roleXML, "InstanceSize")
+      @ipaddress = xml_content(roleXML, "IpAddress")
+      @hostname = xml_content(roleXML, "HostName")
       @hostedservicename = hostedservicename
       @deployname = deployname
       @thumbprint = fetch_thumbprint
       @tcpports = Array.new
       @udpports = Array.new
 
-      endpoints = roleXML.css('InstanceEndpoint')
-      @publicipaddress = xml_content(endpoints[0], 'Vip') if !endpoints.empty?
+      endpoints = roleXML.css("InstanceEndpoint")
+      @publicipaddress = xml_content(endpoints[0], "Vip") if !endpoints.empty?
       endpoints.each do |endpoint|
-        if xml_content(endpoint, 'Name').downcase == 'ssh'
-          @sshport = xml_content(endpoint, 'PublicPort')
-        elsif xml_content(endpoint, 'Name').downcase == 'winrm'
-          @winrmport = xml_content(endpoint, 'PublicPort')
+        if xml_content(endpoint, "Name").casecmp("ssh").zero?
+          @sshport = xml_content(endpoint, "PublicPort")
+        elsif xml_content(endpoint, "Name").casecmp("winrm").zero?
+          @winrmport = xml_content(endpoint, "PublicPort")
         else
           hash = Hash.new
-          hash['Name'] = xml_content(endpoint, 'Name')
-          hash['Vip'] = xml_content(endpoint, 'Vip')
-          hash['PublicPort'] = xml_content(endpoint, 'PublicPort')
-          hash['LocalPort'] = xml_content(endpoint, 'LocalPort')
+          hash["Name"] = xml_content(endpoint, "Name")
+          hash["Vip"] = xml_content(endpoint, "Vip")
+          hash["PublicPort"] = xml_content(endpoint, "PublicPort")
+          hash["LocalPort"] = xml_content(endpoint, "LocalPort")
 
-          if xml_content(endpoint, 'Protocol') == 'tcp'
+          if xml_content(endpoint, "Protocol") == "tcp"
             @tcpports << hash
           else # == 'udp'
             @udpports << hash
@@ -243,31 +244,31 @@ module Azure
 
     def parse_role_list_xml(roleListXML)
       @role_xml = roleListXML
-      os_disk_xml = roleListXML.css('OSVirtualHardDisk')
-      @os_type = xml_content(os_disk_xml, 'OS')
-      @os_version = xml_content(os_disk_xml, 'SourceImageName')
+      os_disk_xml = roleListXML.css("OSVirtualHardDisk")
+      @os_type = xml_content(os_disk_xml, "OS")
+      @os_version = xml_content(os_disk_xml, "SourceImageName")
     end
 
     # Expects endpoint_param_string to be in the form {localport}:{publicport}:{lb_set_name}:{lb_probe_path}
     # Only localport is mandatory.
     def parse_endpoint_from_params(protocol, azure_vm_name, endpoint_param_string)
-      fields = endpoint_param_string.split(':').map(&:strip)
+      fields = endpoint_param_string.split(":").map(&:strip)
       hash = {}
-      hash['LocalPort'] = fields[0]
-      hash['Port'] = fields[1] || fields[0]
-      hash['LoadBalancerName'] = fields[2] if fields[2] != 'EXTERNAL' # TODO: hackity hack.. Shouldn't use magic words.
-      hash['LoadBalancedEndpointSetName'] = fields[3]
-      hash['Protocol'] = protocol
-      if TCP_ENDPOINTS_MAPPING.include?(hash['Port']) && protocol == 'TCP'
-        hash['Name'] = TCP_ENDPOINTS_MAPPING[hash['Port']]
+      hash["LocalPort"] = fields[0]
+      hash["Port"] = fields[1] || fields[0]
+      hash["LoadBalancerName"] = fields[2] if fields[2] != "EXTERNAL" # TODO: hackity hack.. Shouldn't use magic words.
+      hash["LoadBalancedEndpointSetName"] = fields[3]
+      hash["Protocol"] = protocol
+      if TCP_ENDPOINTS_MAPPING.include?(hash["Port"]) && protocol == "TCP"
+        hash["Name"] = TCP_ENDPOINTS_MAPPING[hash["Port"]]
       else
-        hash['Name'] = "#{protocol}Endpoint_chef_#{fields[0]}"
+        hash["Name"] = "#{protocol}Endpoint_chef_#{fields[0]}"
       end
       if fields[2]
-        hash['LoadBalancerProbe'] = {}
-        hash['LoadBalancerProbe']['Path'] = fields[4]
-        hash['LoadBalancerProbe']['Port'] = fields[0]
-        hash['LoadBalancerProbe']['Protocol'] = fields[4] ? 'HTTP' : protocol
+        hash["LoadBalancerProbe"] = {}
+        hash["LoadBalancerProbe"]["Path"] = fields[4]
+        hash["LoadBalancerProbe"]["Port"] = fields[0]
+        hash["LoadBalancerProbe"]["Protocol"] = fields[4] ? "HTTP" : protocol
       end
       hash
     end
@@ -283,252 +284,252 @@ module Azure
 
         if existing_endpoints
           existing_endpoints.each do |eep|
-            ep = eep if eep['LoadBalancedEndpointSetName'] && ep['LoadBalancedEndpointSetName'] && ( eep['LoadBalancedEndpointSetName'] == ep['LoadBalancedEndpointSetName'] )
+            ep = eep if eep["LoadBalancedEndpointSetName"] && ep["LoadBalancedEndpointSetName"] && ( eep["LoadBalancedEndpointSetName"] == ep["LoadBalancedEndpointSetName"] )
           end
         end
 
-        if ep['Port'] == params[:port] && ep['Protocol'].downcase == 'tcp'
+        if ep["Port"] == params[:port] && ep["Protocol"].casecmp("tcp").zero?
           puts("Skipping tcp-endpoints: #{ep['LocalPort']} because this port is already in use by ssh/winrm endpoint in current VM.")
           next
         end
 
-        xml.InputEndpoint {
-          xml.LoadBalancedEndpointSetName ep['LoadBalancedEndpointSetName'] if ep['LoadBalancedEndpointSetName']
-          xml.LocalPort ep['LocalPort']
-          xml.Name ep['Name']
-          xml.Port ep['Port']
-          if ep['LoadBalancerProbe']
-            xml.LoadBalancerProbe {
-              xml.Path ep['LoadBalancerProbe']['Path'] if ep['LoadBalancerProbe']['Path']
-              xml.Port ep['LoadBalancerProbe']['Port']
-              xml.Protocol ep['LoadBalancerProbe']['Protocol']
-              xml.IntervalInSeconds ep['LoadBalancerProbe']['IntervalInSeconds'] if ep['LoadBalancerProbe']['IntervalInSeconds']
-              xml.TimeoutInSeconds ep['LoadBalancerProbe']['TimeoutInSeconds'] if ep['LoadBalancerProbe']['TimeoutInSeconds']
-            }
+        xml.InputEndpoint do
+          xml.LoadBalancedEndpointSetName ep["LoadBalancedEndpointSetName"] if ep["LoadBalancedEndpointSetName"]
+          xml.LocalPort ep["LocalPort"]
+          xml.Name ep["Name"]
+          xml.Port ep["Port"]
+          if ep["LoadBalancerProbe"]
+            xml.LoadBalancerProbe do
+              xml.Path ep["LoadBalancerProbe"]["Path"] if ep["LoadBalancerProbe"]["Path"]
+              xml.Port ep["LoadBalancerProbe"]["Port"]
+              xml.Protocol ep["LoadBalancerProbe"]["Protocol"]
+              xml.IntervalInSeconds ep["LoadBalancerProbe"]["IntervalInSeconds"] if ep["LoadBalancerProbe"]["IntervalInSeconds"]
+              xml.TimeoutInSeconds ep["LoadBalancerProbe"]["TimeoutInSeconds"] if ep["LoadBalancerProbe"]["TimeoutInSeconds"]
+            end
           end
-          xml.Protocol ep['Protocol']
-          xml.EnableDirectServerReturn ep['EnableDirectServerReturn'] if ep['EnableDirectServerReturn']
-          xml.LoadBalancerName ep['LoadBalancerName'] if ep['LoadBalancerName']
-          xml.IdleTimeoutInMinutes ep['IdleTimeoutInMinutes'] if ep['IdleTimeoutInMinutes']
-        }
+          xml.Protocol ep["Protocol"]
+          xml.EnableDirectServerReturn ep["EnableDirectServerReturn"] if ep["EnableDirectServerReturn"]
+          xml.LoadBalancerName ep["LoadBalancerName"] if ep["LoadBalancerName"]
+          xml.IdleTimeoutInMinutes ep["IdleTimeoutInMinutes"] if ep["IdleTimeoutInMinutes"]
+        end
       end
     end
 
     def fetch_thumbprint
       query_result = connection.query_azure("hostedservices/#{@hostedservicename}/deployments/#{@hostedservicename}/roles/#{@name}")
-      query_result.at_css("DefaultWinRmCertificateThumbprint").nil? ? '' : query_result.at_css("DefaultWinRmCertificateThumbprint").text
+      query_result.at_css("DefaultWinRmCertificateThumbprint").nil? ? "" : query_result.at_css("DefaultWinRmCertificateThumbprint").text
     end
 
     def setup(params)
       azure_user_domain_name = params[:azure_user_domain_name] || params[:azure_domain_name]
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.PersistentVMRole(
-          'xmlns'=>'http://schemas.microsoft.com/windowsazure',
-          'xmlns:i'=>'http://www.w3.org/2001/XMLSchema-instance'
-        ) {
-          xml.RoleName {xml.text params[:azure_vm_name]}
-          xml.OsVersion('i:nil' => 'true')
-          xml.RoleType 'PersistentVMRole'
+          "xmlns" => "http://schemas.microsoft.com/windowsazure",
+          "xmlns:i" => "http://www.w3.org/2001/XMLSchema-instance"
+        ) do
+          xml.RoleName { xml.text params[:azure_vm_name] }
+          xml.OsVersion("i:nil" => "true")
+          xml.RoleType "PersistentVMRole"
 
-          xml.ConfigurationSets {
-            if params[:os_type] == 'Linux'
-              xml.ConfigurationSet('i:type' => 'LinuxProvisioningConfigurationSet') {
-                xml.ConfigurationSetType 'LinuxProvisioningConfiguration'
+          xml.ConfigurationSets do
+            if params[:os_type] == "Linux"
+              xml.ConfigurationSet("i:type" => "LinuxProvisioningConfigurationSet") do
+                xml.ConfigurationSetType "LinuxProvisioningConfiguration"
                 xml.HostName params[:azure_vm_name]
                 xml.UserName params[:ssh_user]
                 unless params[:identity_file].nil?
-                  xml.DisableSshPasswordAuthentication 'true'
-                  xml.SSH {
-                     xml.PublicKeys {
-                       xml.PublicKey {
-                         xml.Fingerprint params[:fingerprint].to_s.upcase
-                         xml.Path '/home/' + params[:ssh_user] + '/.ssh/authorized_keys'
-                       }
-                     }
-                  }
+                  xml.DisableSshPasswordAuthentication "true"
+                  xml.SSH do
+                    xml.PublicKeys do
+                      xml.PublicKey do
+                        xml.Fingerprint params[:fingerprint].to_s.upcase
+                        xml.Path "/home/" + params[:ssh_user] + "/.ssh/authorized_keys"
+                      end
+                    end
+                  end
                 else
                   xml.UserPassword params[:ssh_password]
-                  xml.DisableSshPasswordAuthentication 'false'
+                  xml.DisableSshPasswordAuthentication "false"
                 end
-              }
-            elsif params[:os_type] == 'Windows'
-              xml.ConfigurationSet('i:type' => 'WindowsProvisioningConfigurationSet') {
-                xml.ConfigurationSetType 'WindowsProvisioningConfiguration'
+              end
+            elsif params[:os_type] == "Windows"
+              xml.ConfigurationSet("i:type" => "WindowsProvisioningConfigurationSet") do
+                xml.ConfigurationSetType "WindowsProvisioningConfiguration"
                 xml.ComputerName params[:azure_vm_name]
                 xml.AdminPassword params[:admin_password]
-                xml.ResetPasswordOnFirstLogon 'false'
-                xml.EnableAutomaticUpdates 'false'
+                xml.ResetPasswordOnFirstLogon "false"
+                xml.EnableAutomaticUpdates "false"
                 if params[:azure_domain_name]
-                  xml.DomainJoin {
-                    xml.Credentials {
+                  xml.DomainJoin do
+                    xml.Credentials do
                       xml.Domain azure_user_domain_name
-                     xml.Username params[:azure_domain_user]
-                    xml.Password params[:azure_domain_passwd]
-                   }
-                   xml.JoinDomain params[:azure_domain_name]
-                   xml.MachineObjectOU params[:azure_domain_ou_dn] if params[:azure_domain_ou_dn]
-                  }
-                end
-                  if params[:bootstrap_proto].downcase == 'winrm'
-                    if params[:ssl_cert_fingerprint]
-                      xml.StoredCertificateSettings {
-                        xml.CertificateSetting {
-                          xml.StoreLocation "LocalMachine"
-                          xml.StoreName "My"
-                          xml.Thumbprint params[:ssl_cert_fingerprint]
-                        }
-                      }
+                      xml.Username params[:azure_domain_user]
+                      xml.Password params[:azure_domain_passwd]
                     end
-                    xml.WinRM {
-                      xml.Listeners {
-                       if params[:winrm_transport] == "ssl" || params[:ssl_cert_fingerprint]
-                        xml.Listener {
-                          xml.CertificateThumbprint params[:ssl_cert_fingerprint] if params[:ssl_cert_fingerprint]
-                          xml.Protocol 'Https'
-                        }
-                        else
-                        xml.Listener {
-                          xml.Protocol 'Http'
-                        }
-                        end
-                      }
-                    }
+                    xml.JoinDomain params[:azure_domain_name]
+                    xml.MachineObjectOU params[:azure_domain_ou_dn] if params[:azure_domain_ou_dn]
                   end
+                end
+                if params[:bootstrap_proto].casecmp("winrm").zero?
+                  if params[:ssl_cert_fingerprint]
+                    xml.StoredCertificateSettings do
+                      xml.CertificateSetting do
+                        xml.StoreLocation "LocalMachine"
+                        xml.StoreName "My"
+                        xml.Thumbprint params[:ssl_cert_fingerprint]
+                      end
+                    end
+                  end
+                  xml.WinRM do
+                    xml.Listeners do
+                      if params[:winrm_transport] == "ssl" || params[:ssl_cert_fingerprint]
+                        xml.Listener do
+                          xml.CertificateThumbprint params[:ssl_cert_fingerprint] if params[:ssl_cert_fingerprint]
+                          xml.Protocol "Https"
+                        end
+                      else
+                        xml.Listener do
+                          xml.Protocol "Http"
+                        end
+                       end
+                    end
+                  end
+                end
                 xml.AdminUsername params[:winrm_user]
-                if params[:bootstrap_proto].downcase == 'winrm' && (params[:winrm_max_timeout] || params[:winrm_max_memoryPerShell])
-                  xml.AdditionalUnattendContent {
-                    xml.Passes {
-                      xml.UnattendPass {
-                        xml.PassName 'oobeSystem'
-                        xml.Components {
-                          xml.UnattendComponent {
-                            xml.ComponentName 'Microsoft-Windows-Shell-Setup'
-                            xml.ComponentSettings {
-                              xml.ComponentSetting {
-                                xml.SettingName 'AutoLogon'
+                if params[:bootstrap_proto].casecmp("winrm").zero? && (params[:winrm_max_timeout] || params[:winrm_max_memoryPerShell])
+                  xml.AdditionalUnattendContent do
+                    xml.Passes do
+                      xml.UnattendPass do
+                        xml.PassName "oobeSystem"
+                        xml.Components do
+                          xml.UnattendComponent do
+                            xml.ComponentName "Microsoft-Windows-Shell-Setup"
+                            xml.ComponentSettings do
+                              xml.ComponentSetting do
+                                xml.SettingName "AutoLogon"
                                 xml.Content Base64.encode64(
                                   Nokogiri::XML::Builder.new do |auto_logon_xml|
-                                    auto_logon_xml.AutoLogon {
+                                    auto_logon_xml.AutoLogon do
                                       auto_logon_xml.Username params[:winrm_user]
-                                      auto_logon_xml.Password {
+                                      auto_logon_xml.Password do
                                         auto_logon_xml.Value params[:admin_password]
                                         auto_logon_xml.PlainText true
-                                      }
+                                      end
                                       auto_logon_xml.LogonCount 1
                                       auto_logon_xml.Enabled true
-                                    }
+                                    end
                                   end.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION)
                                 ).strip
-                              }
-                              xml.ComponentSetting {
-                                xml.SettingName 'FirstLogonCommands'
+                              end
+                              xml.ComponentSetting do
+                                xml.SettingName "FirstLogonCommands"
                                 xml.Content Base64.encode64(
                                   Nokogiri::XML::Builder.new do |first_logon_xml|
-                                    first_logon_xml.FirstLogonCommands {
+                                    first_logon_xml.FirstLogonCommands do
                                       if params[:winrm_max_timeout]
-                                        first_logon_xml.SynchronousCommand('wcm:action' => 'add') {
+                                        first_logon_xml.SynchronousCommand("wcm:action" => "add") do
                                           first_logon_xml.Order 1
                                           first_logon_xml.CommandLine "cmd.exe /c winrm set winrm/config @{MaxTimeoutms=\"#{params[:winrm_max_timeout]}\"}"
                                           first_logon_xml.Description "Bump WinRM max timeout to #{params[:winrm_max_timeout]} milliseconds"
-                                        }
+                                        end
                                       end
 
                                       if params[:winrm_max_memoryPerShell]
-                                        first_logon_xml.SynchronousCommand('wcm:action' => 'add') {
+                                        first_logon_xml.SynchronousCommand("wcm:action" => "add") do
                                           first_logon_xml.Order 2
                                           first_logon_xml.CommandLine "cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB=\"#{params[:winrm_max_memoryPerShell]}\"}"
                                           first_logon_xml.Description "Bump WinRM max memory per shell to #{params[:winrm_max_memoryPerShell]} MB"
-                                        }
+                                        end
                                       end
-                                    }
+                                    end
                                   end.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION)
                                 ).strip
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                              end
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
                 end
-              }
+              end
             end
 
-            xml.ConfigurationSet('i:type' => 'NetworkConfigurationSet') {
-              xml.ConfigurationSetType 'NetworkConfiguration'
-              xml.InputEndpoints {
+            xml.ConfigurationSet("i:type" => "NetworkConfigurationSet") do
+              xml.ConfigurationSetType "NetworkConfiguration"
+              xml.InputEndpoints do
 
                 #1. bootstrap_proto = 'winrm' for windows => Set winrm port
                 #2. bootstrap_proto = 'ssh' for windows and linux => Set ssh port
                 #3. bootstrap_proto = 'cloud-api' for windows and linux => Set no port
-                if params[:os_type] == 'Windows' and params[:bootstrap_proto].downcase == 'winrm'
-                  xml.InputEndpoint {
-                  if params[:winrm_transport] == "ssl"
-                    xml.LocalPort '5986'
-                  else
-                    xml.LocalPort '5985'
+                if (params[:os_type] == "Windows") && (params[:bootstrap_proto].casecmp("winrm").zero?)
+                  xml.InputEndpoint do
+                    if params[:winrm_transport] == "ssl"
+                      xml.LocalPort "5986"
+                    else
+                      xml.LocalPort "5985"
+                    end
+                    xml.Name "WinRM"
+                    xml.Port params[:port]
+                    xml.Protocol "TCP"
                   end
-                  xml.Name 'WinRM'
-                  xml.Port params[:port]
-                  xml.Protocol 'TCP'
-                }
-                elsif(params[:bootstrap_proto].downcase == 'ssh')
-                  xml.InputEndpoint {
-                  xml.LocalPort '22'
-                  xml.Name 'SSH'
-                  xml.Port params[:port]
-                  xml.Protocol 'TCP'
-                }
+                elsif params[:bootstrap_proto].casecmp("ssh").zero?
+                  xml.InputEndpoint do
+                    xml.LocalPort "22"
+                    xml.Name "SSH"
+                    xml.Port params[:port]
+                    xml.Protocol "TCP"
+                  end
                 end
                 all_endpoints = Array.new
 
                 if params[:tcp_endpoints]
-                  params[:tcp_endpoints].split(',').map(&:strip).each do |endpoint|
-                    all_endpoints << parse_endpoint_from_params('TCP', params[:azure_vm_name], endpoint)
+                  params[:tcp_endpoints].split(",").map(&:strip).each do |endpoint|
+                    all_endpoints << parse_endpoint_from_params("TCP", params[:azure_vm_name], endpoint)
                   end
                 end
                 if params[:udp_endpoints]
-                  params[:udp_endpoints].split(',').map(&:strip).each do |endpoint|
-                    all_endpoints << parse_endpoint_from_params('UDP', params[:azure_vm_name], endpoint)
+                  params[:udp_endpoints].split(",").map(&:strip).each do |endpoint|
+                    all_endpoints << parse_endpoint_from_params("UDP", params[:azure_vm_name], endpoint)
                   end
                 end
                 add_endpoints_to_xml(xml, all_endpoints, params) if all_endpoints.any?
-              }
-              if params[:azure_subnet_name]
-                xml.SubnetNames {
-                  xml.SubnetName params[:azure_subnet_name]
-                }
               end
-            }
-          }
+              if params[:azure_subnet_name]
+                xml.SubnetNames do
+                  xml.SubnetName params[:azure_subnet_name]
+                end
+              end
+            end
+          end
 
           # Azure resource extension support
-          if params[:bootstrap_proto] == 'cloud-api'
-            xml.ResourceExtensionReferences {
-              xml.ResourceExtensionReference {
+          if params[:bootstrap_proto] == "cloud-api"
+            xml.ResourceExtensionReferences do
+              xml.ResourceExtensionReference do
                 xml.ReferenceName params[:chef_extension]
                 xml.Publisher params[:chef_extension_publisher]
                 xml.Name params[:chef_extension]
                 xml.Version params[:chef_extension_version]
-                xml.ResourceExtensionParameterValues {
+                xml.ResourceExtensionParameterValues do
                   if params[:chef_extension_public_param]
-                    xml.ResourceExtensionParameterValue {
+                    xml.ResourceExtensionParameterValue do
                       xml.Key "PublicParams"
                       xml.Value Base64.encode64(params[:chef_extension_public_param].to_json)
                       xml.Type "Public"
-                    }
+                    end
                   end
                   if params[:chef_extension_private_param]
-                    xml.ResourceExtensionParameterValue {
+                    xml.ResourceExtensionParameterValue do
                       xml.Key "PrivateParams"
                       xml.Value Base64.encode64(params[:chef_extension_private_param].to_json)
                       xml.Type "Private"
-                    }
+                    end
                   end
-                }
+                end
                 xml.State "Enable"
-              }
-            }
+              end
+            end
           end
 
           if params[:azure_availability_set]
@@ -540,26 +541,26 @@ module Azure
           xml.Label Base64.encode64(params[:azure_vm_name]).strip
 
           #OSVirtualHardDisk not required in case azure_source_image is a VMImage
-          unless(params[:is_vm_image])
-            xml.OSVirtualHardDisk {
+          unless params[:is_vm_image]
+            xml.OSVirtualHardDisk do
               disk_name = params[:azure_os_disk_name] || "disk_" + SecureRandom.uuid
               xml.DiskName disk_name
-              domain_suffix = params[:azure_api_host_name] ? params[:azure_api_host_name].scan(/core.*/)[0] : ''
-              xml.MediaLink 'http://' + params[:azure_storage_account] + '.blob.' + domain_suffix + '/vhds/' + disk_name + '.vhd'
+              domain_suffix = params[:azure_api_host_name] ? params[:azure_api_host_name].scan(/core.*/)[0] : ""
+              xml.MediaLink "http://" + params[:azure_storage_account] + ".blob." + domain_suffix + "/vhds/" + disk_name + ".vhd"
               xml.SourceImageName params[:azure_source_image]
-            }
+            end
           end
 
           xml.RoleSize params[:azure_vm_size]
-          xml.ProvisionGuestAgent true if params[:bootstrap_proto] == 'cloud-api'
-        }
+          xml.ProvisionGuestAgent true if params[:bootstrap_proto] == "cloud-api"
+        end
       end
       builder.doc
     end
 
     def create(params, roleXML)
       servicecall = "hostedservices/#{params[:azure_dns_name]}/deployments" +
-      "/#{params['deploy_name']}/roles"
+        "/#{params['deploy_name']}/roles"
       @connection.query_azure(servicecall, "post", roleXML.to_xml)
     end
 
@@ -576,31 +577,31 @@ module Azure
       ## using the required values of the updated role_xml
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.PersistentVMRole(
-          'xmlns' => 'http://schemas.microsoft.com/windowsazure',
-          'xmlns:i' => 'http://www.w3.org/2001/XMLSchema-instance'
-        ) {
-            xml.ConfigurationSets role_xml.at_css('ConfigurationSets').children if !role_xml.at_css('ConfigurationSets').nil?
-            xml.ResourceExtensionReferences role_xml.at_css('ResourceExtensionReferences').children if !role_xml.at_css('ResourceExtensionReferences').nil?
-            xml.AvailabilitySetName role_xml.at_css('AvailabilitySetName').children if !role_xml.at_css('AvailabilitySetName').nil?
-            xml.DataVirtualHardDisks role_xml.at_css('DataVirtualHardDisks').children if !role_xml.at_css('DataVirtualHardDisks').nil?
-            xml.OSVirtualHardDisk role_xml.at_css('OSVirtualHardDisk').children if !role_xml.at_css('OSVirtualHardDisk').nil?
-            xml.RoleSize role_xml.at_css('RoleSize').children if !role_xml.at_css('RoleSize').nil?
-            xml.ProvisionGuestAgent role_xml.at_css('ProvisionGuestAgent').children if !role_xml.at_css('ProvisionGuestAgent').nil?
-        }
+          "xmlns" => "http://schemas.microsoft.com/windowsazure",
+          "xmlns:i" => "http://www.w3.org/2001/XMLSchema-instance"
+        ) do
+          xml.ConfigurationSets role_xml.at_css("ConfigurationSets").children if !role_xml.at_css("ConfigurationSets").nil?
+          xml.ResourceExtensionReferences role_xml.at_css("ResourceExtensionReferences").children if !role_xml.at_css("ResourceExtensionReferences").nil?
+          xml.AvailabilitySetName role_xml.at_css("AvailabilitySetName").children if !role_xml.at_css("AvailabilitySetName").nil?
+          xml.DataVirtualHardDisks role_xml.at_css("DataVirtualHardDisks").children if !role_xml.at_css("DataVirtualHardDisks").nil?
+          xml.OSVirtualHardDisk role_xml.at_css("OSVirtualHardDisk").children if !role_xml.at_css("OSVirtualHardDisk").nil?
+          xml.RoleSize role_xml.at_css("RoleSize").children if !role_xml.at_css("RoleSize").nil?
+          xml.ProvisionGuestAgent role_xml.at_css("ProvisionGuestAgent").children if !role_xml.at_css("ProvisionGuestAgent").nil?
+        end
       end
 
-      builder.doc.to_xml.gsub("&lt\;","<").gsub("&gt\;",">")
+      builder.doc.to_xml.gsub("&lt\;", "<").gsub("&gt\;", ">")
     end
 
     def update_role_xml_for_extension(roleXML, params)
       ## check if 'ResourceExtensionReferences' node already exist in the XML,
       ## if no add it, else retrieve the object of the existing node
-      add_resource_extension_references = roleXML.at_css('ResourceExtensionReferences').nil?
+      add_resource_extension_references = roleXML.at_css("ResourceExtensionReferences").nil?
 
       if add_resource_extension_references
-        resource_extension_references = Nokogiri::XML::Node.new('ResourceExtensionReferences', roleXML)
+        resource_extension_references = Nokogiri::XML::Node.new("ResourceExtensionReferences", roleXML)
       else
-        resource_extension_references = roleXML.css('ResourceExtensionReferences')
+        resource_extension_references = roleXML.css("ResourceExtensionReferences")
       end
 
       ## check if Azure Chef Extension is already installed on the given server,
@@ -608,8 +609,8 @@ module Azure
       ## already installed
       ext = nil
       if !add_resource_extension_references
-        if !resource_extension_references.at_css('ReferenceName').nil?
-          resource_extension_references.css('ReferenceName').each { |node| ext = node if node.content == params[:chef_extension] }
+        if !resource_extension_references.at_css("ReferenceName").nil?
+          resource_extension_references.css("ReferenceName").each { |node| ext = node if node.content == params[:chef_extension] }
         end
       end
 
@@ -617,56 +618,56 @@ module Azure
 
       ## create Azure Chef Extension config and add it in the role_xml
       if add_resource_extension_reference
-        resource_extension_reference = Nokogiri::XML::Node.new('ResourceExtensionReference', roleXML)
+        resource_extension_reference = Nokogiri::XML::Node.new("ResourceExtensionReference", roleXML)
 
-        reference_name = Nokogiri::XML::Node.new('ReferenceName', roleXML)
+        reference_name = Nokogiri::XML::Node.new("ReferenceName", roleXML)
         reference_name.content = params[:chef_extension]
         resource_extension_reference.add_child(reference_name)
 
-        publisher = Nokogiri::XML::Node.new('Publisher', roleXML)
+        publisher = Nokogiri::XML::Node.new("Publisher", roleXML)
         publisher.content = params[:chef_extension_publisher]
         resource_extension_reference.add_child(publisher)
 
-        name = Nokogiri::XML::Node.new('Name', roleXML)
+        name = Nokogiri::XML::Node.new("Name", roleXML)
         name.content = params[:chef_extension]
         resource_extension_reference.add_child(name)
 
-        version = Nokogiri::XML::Node.new('Version', roleXML)
+        version = Nokogiri::XML::Node.new("Version", roleXML)
         version.content = params[:chef_extension_version]
         resource_extension_reference.add_child(version)
 
-        resource_extension_parameter_values = Nokogiri::XML::Node.new('ResourceExtensionParameterValues', roleXML)
+        resource_extension_parameter_values = Nokogiri::XML::Node.new("ResourceExtensionParameterValues", roleXML)
         if params[:chef_extension_public_param]
-          resource_extension_parameter_value = Nokogiri::XML::Node.new('ResourceExtensionParameterValue', roleXML)
+          resource_extension_parameter_value = Nokogiri::XML::Node.new("ResourceExtensionParameterValue", roleXML)
 
-          key = Nokogiri::XML::Node.new('Key', roleXML)
-          key.content = 'PublicParams'
+          key = Nokogiri::XML::Node.new("Key", roleXML)
+          key.content = "PublicParams"
           resource_extension_parameter_value.add_child(key)
 
-          value = Nokogiri::XML::Node.new('Value', roleXML)
+          value = Nokogiri::XML::Node.new("Value", roleXML)
           value.content = Base64.encode64(params[:chef_extension_public_param].to_json)
           resource_extension_parameter_value.add_child(value)
 
-          type = Nokogiri::XML::Node.new('Type', roleXML)
-          type.content = 'Public'
+          type = Nokogiri::XML::Node.new("Type", roleXML)
+          type.content = "Public"
           resource_extension_parameter_value.add_child(type)
 
           resource_extension_parameter_values.add_child(resource_extension_parameter_value)
         end
 
         if params[:chef_extension_private_param]
-          resource_extension_parameter_value = Nokogiri::XML::Node.new('ResourceExtensionParameterValue', roleXML)
+          resource_extension_parameter_value = Nokogiri::XML::Node.new("ResourceExtensionParameterValue", roleXML)
 
-          key = Nokogiri::XML::Node.new('Key', roleXML)
-          key.content = 'PrivateParams'
+          key = Nokogiri::XML::Node.new("Key", roleXML)
+          key.content = "PrivateParams"
           resource_extension_parameter_value.add_child(key)
 
-          value = Nokogiri::XML::Node.new('Value', roleXML)
+          value = Nokogiri::XML::Node.new("Value", roleXML)
           value.content = Base64.encode64(params[:chef_extension_private_param].to_json)
           resource_extension_parameter_value.add_child(value)
 
-          type = Nokogiri::XML::Node.new('Type', roleXML)
-          type.content = 'Private'
+          type = Nokogiri::XML::Node.new("Type", roleXML)
+          type.content = "Private"
           resource_extension_parameter_value.add_child(type)
 
           resource_extension_parameter_values.add_child(resource_extension_parameter_value)
@@ -674,8 +675,8 @@ module Azure
 
         resource_extension_reference.add_child(resource_extension_parameter_values)
 
-        state = Nokogiri::XML::Node.new('State', roleXML)
-        state.content = 'enable'
+        state = Nokogiri::XML::Node.new("State", roleXML)
+        state.content = "enable"
         resource_extension_reference.add_child(state)
 
         if add_resource_extension_references
@@ -686,13 +687,13 @@ module Azure
 
         roleXML.add_child(resource_extension_references) if add_resource_extension_references
 
-        add_provision_guest_agent = roleXML.at_css('ProvisionGuestAgent').nil?
+        add_provision_guest_agent = roleXML.at_css("ProvisionGuestAgent").nil?
 
         if add_provision_guest_agent
-          provision_guest_agent = Nokogiri::XML::Node.new('ProvisionGuestAgent', roleXML)
+          provision_guest_agent = Nokogiri::XML::Node.new("ProvisionGuestAgent", roleXML)
           provision_guest_agent.content = true
         else
-          provision_guest_agent = roleXML.css('ProvisionGuestAgent')
+          provision_guest_agent = roleXML.css("ProvisionGuestAgent")
           provision_guest_agent.first.content = true
         end
 
@@ -707,12 +708,12 @@ module Azure
     def update(name, params, roleXML)
       puts "Updating server role..."
       servicecall = "hostedservices/#{params[:azure_dns_name]}" +
-      "/deployments/#{params[:deploy_name]}/roles/#{name}"
-      ret_val = @connection.query_azure(servicecall, 'put', roleXML, '', true, true, 'application/xml')
+        "/deployments/#{params[:deploy_name]}/roles/#{name}"
+      ret_val = @connection.query_azure(servicecall, "put", roleXML, "", true, true, "application/xml")
       error_code, error_message = error_from_response_xml(ret_val)
       if error_code.length > 0
         Chef::Log.debug(ret_val.to_s)
-        raise 'Unable to update role:' + error_code + ' : ' + error_message
+        raise "Unable to update role:" + error_code + " : " + error_message
       end
     end
   end

--- a/lib/azure/service_management/storageaccount.rb
+++ b/lib/azure/service_management/storageaccount.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/utility.rb
+++ b/lib/azure/service_management/utility.rb
@@ -17,7 +17,7 @@
 #
 
 module AzureUtility
-  def xml_content(xml, key, default='')
+  def xml_content(xml, key, default = "")
     content = default
     node = xml.at_css(key)
     if node
@@ -27,15 +27,14 @@ module AzureUtility
   end
 
   def error_from_response_xml(response_xml)
-    error_code_and_message = ['','']
-    error_node = response_xml.at_css('Error')
+    error_code_and_message = ["", ""]
+    error_node = response_xml.at_css("Error")
 
     if error_node
-      error_code_and_message[0] = xml_content(error_node, 'Code')
-      error_code_and_message[1] = xml_content(error_node, 'Message')
+      error_code_and_message[0] = xml_content(error_node, "Code")
+      error_code_and_message[1] = xml_content(error_node, "Message")
     end
 
     error_code_and_message
   end
 end
-

--- a/lib/azure/service_management/utility.rb
+++ b/lib/azure/service_management/utility.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/vnet.rb
+++ b/lib/azure/service_management/vnet.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/azure/service_management/vnet.rb
+++ b/lib/azure/service_management/vnet.rb
@@ -25,8 +25,8 @@ module Azure
     def load
       @vnets ||= begin
         @vnets = {}
-        response = @connection.query_azure('networking/virtualnetwork')
-        response.css('VirtualNetworkSite').each do |vnet|
+        response = @connection.query_azure("networking/virtualnetwork")
+        response.css("VirtualNetworkSite").each do |vnet|
           item = Vnet.new(@connection).parse(vnet)
           @vnets[item.name] = item
         end
@@ -62,73 +62,73 @@ module Azure
     end
 
     def parse(image)
-      @name = image.at_css('Name').content
-      @affinity_group = image.at_css('AffinityGroup') ? image.at_css('AffinityGroup').content : ""
-      @state = image.at_css('State').content
+      @name = image.at_css("Name").content
+      @affinity_group = image.at_css("AffinityGroup") ? image.at_css("AffinityGroup").content : ""
+      @state = image.at_css("State").content
       self
     end
 
     def create(params)
-      response = @connection.query_azure('networking/media')
-      if response.at_css("Error") && response.at_css('Code').text == "ResourceNotFound"
+      response = @connection.query_azure("networking/media")
+      if response.at_css("Error") && response.at_css("Code").text == "ResourceNotFound"
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.NetworkConfiguration(
-            'xmlns'=>'http://schemas.microsoft.com/ServiceHosting/2011/07/NetworkConfiguration'
-          ) {
+            "xmlns" => "http://schemas.microsoft.com/ServiceHosting/2011/07/NetworkConfiguration"
+          ) do
 
-            xml.VirtualNetworkConfiguration {
-              xml.VirtualNetworkSites {
-                xml.VirtualNetworkSite('name' => params[:azure_vnet_name], 'AffinityGroup' => params[:azure_ag_name]) {
+            xml.VirtualNetworkConfiguration do
+              xml.VirtualNetworkSites do
+                xml.VirtualNetworkSite("name" => params[:azure_vnet_name], "AffinityGroup" => params[:azure_ag_name]) do
                   if params[:azure_address_space]
-                    xml.AddressSpace {
+                    xml.AddressSpace do
                       xml.AddressPrefix params[:azure_address_space]
-                    }
+                    end
                   end
-                  xml.Subnets{
-                    xml.Subnet('name' => params[:azure_subnet_name]) {
+                  xml.Subnets do
+                    xml.Subnet("name" => params[:azure_subnet_name]) do
                       xml.AddressPrefix params[:azure_address_space]
-                    }
-                  }
-                }
-              }
-            }
-          }
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
         puts("Creating New Virtual Network: #{params[:azure_vnet_name]}...")
         response = builder
       else
-        vnets = response.css('VirtualNetworkSite')
+        vnets = response.css("VirtualNetworkSite")
         vnet = nil
-        vnets.each { |vn| vnet = vn if vn['name'] == params[:azure_vnet_name] }
+        vnets.each { |vn| vnet = vn if vn["name"] == params[:azure_vnet_name] }
         add = vnet.nil?
-        vnet = Nokogiri::XML::Node.new('VirtualNetworkSite', response) if add
-        vnet['name'] = params[:azure_vnet_name]
-        vnet['AffinityGroup'] = params[:azure_ag_name]
-        if add || !vnet.at_css('AddressSpace')    ## create a new AddressSpace block in XML if VNet or AddressSpace block does not already exist
-          addr_space = Nokogiri::XML::Node.new('AddressSpace', response)
-        else    ## retrieve object of existing AddressSpace if VNet or AddressSpace already exist
-          addr_space = vnet.at_css('AddressSpace')
+        vnet = Nokogiri::XML::Node.new("VirtualNetworkSite", response) if add
+        vnet["name"] = params[:azure_vnet_name]
+        vnet["AffinityGroup"] = params[:azure_ag_name]
+        if add || !vnet.at_css("AddressSpace") ## create a new AddressSpace block in XML if VNet or AddressSpace block does not already exist
+          addr_space = Nokogiri::XML::Node.new("AddressSpace", response)
+        else ## retrieve object of existing AddressSpace if VNet or AddressSpace already exist
+          addr_space = vnet.at_css("AddressSpace")
         end
-        addr_prefix = Nokogiri::XML::Node.new('AddressPrefix', response)
+        addr_prefix = Nokogiri::XML::Node.new("AddressPrefix", response)
         addr_prefix.content = params[:azure_address_space]
-        if add || !vnet.at_css('Subnets')   ## create a new Subnets block in XML if VNet or Subnets block does not already exist
-          subnets = Nokogiri::XML::Node.new('Subnets', response)
-        else    ## retrieve object of existing Subnets if VNet or Subnets already exist
-          subnets = vnet.at_css('Subnets')
+        if add || !vnet.at_css("Subnets") ## create a new Subnets block in XML if VNet or Subnets block does not already exist
+          subnets = Nokogiri::XML::Node.new("Subnets", response)
+        else ## retrieve object of existing Subnets if VNet or Subnets already exist
+          subnets = vnet.at_css("Subnets")
         end
-        saddr_prefix = Nokogiri::XML::Node.new('AddressPrefix', response)
+        saddr_prefix = Nokogiri::XML::Node.new("AddressPrefix", response)
         saddr_prefix.content = params[:azure_address_space]
-        subnet = Nokogiri::XML::Node.new('Subnet', response)
-        subnet['name'] = params[:azure_subnet_name]
+        subnet = Nokogiri::XML::Node.new("Subnet", response)
+        subnet["name"] = params[:azure_subnet_name]
         subnet.children = saddr_prefix
         subnets.children = subnet
-        vnet.add_child(subnets) if add || !vnet.at_css('Subnets')
+        vnet.add_child(subnets) if add || !vnet.at_css("Subnets")
         addr_space.children = addr_prefix
-        vnet.add_child(addr_space) if add || !vnet.at_css('AddressSpace')
+        vnet.add_child(addr_space) if add || !vnet.at_css("AddressSpace")
         vnets.last.add_next_sibling(vnet) if add
         puts("Updating existing Virtual Network: #{params[:azure_vnet_name]}...")
       end
-      @connection.query_azure('networking/media', 'put', response.to_xml)
+      @connection.query_azure("networking/media", "put", response.to_xml)
     end
   end
 end

--- a/lib/chef/knife/azure_ag_create.rb
+++ b/lib/chef/knife/azure_ag_create.rb
@@ -16,36 +16,36 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureAgCreate < Knife
       include Knife::AzureBase
 
-      banner 'knife azure ag create (options)'
+      banner "knife azure ag create (options)"
 
       option :azure_affinity_group,
-        :short => '-a GROUP',
-        :long => '--azure-affinity-group GROUP',
-        :description => 'Specifies new affinity group name.'
+        :short => "-a GROUP",
+        :long => "--azure-affinity-group GROUP",
+        :description => "Specifies new affinity group name."
 
       option :azure_ag_desc,
-        :long => '--azure-ag-desc DESC',
-        :description => 'Optional. Description for new affinity group.'
+        :long => "--azure-ag-desc DESC",
+        :description => "Optional. Description for new affinity group."
 
       option :azure_service_location,
-        :short => '-m LOCATION',
-        :long => '--azure-service-location LOCATION',
-        :description => 'Specifies the geographic location - the name of '\
-                        'the data center location that is valid for your '\
-                        'subscription. Eg: West US, East US, '\
-                        'East Asia, Southeast Asia, North Europe, West Europe'
+        :short => "-m LOCATION",
+        :long => "--azure-service-location LOCATION",
+        :description => "Specifies the geographic location - the name of "\
+                        "the data center location that is valid for your "\
+                        "subscription. Eg: West US, East US, "\
+                        "East Asia, Southeast Asia, North Europe, West Europe"
 
       def run
         $stdout.sync = true
 
-        Chef::Log.info('validating...')
+        Chef::Log.info("validating...")
         validate_asm_keys!(:azure_affinity_group,
                    :azure_service_location)
 
@@ -57,9 +57,9 @@ class Chef
 
         rsp = service.create_affinity_group(params)
         print "\n"
-        if rsp.at_css('Status').nil?
-          if rsp.at_css('Code').nil? || rsp.at_css('Message').nil?
-            puts 'Unknown Error. try -VV'
+        if rsp.at_css("Status").nil?
+          if rsp.at_css("Code").nil? || rsp.at_css("Message").nil?
+            puts "Unknown Error. try -VV"
           else
             puts "#{rsp.at_css('Code').content}: "\
                  "#{rsp.at_css('Message').content}"

--- a/lib/chef/knife/azure_ag_create.rb
+++ b/lib/chef/knife/azure_ag_create.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_ag_list.rb
+++ b/lib/chef/knife/azure_ag_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_ag_list.rb
+++ b/lib/chef/knife/azure_ag_list.rb
@@ -16,14 +16,14 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureAgList < Knife
       include Knife::AzureBase
 
-      banner 'knife azure ag list (options)'
+      banner "knife azure ag list (options)"
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -1,7 +1,7 @@
 
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Copyright:: Copyright (c) 2011 Opscode, Inc.
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: Copyright 2011-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_base.rb
+++ b/lib/chef/knife/azure_base.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
-require 'azure/service_management/ASM_interface'
+require "chef/knife"
+require "azure/service_management/ASM_interface"
 
 class Chef
   class Knife
@@ -31,8 +31,8 @@ class Chef
         includer.class_eval do
 
           deps do
-            require 'readline'
-            require 'chef/json_compat'
+            require "readline"
+            require "chef/json_compat"
           end
 
           option :azure_subscription_id,
@@ -70,7 +70,7 @@ class Chef
         images = service.list_images
         target_image = images.select { |i| i.name == locate_config_value(:azure_source_image) }
         unless target_image[0].nil?
-          return target_image[0].os == 'Windows'
+          return target_image[0].os == "Windows"
         else
           ui.error("Invalid image. Use the command \"knife azure image list\" to verify the image name")
           exit 1
@@ -95,7 +95,7 @@ class Chef
         config[key] || Chef::Config[:knife][key]
       end
 
-      def msg_pair(label, value, color=:cyan)
+      def msg_pair(label, value, color = :cyan)
         if value && !value.to_s.empty?
           puts "#{ui.color(label, color)}: #{value}"
         end
@@ -103,24 +103,24 @@ class Chef
 
       def msg_server_summary(server)
         puts "\n"
-        msg_pair('DNS Name', server.hostedservicename + ".cloudapp.net")
-        msg_pair('VM Name', server.name)
-        msg_pair('Size', server.size)
-        msg_pair('Azure Source Image', locate_config_value(:azure_source_image))
-        msg_pair('Azure Service Location', locate_config_value(:azure_service_location))
-        msg_pair('Public Ip Address', server.publicipaddress)
-        msg_pair('Private Ip Address', server.ipaddress)
-        msg_pair('SSH Port', server.sshport) unless server.sshport.nil?
-        msg_pair('WinRM Port', server.winrmport) unless server.winrmport.nil?
-        msg_pair('TCP Ports', server.tcpports) unless server.tcpports.nil? or server.tcpports.empty?
-        msg_pair('UDP Ports', server.udpports) unless server.udpports.nil? or server.udpports.empty?
-        msg_pair('Environment', locate_config_value(:environment) || '_default')
-        msg_pair('Runlist', locate_config_value(:run_list)) unless locate_config_value(:run_list).empty?
+        msg_pair("DNS Name", server.hostedservicename + ".cloudapp.net")
+        msg_pair("VM Name", server.name)
+        msg_pair("Size", server.size)
+        msg_pair("Azure Source Image", locate_config_value(:azure_source_image))
+        msg_pair("Azure Service Location", locate_config_value(:azure_service_location))
+        msg_pair("Public Ip Address", server.publicipaddress)
+        msg_pair("Private Ip Address", server.ipaddress)
+        msg_pair("SSH Port", server.sshport) unless server.sshport.nil?
+        msg_pair("WinRM Port", server.winrmport) unless server.winrmport.nil?
+        msg_pair("TCP Ports", server.tcpports) unless server.tcpports.nil? || server.tcpports.empty?
+        msg_pair("UDP Ports", server.udpports) unless server.udpports.nil? || server.udpports.empty?
+        msg_pair("Environment", locate_config_value(:environment) || "_default")
+        msg_pair("Runlist", locate_config_value(:run_list)) unless locate_config_value(:run_list).empty?
         puts "\n"
       end
 
       def pretty_key(key)
-        key.to_s.gsub(/_/, ' ').gsub(/\w+/){ |w| (w =~ /(ssh)|(aws)/i) ? w.upcase  : w.capitalize }
+        key.to_s.tr("_", " ").gsub(/\w+/) { |w| (w =~ /(ssh)|(aws)/i) ? w.upcase : w.capitalize }
       end
 
       # validate command pre-requisites (cli options)
@@ -172,12 +172,12 @@ class Chef
           exit 1
         end
 
-        if locate_config_value(:extended_logs) && locate_config_value(:bootstrap_protocol) != 'cloud-api'
+        if locate_config_value(:extended_logs) && locate_config_value(:bootstrap_protocol) != "cloud-api"
           ui.error("--extended-logs option only works with --bootstrap-protocol cloud-api")
           exit 1
         end
 
-        if locate_config_value(:bootstrap_protocol) == 'cloud-api' && locate_config_value(:azure_vm_name).nil? && locate_config_value(:azure_dns_name).nil?
+        if locate_config_value(:bootstrap_protocol) == "cloud-api" && locate_config_value(:azure_vm_name).nil? && locate_config_value(:azure_dns_name).nil?
           ui.error("Specifying the DNS name using --azure-dns-name or VM name using --azure-vm-name option is required with --bootstrap-protocol cloud-api")
           exit 1
         end
@@ -187,7 +187,7 @@ class Chef
             raise ArgumentError, "The daemon option is only supported for Windows nodes."
           end
 
-          unless  locate_config_value(:bootstrap_protocol) == 'cloud-api'
+          unless  locate_config_value(:bootstrap_protocol) == "cloud-api"
             raise ArgumentError, "The --daemon option requires the use of --bootstrap-protocol cloud-api"
           end
 
@@ -205,7 +205,7 @@ class Chef
             errors << "You did not provide a valid '#{pretty_key(k)}' value. Please set knife[:#{k}] in your knife.rb or pass as an option."
           end
         end
-        if errors.each{|e| ui.error(e)}.any?
+        if errors.each { |e| ui.error(e) }.any?
           exit 1
         end
       end
@@ -215,11 +215,11 @@ class Chef
         mandatory_keys = [:azure_subscription_id, :azure_mgmt_cert, :azure_api_host_name]
         keys.concat(mandatory_keys)
 
-        if(locate_config_value(:azure_mgmt_cert) != nil)
+        if !locate_config_value(:azure_mgmt_cert).nil?
           config[:azure_mgmt_cert] = File.read find_file(locate_config_value(:azure_mgmt_cert))
         end
 
-        if(locate_config_value(:azure_publish_settings_file) != nil)
+        if !locate_config_value(:azure_publish_settings_file).nil?
           parse_publish_settings_file(locate_config_value(:azure_publish_settings_file))
         elsif locate_config_value(:azure_subscription_id).nil? && locate_config_value(:azure_mgmt_cert).nil? && locate_config_value(:azure_api_host_name).nil?
           azureprofile_file = get_azure_profile_file_path
@@ -231,10 +231,10 @@ class Chef
       end
 
       def parse_publish_settings_file(filename)
-        require 'nokogiri'
-        require 'base64'
-        require 'openssl'
-        require 'uri'
+        require "nokogiri"
+        require "base64"
+        require "openssl"
+        require "uri"
         begin
           doc = Nokogiri::XML(File.open(find_file(filename)))
           profile = doc.at_css("PublishProfile")
@@ -258,23 +258,23 @@ class Chef
       end
 
       def get_azure_profile_file_path
-        '~/.azure/azureProfile.json'
+        "~/.azure/azureProfile.json"
       end
 
       def parse_azure_profile(filename, errors)
-        require 'openssl'
-        require 'uri'
+        require "openssl"
+        require "uri"
         errors = [] if errors.nil?
         azure_profile = File.read(File.expand_path(filename))
         azure_profile = JSON.parse(azure_profile)
         default_subscription = get_default_subscription(azure_profile)
-        if default_subscription.has_key?('id') && default_subscription.has_key?('managementCertificate') && default_subscription.has_key?('managementEndpointUrl')
+        if default_subscription.has_key?("id") && default_subscription.has_key?("managementCertificate") && default_subscription.has_key?("managementEndpointUrl")
 
-          Chef::Config[:knife][:azure_subscription_id] = default_subscription['id']
-          mgmt_key = OpenSSL::PKey::RSA.new(default_subscription['managementCertificate']['key']).to_pem
-          mgmt_cert = OpenSSL::X509::Certificate.new(default_subscription['managementCertificate']['cert']).to_pem
+          Chef::Config[:knife][:azure_subscription_id] = default_subscription["id"]
+          mgmt_key = OpenSSL::PKey::RSA.new(default_subscription["managementCertificate"]["key"]).to_pem
+          mgmt_cert = OpenSSL::X509::Certificate.new(default_subscription["managementCertificate"]["cert"]).to_pem
           Chef::Config[:knife][:azure_mgmt_cert] = mgmt_key + mgmt_cert
-          Chef::Config[:knife][:azure_api_host_name] = URI(default_subscription['managementEndpointUrl']).host
+          Chef::Config[:knife][:azure_api_host_name] = URI(default_subscription["managementEndpointUrl"]).host
         else
           errors << "Check if values set for 'id', 'managementCertificate', 'managementEndpointUrl' in -> #{filename} for 'defaultSubscription'. \n  OR "
         end
@@ -283,8 +283,8 @@ class Chef
 
       def get_default_subscription(azure_profile)
         first_subscription_as_default = nil
-        azure_profile['subscriptions'].each do |subscription|
-          if subscription['isDefault']
+        azure_profile["subscriptions"].each do |subscription|
+          if subscription["isDefault"]
             Chef::Log.info("Default subscription \'#{subscription['name']}\'' selected.")
             return subscription
           end
@@ -295,7 +295,7 @@ class Chef
         if first_subscription_as_default
           Chef::Log.info("First subscription \'#{subscription['name']}\' selected as default.")
         else
-          Chef::Log.info('No subscriptions found.')
+          Chef::Log.info("No subscriptions found.")
           exit 1
         end
         first_subscription_as_default
@@ -308,10 +308,10 @@ class Chef
           file = name
         elsif config_dir && File.exist?(File.join(config_dir, name))
           file = File.join(config_dir, name)
-        elsif File.exist?(File.join(ENV['HOME'], '.chef', name))
-          file = File.join(ENV['HOME'], '.chef', name)
+        elsif File.exist?(File.join(ENV["HOME"], ".chef", name))
+          file = File.join(ENV["HOME"], ".chef", name)
         else
-          ui.error('Unable to find file - ' + name)
+          ui.error("Unable to find file - " + name)
           exit 1
         end
         file
@@ -327,15 +327,15 @@ class Chef
       def fetch_role
         deployment = fetch_deployment
 
-        if deployment.at_css('Deployment Name') != nil
-          role_list_xml =  deployment.css('RoleInstanceList RoleInstance')
+        if deployment.at_css("Deployment Name") != nil
+          role_list_xml = deployment.css("RoleInstanceList RoleInstance")
           role_list_xml.each do |role|
             if role.at_css("RoleName").text == (locate_config_value(:azure_vm_name) || @name_args[0])
               return role
             end
           end
         end
-        return nil
+        nil
       end
 
       def fetch_extension(role)
@@ -347,7 +347,7 @@ class Chef
             return ext
           end
         end
-        return nil
+        nil
       end
 
       def fetch_substatus(extension)
@@ -358,19 +358,19 @@ class Chef
             return substatus
           end
         end
-        return nil
+        nil
       end
 
       def fetch_chef_client_logs(fetch_process_start_time, fetch_process_wait_timeout)
         ## fetch server details ##
         role = fetch_role
-        if role != nil
+        if !role.nil?
           ## fetch Chef Extension details deployed on the server ##
           ext = fetch_extension(role)
-          if ext != nil
+          if !ext.nil?
             ## fetch substatus field which contains the chef-client run logs ##
             substatus = fetch_substatus(ext)
-            if substatus != nil
+            if !substatus.nil?
               ## chef-client run logs becomes available ##
               name = substatus.at_css("Name").text
               status = substatus.at_css("Status").text
@@ -393,11 +393,11 @@ class Chef
               end
               puts "#{ui.color(status, color, :bold)}"
               puts "----> chef-client run logs: "
-              puts "\n#{message}\n"  ## message field of substatus contains the chef-client run logs ##
+              puts "\n#{message}\n" ## message field of substatus contains the chef-client run logs ##
             else
               ## unavailability of the substatus field indicates that chef-client run is not completed yet on the server ##
               fetch_process_wait_time = ((Time.now - fetch_process_start_time) / 60).round
-              if fetch_process_wait_time <= fetch_process_wait_timeout  ## wait for maximum 30 minutes until chef-client run logs becomes available ##
+              if fetch_process_wait_time <= fetch_process_wait_timeout ## wait for maximum 30 minutes until chef-client run logs becomes available ##
                 print "#{ui.color('.', :bold)}"
                 sleep 30
                 fetch_chef_client_logs(fetch_process_start_time, fetch_process_wait_timeout)

--- a/lib/chef/knife/azure_image_list.rb
+++ b/lib/chef/knife/azure_image_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
@@ -34,24 +34,22 @@ class Chef
         :boolean => true,
         :description => "Show all the fields of the images"
 
-
       def run
         $stdout.sync = true
 
         validate_asm_keys!
         items = service.list_images
 
-        image_labels = !locate_config_value(:show_all_fields) ? ['Name', 'OS', 'Location'] : ['Name', 'Category', 'Label', 'OS', 'Location']
-        image_list =  image_labels.map {|label| ui.color(label, :bold)}
+        image_labels = !locate_config_value(:show_all_fields) ? %w{Name OS Location} : %w{Name Category Label OS Location}
+        image_list =  image_labels.map { |label| ui.color(label, :bold) }
 
-        image_items = image_labels.map {|item| item.downcase }
+        image_items = image_labels.map { |item| item.downcase }
         items.each do |image|
-         image_items.each {|item| image_list << image.send(item).to_s }
+          image_items.each { |item| image_list << image.send(item).to_s }
         end
 
         puts "\n"
         puts ui.list(image_list, :uneven_columns_across, !locate_config_value(:show_all_fields) ? 3 : 5)
-
       end
     end
   end

--- a/lib/chef/knife/azure_image_list.rb
+++ b/lib/chef/knife/azure_image_list.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Adam Jacob (<adam@chef.io>)
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_internal-lb_create.rb
+++ b/lib/chef/knife/azure_internal-lb_create.rb
@@ -16,28 +16,28 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureInternalLbCreate < Knife
       include Knife::AzureBase
 
-      banner 'knife azure internal lb create (options)'
+      banner "knife azure internal lb create (options)"
 
       option :azure_load_balancer,
-        :short => '-n NAME',
-        :long => '--azure-load-balancer NAME',
-        :description => 'Required. Specifies new load balancer name.'
+        :short => "-n NAME",
+        :long => "--azure-load-balancer NAME",
+        :description => "Required. Specifies new load balancer name."
 
       option :azure_lb_static_vip,
-        :long => '--azure-lb-static-vip VIP',
-        :description => 'Optional. The Virtual IP that will be used for the load balancer.'
+        :long => "--azure-lb-static-vip VIP",
+        :description => "Optional. The Virtual IP that will be used for the load balancer."
 
       option :azure_subnet_name,
-        :long => '--azure-subnet-name SUBNET_NAME',
-        :description => 'Required if static VIP is set. Specifies the subnet name '\
-                        'the load balancer is located in.'
+        :long => "--azure-subnet-name SUBNET_NAME",
+        :description => "Required if static VIP is set. Specifies the subnet name "\
+                        "the load balancer is located in."
 
       option :azure_dns_name,
         :long => "--azure-dns-name DNS_NAME",
@@ -46,7 +46,7 @@ class Chef
       def run
         $stdout.sync = true
 
-        Chef::Log.info('validating...')
+        Chef::Log.info("validating...")
         validate_asm_keys!(:azure_load_balancer)
 
         params = {
@@ -58,9 +58,9 @@ class Chef
 
         rsp = service.create_internal_lb(params)
         print "\n"
-        if rsp.at_css('Status').nil?
-          if rsp.at_css('Code').nil? || rsp.at_css('Message').nil?
-            puts 'Unknown Error. try -VV'
+        if rsp.at_css("Status").nil?
+          if rsp.at_css("Code").nil? || rsp.at_css("Message").nil?
+            puts "Unknown Error. try -VV"
           else
             puts "#{rsp.at_css('Code').content}: "\
                  "#{rsp.at_css('Message').content}"

--- a/lib/chef/knife/azure_internal-lb_create.rb
+++ b/lib/chef/knife/azure_internal-lb_create.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aiman Alsari (aiman.alsari@gmail.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_internal-lb_list.rb
+++ b/lib/chef/knife/azure_internal-lb_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aiman Alsari (aiman.alsari@gmail.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_internal-lb_list.rb
+++ b/lib/chef/knife/azure_internal-lb_list.rb
@@ -16,14 +16,14 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureInternalLbList < Knife
       include Knife::AzureBase
 
-      banner 'knife azure internal lb list (options)'
+      banner "knife azure internal lb list (options)"
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -18,11 +18,11 @@
 # limitations under the License.
 #
 
-require 'chef/knife/azure_base'
-require 'chef/knife/winrm_base'
-require 'securerandom'
-require 'chef/knife/bootstrap/bootstrap_options'
-require 'chef/knife/bootstrap/bootstrapper'
+require "chef/knife/azure_base"
+require "chef/knife/winrm_base"
+require "securerandom"
+require "chef/knife/bootstrap/bootstrap_options"
+require "chef/knife/bootstrap/bootstrapper"
 
 class Chef
   class Knife
@@ -34,18 +34,17 @@ class Chef
       include Knife::Bootstrap::Bootstrapper
 
       deps do
-        require 'readline'
-        require 'chef/json_compat'
-        require 'chef/knife/bootstrap'
-        require 'chef/knife/bootstrap_windows_ssh'
-        require 'chef/knife/core/windows_bootstrap_context'
+        require "readline"
+        require "chef/json_compat"
+        require "chef/knife/bootstrap"
+        require "chef/knife/bootstrap_windows_ssh"
+        require "chef/knife/core/windows_bootstrap_context"
         Chef::Knife::Bootstrap.load_deps
       end
 
       banner "knife azure server create (options)"
 
       attr_accessor :initial_sleep_delay
-
 
       option :bootstrap_protocol,
         :long => "--bootstrap-protocol protocol",
@@ -71,7 +70,7 @@ class Chef
         :long        => "--node-ssl-verify-mode [peer|none]",
         :description => "Whether or not to verify the SSL cert for all HTTPS requests.",
         :proc        => Proc.new { |v|
-          valid_values = ["none", "peer"]
+          valid_values = %w{none peer}
           unless valid_values.include?(v)
             raise "Invalid value '#{v}' for --node-ssl-verify-mode. Valid values are: #{valid_values.join(", ")}"
           end
@@ -132,7 +131,7 @@ class Chef
         :short => "-z SIZE",
         :long => "--azure-vm-size SIZE",
         :description => "Optional. Size of virtual machine (ExtraSmall, Small, Medium, Large, ExtraLarge)",
-        :default => 'Small',
+        :default => "Small",
         :proc => Proc.new { |si| Chef::Config[:knife][:azure_vm_size] = si }
 
       option :azure_availability_set,
@@ -263,14 +262,14 @@ class Chef
             end
           end
         rescue Exception => e
-          Chef::Log.error("#{e.to_s}")
-          raise 'Verify connectivity to Azure and subscription resource limit compliance (e.g. maximum CPU core limits) and try again.'
+          Chef::Log.error("#{e}")
+          raise "Verify connectivity to Azure and subscription resource limit compliance (e.g. maximum CPU core limits) and try again."
         end
       end
 
       def wait_for_virtual_machine_state(vm_status_goal, total_wait_time_in_minutes, retry_interval_in_seconds)
-        vm_status_ordering = {:vm_status_not_detected => 0, :vm_status_provisioning => 1, :vm_status_ready => 2}
-        vm_status_description = {:vm_status_not_detected => 'any', :vm_status_provisioning => 'provisioning', :vm_status_ready => 'ready'}
+        vm_status_ordering = { :vm_status_not_detected => 0, :vm_status_provisioning => 1, :vm_status_ready => 2 }
+        vm_status_description = { :vm_status_not_detected => "any", :vm_status_provisioning => "provisioning", :vm_status_ready => "ready" }
 
         print ui.color("Waiting for virtual machine to reach status '#{vm_status_description[vm_status_goal]}'", :magenta)
 
@@ -283,7 +282,7 @@ class Chef
         begin
           vm_status = get_virtual_machine_status()
           vm_ready = vm_status_ordering[vm_status] >= vm_status_ordering[vm_status_goal]
-          print '.'
+          print "."
           sleep retry_interval_in_seconds if !vm_ready
           polling_attempts += 1
         end until vm_ready || polling_attempts >= max_polling_attempts
@@ -298,10 +297,9 @@ class Chef
       end
 
       def wait_for_resource_extension_state(extension_status_goal, total_wait_time_in_minutes, retry_interval_in_seconds)
+        extension_status_ordering = { :extension_status_not_detected => 0, :wagent_provisioning => 1, :extension_installing => 2, :extension_provisioning => 3, :extension_ready => 4 }
 
-        extension_status_ordering = {:extension_status_not_detected => 0, :wagent_provisioning => 1, :extension_installing => 2, :extension_provisioning => 3, :extension_ready => 4}
-
-        status_description = {:extension_status_not_detected => 'any', :wagent_provisioning => 'wagent provisioning', :extension_installing => "installing", :extension_provisioning => "provisioning", :extension_ready => "ready" }
+        status_description = { :extension_status_not_detected => "any", :wagent_provisioning => "wagent provisioning", :extension_installing => "installing", :extension_provisioning => "provisioning", :extension_ready => "ready" }
 
         print ui.color("Waiting for Resource Extension to reach status '#{status_description[extension_status_goal]}'", :magenta)
 
@@ -313,7 +311,7 @@ class Chef
         begin
           extension_status = get_extension_status()
           extension_ready = extension_status_ordering[extension_status[:status]] >= extension_status_ordering[extension_status_goal]
-          print '.'
+          print "."
           sleep retry_interval_in_seconds if !extension_ready
           polling_attempts += 1
         end until extension_ready || polling_attempts >= max_polling_attempts
@@ -328,11 +326,11 @@ class Chef
         extension_status[:status]
       end
 
-      def get_virtual_machine_status()
+      def get_virtual_machine_status
         role = service.get_role_server(locate_config_value(:azure_dns_name), locate_config_value(:azure_vm_name))
         unless role.nil?
-          Chef::Log.debug("Role status is #{role.status.to_s}")
-          if  "ReadyRole".eql? role.status.to_s
+          Chef::Log.debug("Role status is #{role.status}")
+          if "ReadyRole".eql? role.status.to_s
             return :vm_status_ready
           elsif "Provisioning".eql? role.status.to_s
             return :vm_status_provisioning
@@ -340,16 +338,16 @@ class Chef
             return :vm_status_not_detected
           end
         end
-        return :vm_status_not_detected
+        :vm_status_not_detected
       end
 
-      def get_extension_status()
+      def get_extension_status
         deployment_name = service.deployment_name(locate_config_value(:azure_dns_name))
         deployment = service.deployment("hostedservices/#{locate_config_value(:azure_dns_name)}/deployments/#{deployment_name}")
         extension_status = Hash.new
 
-        if deployment.at_css('Deployment Name') != nil
-          role_list_xml =  deployment.css('RoleInstanceList RoleInstance')
+        if deployment.at_css("Deployment Name") != nil
+          role_list_xml = deployment.css("RoleInstanceList RoleInstance")
           role_list_xml.each do |role|
             if role.at_css("RoleName").text == locate_config_value(:azure_vm_name)
               lnx_waagent_fail_msg = "Failed to deserialize the status reported by the Guest Agent"
@@ -370,7 +368,7 @@ class Chef
                   extension_status[:status] = :extension_status_not_detected
                 end
               # This fix is for linux waagent issue: api unable to deserialize the waagent status.
-              elsif (role.at_css('GuestAgentStatus Status').text == 'NotReady') && (waagent_status_msg == lnx_waagent_fail_msg)
+              elsif (role.at_css("GuestAgentStatus Status").text == "NotReady") && (waagent_status_msg == lnx_waagent_fail_msg)
                 extension_status[:status] = :extension_ready
               else
                 extension_status[:status] = :wagent_provisioning
@@ -383,7 +381,7 @@ class Chef
         else
           extension_status[:status] = :extension_status_not_detected
         end
-        return extension_status
+        extension_status
       end
 
       def run
@@ -399,14 +397,14 @@ class Chef
         config[:chef_node_name] = locate_config_value(:azure_vm_name) unless locate_config_value(:chef_node_name)
         service.create_server(create_server_def)
         wait_until_virtual_machine_ready()
-        if locate_config_value(:bootstrap_protocol) == 'cloud-api' && locate_config_value(:extended_logs)
+        if locate_config_value(:bootstrap_protocol) == "cloud-api" && locate_config_value(:extended_logs)
           print "\n\nWaiting for the first chef-client run"
           fetch_chef_client_logs(Time.now, 30)
         end
         server = service.get_role_server(locate_config_value(:azure_dns_name), locate_config_value(:azure_vm_name))
         msg_server_summary(server)
 
-        bootstrap_exec(server) unless locate_config_value(:bootstrap_protocol) == 'cloud-api'
+        bootstrap_exec(server) unless locate_config_value(:bootstrap_protocol) == "cloud-api"
       end
 
       def create_server_def
@@ -436,7 +434,7 @@ class Chef
           :winrm_max_memoryPerShell => locate_config_value(:winrm_max_memory_per_shell)
         }
 
-        if locate_config_value(:bootstrap_protocol) == 'cloud-api'
+        if locate_config_value(:bootstrap_protocol) == "cloud-api"
           server_def[:chef_extension] = get_chef_extension_name
           server_def[:chef_extension_publisher] = get_chef_extension_publisher
           server_def[:chef_extension_version] = get_chef_extension_version
@@ -444,7 +442,7 @@ class Chef
           server_def[:chef_extension_private_param] = get_chef_extension_private_params
         else
           if is_image_windows?
-            if not locate_config_value(:winrm_password) or not locate_config_value(:bootstrap_protocol)
+            if (not locate_config_value(:winrm_password)) || (not locate_config_value(:bootstrap_protocol))
               ui.error("WinRM Password and Bootstrapping Protocol are compulsory parameters")
               exit 1
             end
@@ -465,7 +463,7 @@ class Chef
               ui.error("SSH User is compulsory parameter")
               exit 1
             end
-            unless locate_config_value(:ssh_password) or locate_config_value(:identity_file)
+            unless locate_config_value(:ssh_password) || locate_config_value(:identity_file)
               ui.error("Specify either SSH Key or SSH Password")
               exit 1
             end
@@ -473,12 +471,12 @@ class Chef
         end
 
         if is_image_windows?
-          server_def[:os_type] = 'Windows'
+          server_def[:os_type] = "Windows"
           server_def[:admin_password] = locate_config_value(:winrm_password)
           server_def[:bootstrap_proto] = locate_config_value(:bootstrap_protocol)
         else
-          server_def[:os_type] = 'Linux'
-          server_def[:bootstrap_proto] = (locate_config_value(:bootstrap_protocol) == 'winrm') ? 'ssh' : locate_config_value(:bootstrap_protocol)
+          server_def[:os_type] = "Linux"
+          server_def[:bootstrap_proto] = (locate_config_value(:bootstrap_protocol) == "winrm") ? "ssh" : locate_config_value(:bootstrap_protocol)
           server_def[:ssh_user] = locate_config_value(:ssh_user)
           server_def[:ssh_password] = locate_config_value(:ssh_password)
           server_def[:identity_file] = locate_config_value(:identity_file)
@@ -486,11 +484,11 @@ class Chef
         end
 
         azure_connect_to_existing_dns = locate_config_value(:azure_connect_to_existing_dns)
-        if is_image_windows? && server_def[:bootstrap_proto] == 'winrm'
-          port = locate_config_value(:winrm_port) || '5985'
+        if is_image_windows? && server_def[:bootstrap_proto] == "winrm"
+          port = locate_config_value(:winrm_port) || "5985"
           port = locate_config_value(:winrm_port) || Random.rand(64000) + 1000 if azure_connect_to_existing_dns
-        elsif server_def[:bootstrap_proto] == 'ssh'
-          port = locate_config_value(:ssh_port) || '22'
+        elsif server_def[:bootstrap_proto] == "ssh"
+          port = locate_config_value(:ssh_port) || "22"
           port = locate_config_value(:ssh_port) || Random.rand(64000) + 1000 if azure_connect_to_existing_dns
         end
 
@@ -502,11 +500,11 @@ class Chef
         if locate_config_value(:azure_domain_user)
           # extract domain name since it should be part of username
           case locate_config_value(:azure_domain_user)
-          when /(\S+)\\(.+)/  # format - fully-qualified-DNS-domain\username
+          when /(\S+)\\(.+)/ # format - fully-qualified-DNS-domain\username
             server_def[:azure_domain_name] = $1 if locate_config_value(:azure_domain_name).nil?
             server_def[:azure_user_domain_name] = $1
             server_def[:azure_domain_user] = $2
-          when /(.+)@(\S+)/  # format - user@fully-qualified-DNS-domain
+          when /(.+)@(\S+)/ # format - user@fully-qualified-DNS-domain
             server_def[:azure_domain_name] = $2 if locate_config_value(:azure_domain_name).nil?
             server_def[:azure_user_domain_name] = $2
             server_def[:azure_domain_user] = $1
@@ -557,7 +555,7 @@ class Chef
       def get_dns_name(azure_dns_name, prefix = "az-")
         return azure_dns_name unless azure_dns_name.nil?
         if locate_config_value(:azure_vm_name).nil?
-          azure_dns_name = prefix + SecureRandom.hex(( MAX_VM_NAME_CHARACTERS - prefix.length)/2)
+          azure_dns_name = prefix + SecureRandom.hex(( MAX_VM_NAME_CHARACTERS - prefix.length) / 2)
         else
           azure_dns_name = locate_config_value(:azure_vm_name)
         end

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_server_delete.rb
+++ b/lib/chef/knife/azure_server_delete.rb
@@ -18,11 +18,11 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 # These two are needed for the '--purge' deletion case
-require 'chef/node'
-require 'chef/api_client'
+require "chef/node"
+require "chef/api_client"
 
 class Chef
   class Knife
@@ -84,22 +84,20 @@ class Chef
       # the user is already making their intent known.  It is not
       # necessary to make them confirm two more times.
       def destroy_item(klass, name, type_name)
-        begin
-          object = klass.load(name)
-          object.destroy
-          ui.warn("Deleted #{type_name} #{name}")
-        rescue Net::HTTPServerException
-          ui.warn("Could not find a #{type_name} named #{name} to delete. Please provide --node-name option and it's value")
-        end
+        object = klass.load(name)
+        object.destroy
+        ui.warn("Deleted #{type_name} #{name}")
+      rescue Net::HTTPServerException
+        ui.warn("Could not find a #{type_name} named #{name} to delete. Please provide --node-name option and it's value")
       end
 
       def validate_disk_and_storage
-         if locate_config_value(:preserve_azure_os_disk) && locate_config_value(:delete_azure_storage_account)
-            ui.warn("Cannot delete storage account while keeping OS Disk. Please set any one option.")
-            exit
-          else
-            true
-          end
+        if locate_config_value(:preserve_azure_os_disk) && locate_config_value(:delete_azure_storage_account)
+          ui.warn("Cannot delete storage account while keeping OS Disk. Please set any one option.")
+          exit
+        else
+          true
+         end
       end
 
       def run
@@ -108,16 +106,16 @@ class Chef
         @name_args.each do |name|
           begin
             service.delete_server( { name: name, preserve_azure_os_disk: locate_config_value(:preserve_azure_os_disk),
-                                    preserve_azure_vhd: locate_config_value(:preserve_azure_vhd),
-                                    preserve_azure_dns_name: locate_config_value(:preserve_azure_dns_name),
-                                    delete_azure_storage_account: locate_config_value(:delete_azure_storage_account),
+                                     preserve_azure_vhd: locate_config_value(:preserve_azure_vhd),
+                                     preserve_azure_dns_name: locate_config_value(:preserve_azure_dns_name),
+                                     delete_azure_storage_account: locate_config_value(:delete_azure_storage_account),
                                      wait: locate_config_value(:wait) } )
 
             if config[:purge]
               node_to_delete = config[:chef_node_name] || name
               if node_to_delete
-                destroy_item(Chef::Node, node_to_delete, 'node')
-                destroy_item(Chef::ApiClient, node_to_delete, 'client')
+                destroy_item(Chef::Node, node_to_delete, "node")
+                destroy_item(Chef::ApiClient, node_to_delete, "client")
               else
                 ui.warn("Node name to purge not provided. Corresponding client node will remain on Chef Server.")
               end

--- a/lib/chef/knife/azure_server_delete.rb
+++ b/lib/chef/knife/azure_server_delete.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Copyright:: Copyright (c) 2009-2011 Opscode, Inc.
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Copyright:: Copyright 2009-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_server_list.rb
+++ b/lib/chef/knife/azure_server_list.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Adam Jacob (<adam@chef.io>)
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_server_list.rb
+++ b/lib/chef/knife/azure_server_list.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife

--- a/lib/chef/knife/azure_server_show.rb
+++ b/lib/chef/knife/azure_server_show.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
@@ -26,7 +26,7 @@ class Chef
 
       include Knife::AzureBase
 
-      banner "knife azure server show SERVER [SERVER]"  
+      banner "knife azure server show SERVER [SERVER]"
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/azure_server_show.rb
+++ b/lib/chef/knife/azure_server_show.rb
@@ -1,8 +1,8 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# Author:: Seth Chisamore (<schisamo@chef.io>)
+# Author:: Adam Jacob (<adam@chef.io>)
+# Copyright:: Copyright 2010-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_vnet_create.rb
+++ b/lib/chef/knife/azure_vnet_create.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azure_vnet_create.rb
+++ b/lib/chef/knife/azure_vnet_create.rb
@@ -16,41 +16,41 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureVnetCreate < Knife
       include Knife::AzureBase
 
-      banner 'knife azure vnet create (options)'
+      banner "knife azure vnet create (options)"
 
       option :azure_network_name,
-        :short => '-n NETWORK_NAME',
-        :long => '--azure-network-name NETWORK_NAME',
+        :short => "-n NETWORK_NAME",
+        :long => "--azure-network-name NETWORK_NAME",
         :description =>
-          'Specifies the name of the virtual network to create.'
+          "Specifies the name of the virtual network to create."
 
       option :azure_affinity_group,
-        :short => '-a GROUP',
-        :long => '--azure-affinity-group GROUP',
+        :short => "-a GROUP",
+        :long => "--azure-affinity-group GROUP",
         :description =>
-          'Specifies the affinity group to associate with the vnet.'
+          "Specifies the affinity group to associate with the vnet."
 
       option :azure_address_space,
-        :long => '--azure-address-space CIDR',
+        :long => "--azure-address-space CIDR",
         :description =>
-          'Specifies the address space of the vnet using CIDR notation.'
+          "Specifies the address space of the vnet using CIDR notation."
 
       option :azure_subnet_name,
-        :long => '--azure-subnet-name CIDR',
+        :long => "--azure-subnet-name CIDR",
         :description =>
-          'Specifies the Subnet Name.'
+          "Specifies the Subnet Name."
 
       def run
         $stdout.sync = true
 
-        Chef::Log.info('validating...')
+        Chef::Log.info("validating...")
         validate_asm_keys!(:azure_network_name, :azure_affinity_group, :azure_address_space)
 
         params = {
@@ -62,9 +62,9 @@ class Chef
 
         rsp = service.create_vnet(params)
         print "\n"
-        if rsp.at_css('Status').nil?
-          if rsp.at_css('Code').nil? || rsp.at_css('Message').nil?
-            puts 'Unknown Error. try -VV'
+        if rsp.at_css("Status").nil?
+          if rsp.at_css("Code").nil? || rsp.at_css("Message").nil?
+            puts "Unknown Error. try -VV"
           else
             puts "#{rsp.at_css('Code').content}: "\
                  "#{rsp.at_css('Message').content}"

--- a/lib/chef/knife/azure_vnet_list.rb
+++ b/lib/chef/knife/azure_vnet_list.rb
@@ -16,14 +16,14 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azure_base', __FILE__)
+require File.expand_path("../azure_base", __FILE__)
 
 class Chef
   class Knife
     class AzureVnetList < Knife
       include Knife::AzureBase
 
-      banner 'knife azure vnet list (options)'
+      banner "knife azure vnet list (options)"
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/azure_vnet_list.rb
+++ b/lib/chef/knife/azure_vnet_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeff Mendoza (jeffmendoza@live.com)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/azurerm_base.rb
+++ b/lib/chef/knife/azurerm_base.rb
@@ -17,12 +17,12 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
-require 'azure/resource_management/ARM_interface'
-require 'mixlib/shellout'
-require 'chef/mixin/shell_out'
-require 'time'
-require 'json'
+require "chef/knife"
+require "azure/resource_management/ARM_interface"
+require "mixlib/shellout"
+require "chef/mixin/shell_out"
+require "time"
+require "json"
 
 class Chef
   class Knife
@@ -34,15 +34,15 @@ class Chef
       XPLAT_VERSION_WITH_WCM_DEPRECATED ||= "0.10.5"
 
       if Chef::Platform.windows?
-        require 'azure/resource_management/windows_credentials'
+        require "azure/resource_management/windows_credentials"
         include Azure::ARM::WindowsCredentials
       end
 
       def self.included(includer)
         includer.class_eval do
           deps do
-            require 'readline'
-            require 'chef/json_compat'
+            require "readline"
+            require "chef/json_compat"
           end
 
           option :azure_resource_group_name,
@@ -64,7 +64,7 @@ class Chef
 
       def locate_config_value(key)
         key = key.to_sym
-        config[key] || Chef::Config[:knife][key]  || default_config[key]
+        config[key] || Chef::Config[:knife][key] || default_config[key]
       end
 
       # validates ARM mandatory keys
@@ -84,14 +84,14 @@ class Chef
             errors << "You did not provide a valid '#{pretty_key(k)}' value. Please set knife[:#{k}] in your knife.rb."
           end
         end
-        if errors.each{|e| ui.error(e)}.any?
+        if errors.each { |e| ui.error(e) }.any?
           exit 1
         end
       end
 
       def authentication_details
         if is_azure_cred?
-          return {:azure_tenant_id => locate_config_value(:azure_tenant_id), :azure_client_id => locate_config_value(:azure_client_id), :azure_client_secret => locate_config_value(:azure_client_secret)}
+          return { :azure_tenant_id => locate_config_value(:azure_tenant_id), :azure_client_id => locate_config_value(:azure_client_id), :azure_client_secret => locate_config_value(:azure_client_secret) }
         elsif Chef::Platform.windows?
           token_details = token_details_for_windows()
         else
@@ -102,9 +102,9 @@ class Chef
       end
 
       def get_azure_cli_version
-        if @azure_version  != ""
+        if @azure_version != ""
           get_version = shell_out!("azure -v || az -v | grep azure-cli", { returns: [0] }).stdout
-          @azure_version = get_version.gsub(/[^0-9.]/, '')
+          @azure_version = get_version.gsub(/[^0-9.]/, "")
         end
         @azure_prefix = @azure_version.to_i < 2 ? "azure" : "az"
         @azure_version
@@ -123,10 +123,10 @@ class Chef
       end
 
       def token_details_from_accessToken_file
-        home_dir = File.expand_path('~')
-        file = File.read(home_dir + '/.azure/accessTokens.json')
+        home_dir = File.expand_path("~")
+        file = File.read(home_dir + "/.azure/accessTokens.json")
         file = JSON.parse(file)
-        token_details = {:tokentype => file[-1]["tokenType"], :user => file[-1]["userId"], :token => file[-1]["accessToken"], :clientid => file[-1]["_clientId"], :expiry_time => file[-1]["expiresOn"], :refreshtoken => file[-1]["refreshToken"]}
+        token_details = { :tokentype => file[-1]["tokenType"], :user => file[-1]["userId"], :token => file[-1]["accessToken"], :clientid => file[-1]["_clientId"], :expiry_time => file[-1]["expiresOn"], :refreshtoken => file[-1]["refreshToken"] }
         token_details
       end
 
@@ -148,13 +148,11 @@ class Chef
       end
 
       def azure_authentication
-        begin
-          ui.log("Authenticating...")
-          Mixlib::ShellOut.new("#{@azure_prefix} vm show 'knifetest@resourcegroup' testvm", :timeout => 30).run_command
-        rescue Mixlib::ShellOut::CommandTimeout
-        rescue Exception
-          raise_azure_status
-        end
+        ui.log("Authenticating...")
+        Mixlib::ShellOut.new("#{@azure_prefix} vm show 'knifetest@resourcegroup' testvm", :timeout => 30).run_command
+      rescue Mixlib::ShellOut::CommandTimeout
+      rescue Exception
+        raise_azure_status
       end
 
       def check_token_validity(token_details)
@@ -176,18 +174,18 @@ class Chef
             raise login_message
           end
         else
-          home_dir = File.expand_path('~')
-          if !File.exists?(home_dir + "/.azure/accessTokens.json") || File.size?(home_dir + '/.azure/accessTokens.json') <= 2
+          home_dir = File.expand_path("~")
+          if !File.exist?(home_dir + "/.azure/accessTokens.json") || File.size?(home_dir + "/.azure/accessTokens.json") <= 2
             raise login_message
           end
         end
       end
 
       def parse_publish_settings_file(filename)
-        require 'nokogiri'
-        require 'base64'
-        require 'openssl'
-        require 'uri'
+        require "nokogiri"
+        require "base64"
+        require "openssl"
+        require "uri"
         begin
           doc = Nokogiri::XML(File.open(find_file(filename)))
           profile = doc.at_css("PublishProfile")
@@ -204,7 +202,7 @@ class Chef
           end
           Chef::Config[:knife][:azure_mgmt_cert] = management_cert.certificate.to_pem + management_cert.key.to_pem
           Chef::Config[:knife][:azure_subscription_id] = doc.at_css("Subscription").attribute("Id").value
-        rescue=> error
+        rescue => error
           puts "#{error.class} and #{error.message}"
           exit 1
         end
@@ -217,10 +215,10 @@ class Chef
           file = name
         elsif config_dir && File.exist?(File.join(config_dir, name))
           file = File.join(config_dir, name)
-        elsif File.exist?(File.join(ENV['HOME'], '.chef', name))
-          file = File.join(ENV['HOME'], '.chef', name)
+        elsif File.exist?(File.join(ENV["HOME"], ".chef", name))
+          file = File.join(ENV["HOME"], ".chef", name)
         else
-          ui.error('Unable to find file - ' + name)
+          ui.error("Unable to find file - " + name)
           exit 1
         end
         file
@@ -228,37 +226,37 @@ class Chef
 
       def msg_server_summary(server)
         puts "\n\n"
-        if server.provisioningstate == 'Succeeded'
+        if server.provisioningstate == "Succeeded"
           Chef::Log.info("Server creation went successfull.")
           puts "\nServer Details are:\n"
 
-          msg_pair('Server ID', server.id)
-          msg_pair('Server Name', server.name)
-          msg_pair('Server Public IP Address', server.publicipaddress)
+          msg_pair("Server ID", server.id)
+          msg_pair("Server Name", server.name)
+          msg_pair("Server Public IP Address", server.publicipaddress)
           if is_image_windows?
-            msg_pair('Server RDP Port', server.rdpport)
+            msg_pair("Server RDP Port", server.rdpport)
           else
-            msg_pair('Server SSH Port', server.sshport)
+            msg_pair("Server SSH Port", server.sshport)
           end
-          msg_pair('Server Location', server.locationname)
-          msg_pair('Server OS Type', server.ostype)
-          msg_pair('Server Provisioning State', server.provisioningstate)
+          msg_pair("Server Location", server.locationname)
+          msg_pair("Server OS Type", server.ostype)
+          msg_pair("Server Provisioning State", server.provisioningstate)
         else
           Chef::Log.info("Server Creation Failed.")
         end
 
         puts "\n\n"
 
-        if server.resources.provisioning_state == 'Succeeded'
+        if server.resources.provisioning_state == "Succeeded"
           Chef::Log.info("Server Extension creation went successfull.")
           puts "\nServer Extension Details are:\n"
 
-          msg_pair('Server Extension ID', server.resources.id)
-          msg_pair('Server Extension Name', server.resources.name)
-          msg_pair('Server Extension Publisher', server.resources.publisher)
-          msg_pair('Server Extension Type', server.resources.type)
-          msg_pair('Server Extension Type Handler Version', server.resources.type_handler_version)
-          msg_pair('Server Extension Provisioning State', server.resources.provisioning_state)
+          msg_pair("Server Extension ID", server.resources.id)
+          msg_pair("Server Extension Name", server.resources.name)
+          msg_pair("Server Extension Publisher", server.resources.publisher)
+          msg_pair("Server Extension Type", server.resources.type)
+          msg_pair("Server Extension Type Handler Version", server.resources.type_handler_version)
+          msg_pair("Server Extension Provisioning State", server.resources.provisioning_state)
         else
           Chef::Log.info("Server Extension Creation Failed.")
         end
@@ -270,16 +268,16 @@ class Chef
           raise ArgumentError, "When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified."
         end
 
-        if locate_config_value(:azure_vnet_subnet_name) == 'GatewaySubnet'
-          raise ArgumentError, 'GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.'
+        if locate_config_value(:azure_vnet_subnet_name) == "GatewaySubnet"
+          raise ArgumentError, "GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways."
         end
 
-        if locate_config_value(:node_ssl_verify_mode) && !["none", "peer"].include?(locate_config_value(:node_ssl_verify_mode))
+        if locate_config_value(:node_ssl_verify_mode) && !%w{none peer}.include?(locate_config_value(:node_ssl_verify_mode))
           raise ArgumentError, "Invalid value '#{locate_config_value(:node_ssl_verify_mode)}' for --node-ssl-verify-mode. Use Valid values i.e 'none', 'peer'."
         end
 
         if is_image_windows?
-          if locate_config_value(:winrm_user).nil? ||  locate_config_value(:winrm_password).nil?
+          if locate_config_value(:winrm_user).nil? || locate_config_value(:winrm_password).nil?
             raise ArgumentError, "Please provide --winrm-user and --winrm-password options for Windows option."
           end
         end
@@ -307,19 +305,19 @@ class Chef
         end
 
         config[:ohai_hints] = format_ohai_hints(locate_config_value(:ohai_hints))
-        validate_ohai_hints if ! locate_config_value(:ohai_hints).casecmp('default').zero?
+        validate_ohai_hints if ! locate_config_value(:ohai_hints).casecmp("default").zero?
       end
 
-  private
+      private
 
-      def msg_pair(label, value, color=:cyan)
+      def msg_pair(label, value, color = :cyan)
         if value && !value.to_s.empty?
           puts "#{ui.color(label, color)}: #{value}"
         end
       end
 
       def pretty_key(key)
-        key.to_s.gsub(/_/, ' ').gsub(/\w+/){ |w| (w =~ /(ssh)|(aws)/i) ? w.upcase  : w.capitalize }
+        key.to_s.tr("_", " ").gsub(/\w+/) { |w| (w =~ /(ssh)|(aws)/i) ? w.upcase : w.capitalize }
       end
 
       def is_image_windows?
@@ -340,7 +338,7 @@ class Chef
       end
 
       def is_WCM_env_var_set?
-        ENV['AZURE_USE_SECURE_TOKEN_STORAGE'].nil? ? false : true
+        ENV["AZURE_USE_SECURE_TOKEN_STORAGE"].nil? ? false : true
       end
 
       def raise_azure_status

--- a/lib/chef/knife/azurerm_base.rb
+++ b/lib/chef/knife/azurerm_base.rb
@@ -1,4 +1,4 @@
-
+#
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
 #
 # Copyright:: Copyright 2009-2018, Chef Software Inc.

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -17,10 +17,10 @@
 # limitations under the License.
 #
 
-require 'chef/knife/azurerm_base'
-require 'securerandom'
-require 'chef/knife/bootstrap/common_bootstrap_options'
-require 'chef/knife/bootstrap/bootstrapper'
+require "chef/knife/azurerm_base"
+require "securerandom"
+require "chef/knife/bootstrap/common_bootstrap_options"
+require "chef/knife/bootstrap/bootstrapper"
 
 class Chef
   class Knife
@@ -83,7 +83,7 @@ class Chef
                                       Standard_GRS (Standard Geo-redundant storage)
                                       Standard_RAGRS (Standard Read access geo-redundant storage)
                                       Premium_LRS (Premium Locally-redundant storage)",
-        :default => 'Standard_GRS'
+        :default => "Standard_GRS"
 
       option :azure_vm_name,
         :long => "--azure-vm-name NAME",
@@ -121,7 +121,7 @@ class Chef
         :long => "--azure-image-reference-version VERSION",
         :description => "Optional. Specifies the version of the image used to create the virtual machine.
                           Default value is 'latest'",
-        :default => 'latest'
+        :default => "latest"
 
       option :azure_image_os_type,
         :long => "--azure-image-os-type OSTYPE",
@@ -131,7 +131,7 @@ class Chef
         :short => "-z SIZE",
         :long => "--azure-vm-size SIZE",
         :description => "Optional. Size of virtual machine (ExtraSmall, Small, Medium, Large, ExtraLarge)",
-        :default => 'Small',
+        :default => "Small",
         :proc => Proc.new { |si| Chef::Config[:knife][:azure_vm_size] = si }
 
       option :azure_availability_set,
@@ -188,7 +188,7 @@ class Chef
                                      Supported values are: vm_name, public_fqdn and platform.
                                      User can pass any comma separated combination of these values like 'vm_name,public_fqdn'.
                                      Default value is 'default' which corresponds to the supported values list mentioned here.",
-        :default => 'default'
+        :default => "default"
 
       def run
         $stdout.sync = true
@@ -241,12 +241,12 @@ class Chef
 
         # We assign azure_vm_name to chef_node_name If node name is nill because storage account name is combination of hash value and node name.
         config[:chef_node_name] ||= locate_config_value(:azure_vm_name)
-        
+
         server_def[:azure_storage_account] = locate_config_value(:azure_vm_name) if server_def[:azure_storage_account].nil?
-        server_def[:azure_storage_account] = server_def[:azure_storage_account].gsub(/[!@#$%^&*()_-]/,'')
+        server_def[:azure_storage_account] = server_def[:azure_storage_account].gsub(/[!@#$%^&*()_-]/, "")
 
         server_def[:azure_os_disk_name] = locate_config_value(:azure_vm_name) if server_def[:azure_os_disk_name].nil?
-        server_def[:azure_os_disk_name] = server_def[:azure_os_disk_name].gsub(/[!@#$%^&*()_-]/,'')
+        server_def[:azure_os_disk_name] = server_def[:azure_os_disk_name].gsub(/[!@#$%^&*()_-]/, "")
 
         server_def[:azure_vnet_name] = locate_config_value(:azure_vm_name) if server_def[:azure_vnet_name].nil?
         server_def[:azure_vnet_subnet_name] = locate_config_value(:azure_vm_name) if locate_config_value(:azure_vnet_subnet_name).nil?
@@ -274,16 +274,16 @@ class Chef
       end
 
       def supported_ohai_hints
-        [
-          'vm_name',
-          'public_fqdn',
-          'platform'
-        ]
+        %w{
+          vm_name
+          public_fqdn
+          platform
+        }
       end
 
       def format_ohai_hints(ohai_hints)
-        ohai_hints = ohai_hints.split(',').each { |hint| hint.strip! }
-        ohai_hints.join(',')
+        ohai_hints = ohai_hints.split(",").each { |hint| hint.strip! }
+        ohai_hints.join(",")
       end
 
       def is_supported_ohai_hint?(hint)
@@ -291,7 +291,7 @@ class Chef
       end
 
       def validate_ohai_hints
-        hint_values = locate_config_value(:ohai_hints).split(',')
+        hint_values = locate_config_value(:ohai_hints).split(",")
         hint_values.each do |hint|
           if ! is_supported_ohai_hint?(hint)
             raise ArgumentError, "Ohai Hint name #{hint} passed is not supported. Please run the command help to see the list of supported values."
@@ -332,7 +332,7 @@ class Chef
             when "windows"
               set_os_image("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter")
             else
-              raise ArgumentError, 'Invalid value of --azure-image-os-type. Accepted values ubuntu|centos|windows'
+              raise ArgumentError, "Invalid value of --azure-image-os-type. Accepted values ubuntu|centos|windows"
             end
           else
             validate_arm_keys!(:azure_image_os_type) unless is_image_os_type?
@@ -360,7 +360,7 @@ class Chef
       end
 
       def validate_publisher_and_offer
-        if (locate_config_value(:azure_image_reference_publisher) || locate_config_value(:azure_image_reference_offer))
+        if locate_config_value(:azure_image_reference_publisher) || locate_config_value(:azure_image_reference_offer)
           # if azure_image_os_type is given and any of the other image reference parameters like publisher or offer are also given,
           # raise error
           raise ArgumentError, 'Please specify either --azure-image-os-type OR --azure-image-os-type with --azure-image-reference-sku or 4 image reference parameters i.e.

--- a/lib/chef/knife/azurerm_server_delete.rb
+++ b/lib/chef/knife/azurerm_server_delete.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Barry Davis (barryd@jetstreamsoftware.com)
-# Author:: Adam Jacob (<adam@opscode.com>)
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
+# Author:: Adam Jacob (<adam@chef.io>)
+# Author:: Seth Chisamore (<schisamo@chef.io>)
 # Copyright:: Copyright 2009-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef/knife/azurerm_server_delete.rb
+++ b/lib/chef/knife/azurerm_server_delete.rb
@@ -18,11 +18,11 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azurerm_base', __FILE__)
+require File.expand_path("../azurerm_base", __FILE__)
 
 # These two are needed for the '--purge' deletion case
-require 'chef/node'
-require 'chef/api_client'
+require "chef/node"
+require "chef/api_client"
 
 class Chef
   class Knife
@@ -57,51 +57,47 @@ class Chef
       # necessary to make them confirm two more times.
 
       def destroy_item(klass, name, type_name)
-        begin
-          object = klass.load(name)
-          object.destroy
-          ui.warn("Deleted #{type_name} #{name}")
-        rescue Net::HTTPServerException
-          ui.warn("Could not find a #{type_name} named #{name} to delete!")
-        end
+        object = klass.load(name)
+        object.destroy
+        ui.warn("Deleted #{type_name} #{name}")
+      rescue Net::HTTPServerException
+        ui.warn("Could not find a #{type_name} named #{name} to delete!")
       end
 
       def run
-        begin
-          $stdout.sync = true
-          # check azure cli version due to azure changed `azure` to `az` in azure-cli2.0
-          get_azure_cli_version
-          validate_arm_keys!(:azure_resource_group_name)
-          @vm_name = @name_args[0]
+        $stdout.sync = true
+        # check azure cli version due to azure changed `azure` to `az` in azure-cli2.0
+        get_azure_cli_version
+        validate_arm_keys!(:azure_resource_group_name)
+        @vm_name = @name_args[0]
 
-          if locate_config_value(:delete_resource_group)
-            delete_resource_group
-          else
-            service.delete_server(locate_config_value(:azure_resource_group_name), @vm_name)
-          end
-
-          if config[:purge]
-            purge_node
-          else
-            ui.warn("Corresponding node and client for the #{@vm_name} server were not deleted and remain registered with the Chef Server")
-          end
-        rescue => error
-          service.common_arm_rescue_block(error)
+        if locate_config_value(:delete_resource_group)
+          delete_resource_group
+        else
+          service.delete_server(locate_config_value(:azure_resource_group_name), @vm_name)
         end
+
+        if config[:purge]
+          purge_node
+        else
+          ui.warn("Corresponding node and client for the #{@vm_name} server were not deleted and remain registered with the Chef Server")
+        end
+      rescue => error
+        service.common_arm_rescue_block(error)
       end
 
       def delete_resource_group
         resource_group_name = locate_config_value(:azure_resource_group_name)
         ui.warn "Deleting resource group will delete all the virtual_machines inside it."
         begin
-          ui.confirm('Do you really want to delete resource group')
+          ui.confirm("Do you really want to delete resource group")
         rescue SystemExit   # Need to handle this as confirming with N/n raises SystemExit exception
           server = nil      # Cleanup is implicitly performed in other cloud plugins
           ui.warn "Resource group not deleted. Proceeding for server delete ..."
           service.delete_server(locate_config_value(:azure_resource_group_name), @vm_name)
           exit
         end
-        ui.info 'Deleting Resource Group '+resource_group_name+' and Virtual Machine '+@vm_name+' ..'
+        ui.info "Deleting Resource Group " + resource_group_name + " and Virtual Machine " + @vm_name + " .."
         service.delete_resource_group(locate_config_value(:azure_resource_group_name))
         ui.warn "Deleted resource_group_name #{resource_group_name} and #{@vm_name}"
       end
@@ -109,8 +105,8 @@ class Chef
       def purge_node
         node_to_delete = config[:chef_node_name] || @vm_name
         if node_to_delete
-          destroy_item(Chef::Node, node_to_delete, 'node')
-          destroy_item(Chef::ApiClient, node_to_delete, 'client')
+          destroy_item(Chef::Node, node_to_delete, "node")
+          destroy_item(Chef::ApiClient, node_to_delete, "client")
         else
           ui.warn("Node name to purge not provided. Corresponding client node will remain on Chef Server.")
         end

--- a/lib/chef/knife/azurerm_server_list.rb
+++ b/lib/chef/knife/azurerm_server_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azurerm_base', __FILE__)
+require File.expand_path("../azurerm_base", __FILE__)
 
 class Chef
   class Knife

--- a/lib/chef/knife/azurerm_server_show.rb
+++ b/lib/chef/knife/azurerm_server_show.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require File.expand_path('../azurerm_base', __FILE__)
+require File.expand_path("../azurerm_base", __FILE__)
 
 class Chef
   class Knife

--- a/lib/chef/knife/bootstrap/bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/bootstrap_options.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
 #
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/bootstrap/bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/bootstrap_options.rb
@@ -23,8 +23,8 @@
 # choice to bootstrap the target system through cloud-api protocol.
 #
 
-require 'chef/knife/winrm_base'
-require 'chef/knife/bootstrap_windows_base'
+require "chef/knife/winrm_base"
+require "chef/knife/bootstrap_windows_base"
 class Chef
   class Knife
     class Bootstrap
@@ -36,7 +36,7 @@ class Chef
             include Knife::WinrmBase
             include Knife::BootstrapWindowsBase
             deps do
-              require 'chef/knife/bootstrap'
+              require "chef/knife/bootstrap"
               Chef::Knife::Bootstrap.load_deps
             end
 
@@ -97,10 +97,9 @@ class Chef
                                 none - Currently prevents the chef-client service from being configured as a service.
                                 service - Configures the chef-client to run automatically in the background as a service.
                                 task - Configures the chef-client to run automatically in the background as a scheduled task."
-  	  	  end
+          end
         end
-  	  end
-  	end
+      end
+    end
   end
 end
-

--- a/lib/chef/knife/bootstrap/bootstrapper.rb
+++ b/lib/chef/knife/bootstrap/bootstrapper.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
 #
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/bootstrap/bootstrapper.rb
+++ b/lib/chef/knife/bootstrap/bootstrapper.rb
@@ -23,13 +23,13 @@ class Chef
       module Bootstrapper
 
         def load_winrm_deps
-          require 'winrm'
-          require 'chef/knife/winrm'
-          require 'chef/knife/bootstrap_windows_winrm'
+          require "winrm"
+          require "chef/knife/winrm"
+          require "chef/knife/bootstrap_windows_winrm"
         end
 
         def default_bootstrap_template
-          is_image_windows? ? 'windows-chef-client-msi' : 'chef-full'
+          is_image_windows? ? "windows-chef-client-msi" : "chef-full"
         end
 
         def tcp_test_ssh(fqdn, sshport)
@@ -42,67 +42,67 @@ class Chef
           else
             false
           end
-          rescue SocketError
-            sleep 2
-            false
-          rescue Errno::ETIMEDOUT
-            false
-          rescue Errno::EPERM
-            false
-          rescue Errno::ECONNREFUSED
-            sleep 2
-            false
-          rescue Errno::EHOSTUNREACH
-            sleep 2
-            false
-          ensure
-            tcp_socket && tcp_socket.close
+        rescue SocketError
+          sleep 2
+          false
+        rescue Errno::ETIMEDOUT
+          false
+        rescue Errno::EPERM
+          false
+        rescue Errno::ECONNREFUSED
+          sleep 2
+          false
+        rescue Errno::EHOSTUNREACH
+          sleep 2
+          false
+        ensure
+          tcp_socket && tcp_socket.close
         end
 
         def tcp_test_winrm(ip_addr, port)
           hostname = ip_addr
           socket = TCPSocket.new(hostname, port)
-          return true
-          rescue SocketError
-            sleep 2
-            false
-          rescue Errno::ETIMEDOUT
-            false
-          rescue Errno::EPERM
-            false
-          rescue Errno::ECONNREFUSED
-            sleep 2
-            false
-          rescue Errno::EHOSTUNREACH
-            sleep 2
-            false
-          rescue Errno::ENETUNREACH
-            sleep 2
-            false
+          true
+        rescue SocketError
+          sleep 2
+          false
+        rescue Errno::ETIMEDOUT
+          false
+        rescue Errno::EPERM
+          false
+        rescue Errno::ECONNREFUSED
+          sleep 2
+          false
+        rescue Errno::EHOSTUNREACH
+          sleep 2
+          false
+        rescue Errno::ENETUNREACH
+          sleep 2
+          false
         end
 
         def bootstrap_exec(server)
           fqdn = server.publicipaddress
 
           if is_image_windows?
-            if locate_config_value(:bootstrap_protocol) == 'ssh'
+            if locate_config_value(:bootstrap_protocol) == "ssh"
               port = server.sshport
               print "#{ui.color("Waiting for sshd on #{fqdn}:#{port}", :magenta)}"
 
-              print(".") until tcp_test_ssh(fqdn,port) {
+              print(".") until tcp_test_ssh(fqdn, port) do
                 sleep @initial_sleep_delay ||= 10
                 puts("done")
-              }
+              end
 
-            elsif locate_config_value(:bootstrap_protocol) == 'winrm'
+            elsif locate_config_value(:bootstrap_protocol) == "winrm"
               port = server.winrmport
 
               print "#{ui.color("Waiting for winrm on #{fqdn}:#{port}", :magenta)}"
 
-              print(".") until tcp_test_winrm(fqdn,port) {
+              print(".") until tcp_test_winrm(fqdn, port) do
                 sleep @initial_sleep_delay ||= 10
                 puts("done")
-              }
+              end
             end
 
             puts("\n")
@@ -117,10 +117,10 @@ class Chef
 
             print ui.color("Waiting for sshd on #{fqdn}:#{port}", :magenta)
 
-            print(".") until tcp_test_ssh(fqdn,port) {
+            print(".") until tcp_test_ssh(fqdn, port) do
               sleep @initial_sleep_delay ||= 10
               puts("done")
-            }
+            end
 
             puts("\n")
             bootstrap_for_node(server, fqdn, port).run
@@ -164,16 +164,16 @@ class Chef
         end
 
         def bootstrap_for_windows_node(server, fqdn, port)
-          if locate_config_value(:bootstrap_protocol) == 'winrm'
+          if locate_config_value(:bootstrap_protocol) == "winrm"
 
             load_winrm_deps
             if not Chef::Platform.windows?
-              require 'gssapi'
+              require "gssapi"
             end
 
             bootstrap = Chef::Knife::BootstrapWindowsWinrm.new
 
-            bootstrap.config[:winrm_user] = locate_config_value(:winrm_user) || 'Administrator'
+            bootstrap.config[:winrm_user] = locate_config_value(:winrm_user) || "Administrator"
             bootstrap.config[:winrm_password] = locate_config_value(:winrm_password)
             bootstrap.config[:winrm_transport] = locate_config_value(:winrm_transport)
             bootstrap.config[:winrm_authentication_protocol] = locate_config_value(:winrm_authentication_protocol)
@@ -181,7 +181,7 @@ class Chef
             bootstrap.config[:auth_timeout] = locate_config_value(:auth_timeout)
             # Todo: we should skip cert generate in case when winrm_ssl_verify_mode=verify_none
             bootstrap.config[:winrm_ssl_verify_mode] = locate_config_value(:winrm_ssl_verify_mode)
-          elsif locate_config_value(:bootstrap_protocol) == 'ssh'
+          elsif locate_config_value(:bootstrap_protocol) == "ssh"
             bootstrap = Chef::Knife::BootstrapWindowsSsh.new
             bootstrap.config[:ssh_user] = locate_config_value(:ssh_user)
             bootstrap.config[:ssh_password] = locate_config_value(:ssh_password)
@@ -210,7 +210,7 @@ class Chef
           bootstrap.config[:ssh_port] = port
           bootstrap.config[:identity_file] = locate_config_value(:identity_file)
           bootstrap.config[:chef_node_name] = locate_config_value(:chef_node_name) || server.name
-          bootstrap.config[:use_sudo] = true unless locate_config_value(:ssh_user) == 'root'
+          bootstrap.config[:use_sudo] = true unless locate_config_value(:ssh_user) == "root"
           bootstrap.config[:use_sudo_password] = true if bootstrap.config[:use_sudo]
           bootstrap.config[:environment] = locate_config_value(:environment)
           # may be needed for vpc_mode
@@ -253,20 +253,20 @@ class Chef
         end
 
         def default_hint_options
-          [
-            'vm_name',
-            'public_fqdn',
-            'platform'
-          ]
+          %w{
+            vm_name
+            public_fqdn
+            platform
+          }
         end
 
         def ohai_hints
           hint_values = locate_config_value(:ohai_hints)
 
-          if hint_values.casecmp('default').zero?
+          if hint_values.casecmp("default").zero?
             hints = default_hint_options
           else
-            hints = hint_values.split(',')
+            hints = hint_values.split(",")
           end
 
           hints
@@ -274,7 +274,7 @@ class Chef
 
         def get_chef_extension_public_params
           pub_config = Hash.new
-          if(locate_config_value(:azure_extension_client_config))
+          if locate_config_value(:azure_extension_client_config)
             pub_config[:client_rb] = File.read(locate_config_value(:azure_extension_client_config))
           else
             pub_config[:client_rb] = "chef_server_url \t #{Chef::Config[:chef_server_url].to_json}\nvalidation_client_name\t#{Chef::Config[:validation_client_name].to_json}"
@@ -311,8 +311,8 @@ class Chef
           cli_secret_file = nil if cli_secret_file == knife_secret_file
           cli_secret = nil if cli_secret == knife_secret
 
-          cli_secret_file = Chef::EncryptedDataBagItem.load_secret(cli_secret_file) if cli_secret_file != nil
-          knife_secret_file = Chef::EncryptedDataBagItem.load_secret(knife_secret_file) if knife_secret_file != nil
+          cli_secret_file = Chef::EncryptedDataBagItem.load_secret(cli_secret_file) if !cli_secret_file.nil?
+          knife_secret_file = Chef::EncryptedDataBagItem.load_secret(knife_secret_file) if !knife_secret_file.nil?
 
           cli_secret_file || cli_secret || knife_secret_file || knife_secret
         end
@@ -321,7 +321,7 @@ class Chef
           client_builder = Chef::Knife::Bootstrap::ClientBuilder.new(
             chef_config: Chef::Config,
             knife_config: config,
-            ui: ui,
+            ui: ui
           )
           client_builder.run
           client_builder.client_path
@@ -331,14 +331,14 @@ class Chef
           pri_config = Hash.new
 
           # validator less bootstrap support for bootstrap protocol cloud-api
-          if (Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key])))
-            if Chef::VERSION.split('.').first.to_i == 11
-              ui.error('Unable to find validation key. Please verify your configuration file for validation_key config value.')
+          if Chef::Config[:validation_key] && !File.exist?(File.expand_path(Chef::Config[:validation_key]))
+            if Chef::VERSION.split(".").first.to_i == 11
+              ui.error("Unable to find validation key. Please verify your configuration file for validation_key config value.")
               exit 1
             end
             if config[:server_count].to_i > 1
               node_name = config[:chef_node_name]
-              0.upto (config[:server_count].to_i-1) do |count|
+              0.upto (config[:server_count].to_i - 1) do |count|
                 config[:chef_node_name] = node_name + count.to_s
                 key_path = create_node_and_client_pem
                 pri_config[("client_pem" + count.to_s).to_sym] = File.read(key_path)
@@ -357,7 +357,7 @@ class Chef
             if File.exist?(File.expand_path(locate_config_value(:cert_path)))
               pri_config[:chef_server_crt] = File.read(locate_config_value(:cert_path))
             else
-              ui.error('Specified SSL certificate does not exist.')
+              ui.error("Specified SSL certificate does not exist.")
               exit 1
             end
           end

--- a/lib/chef/knife/bootstrap/common_bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/common_bootstrap_options.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
 #
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/bootstrap/common_bootstrap_options.rb
+++ b/lib/chef/knife/bootstrap/common_bootstrap_options.rb
@@ -29,7 +29,7 @@ class Chef
           includer.class_eval do
 
             deps do
-              require 'chef/knife/bootstrap'
+              require "chef/knife/bootstrap"
               Chef::Knife::Bootstrap.load_deps
             end
 
@@ -69,7 +69,7 @@ class Chef
               :long        => "--node-ssl-verify-mode [peer|none]",
               :description => "Whether or not to verify the SSL cert for all HTTPS requests.",
               :proc        => Proc.new { |v|
-                valid_values = ["none", "peer"]
+                valid_values = %w{none peer}
                 unless valid_values.include?(v)
                   raise "Invalid value '#{v}' for --node-ssl-verify-mode. Valid values are: #{valid_values.join(", ")}"
                 end
@@ -117,4 +117,3 @@ class Chef
     end
   end
 end
-

--- a/lib/chef/knife/bootstrap_azure.rb
+++ b/lib/chef/knife/bootstrap_azure.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require 'chef/knife/azure_base'
-require 'chef/knife/bootstrap/common_bootstrap_options'
-require 'chef/knife/bootstrap/bootstrapper'
+require "chef/knife/azure_base"
+require "chef/knife/bootstrap/common_bootstrap_options"
+require "chef/knife/bootstrap/bootstrapper"
 
 class Chef
   class Knife
@@ -49,8 +49,8 @@ class Chef
               fetch_chef_client_logs(Time.now, 35)
             end
           else
-            raise ArgumentError, 'Please specify the SERVER name which needs to be bootstrapped via the Chef Extension.' if @name_args.length == 0
-            raise ArgumentError, 'Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension.' if @name_args.length > 1
+            raise ArgumentError, "Please specify the SERVER name which needs to be bootstrapped via the Chef Extension." if @name_args.length == 0
+            raise ArgumentError, "Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension." if @name_args.length > 1
           end
         rescue => error
           ui.error("#{error.message}")
@@ -85,11 +85,11 @@ class Chef
           ui.info "Setting the Chef Extension parameters."
           ext_params = Hash.new
           case server.os_type.downcase
-          when 'windows'
-            ext_params[:chef_extension] = 'ChefClient'
-          when 'linux'
-            if ['ubuntu', 'debian', 'rhel', 'centos'].any? { |platform| server.os_version.downcase.include? platform }
-              ext_params[:chef_extension] = 'LinuxChefClient'
+          when "windows"
+            ext_params[:chef_extension] = "ChefClient"
+          when "linux"
+            if %w{ubuntu debian rhel centos}.any? { |platform| server.os_version.downcase.include? platform }
+              ext_params[:chef_extension] = "LinuxChefClient"
             else
               raise "OS version #{server.os_version} for OS type #{server.os_type} is not supported."
             end
@@ -121,8 +121,8 @@ class Chef
           my_role = nil
           sleep_and_wait = false
           deployment = fetch_deployment
-          if deployment.at_css('Deployment Name') != nil
-            role_list_xml =  deployment.css('RoleInstanceList RoleInstance')
+          if deployment.at_css("Deployment Name") != nil
+            role_list_xml = deployment.css("RoleInstanceList RoleInstance")
             ## list of roles found under the deployment ##
             role_list_xml.each do |role|
               ## search in the roles list for the given role ##

--- a/lib/chef/knife/bootstrap_azure.rb
+++ b/lib/chef/knife/bootstrap_azure.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aliasgar Batterywala (aliasgar.batterywala@clogeny.com)
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/bootstrap_azurerm.rb
+++ b/lib/chef/knife/bootstrap_azurerm.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Nimisha Sharad (nimisha.sharad@clogeny.com)
 #
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/bootstrap_azurerm.rb
+++ b/lib/chef/knife/bootstrap_azurerm.rb
@@ -17,11 +17,11 @@
 # limitations under the License.
 #
 
-require 'chef/knife/azurerm_base'
-require 'chef/knife/bootstrap/common_bootstrap_options'
-require 'chef/knife/bootstrap/bootstrapper'
-require 'azure/resource_management/ARM_interface'
-require 'time'
+require "chef/knife/azurerm_base"
+require "chef/knife/bootstrap/common_bootstrap_options"
+require "chef/knife/bootstrap/bootstrapper"
+require "azure/resource_management/ARM_interface"
+require "time"
 
 class Chef
   class Knife
@@ -49,16 +49,16 @@ class Chef
             ext_params = set_ext_params
             vm_extension = service.create_vm_extension(ext_params)
             if vm_extension
-              if ext_params[:chef_extension_public_param][:extendedLogs] == 'true'
+              if ext_params[:chef_extension_public_param][:extendedLogs] == "true"
                 service.fetch_chef_client_logs(ext_params[:azure_resource_group_name], ext_params[:azure_vm_name], ext_params[:chef_extension], Time.now)
-              end 
+              end
               ui.log("VirtualMachineExtension creation successfull.")
               ui.log("Virtual Machine Extension name is: #{vm_extension.name}")
               ui.log("Virtual Machine Extension ID is: #{vm_extension.id}")
             end
           else
-            raise ArgumentError, 'Please specify the SERVER name which needs to be bootstrapped via the Chef Extension.' if @name_args.length == 0
-            raise ArgumentError, 'Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension.' if @name_args.length > 1
+            raise ArgumentError, "Please specify the SERVER name which needs to be bootstrapped via the Chef Extension." if @name_args.length == 0
+            raise ArgumentError, "Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension." if @name_args.length > 1
           end
         rescue => error
           service.common_arm_rescue_block(error)
@@ -74,11 +74,11 @@ class Chef
           else
             ext_params = Hash.new
             case server.storage_profile.os_disk.os_type.downcase
-            when 'windows'
-              ext_params[:chef_extension] = 'ChefClient'
-            when 'linux'
-              if ['ubuntu', 'debian', 'rhel', 'centos'].any? { |platform| server.storage_profile.image_reference.offer.downcase.include? platform }
-                ext_params[:chef_extension] = 'LinuxChefClient'
+            when "windows"
+              ext_params[:chef_extension] = "ChefClient"
+            when "linux"
+              if %w{ubuntu debian rhel centos}.any? { |platform| server.storage_profile.image_reference.offer.downcase.include? platform }
+                ext_params[:chef_extension] = "LinuxChefClient"
               else
                 raise "Offer #{server.storage_profile.image_reference.offer} is not supported in the extension."
               end

--- a/lib/knife-azure/version.rb
+++ b/lib/knife-azure/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Azure
     VERSION = "1.8.5"
-    MAJOR, MINOR, TINY = VERSION.split('.')
+    MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end

--- a/spec/functional/ag_test.rb
+++ b/spec/functional/ag_test.rb
@@ -1,21 +1,21 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
-describe 'ags' do
+describe "ags" do
   before(:all) do
     @connection = Azure::Connection.new(TEST_PARAMS)
   end
 
-  it 'create' do
-    rsp = @connection.ags.create(azure_ag_name: 'func-test-new-ag',
-                                 azure_location: 'West US')
-    rsp.at_css('Status').should_not be_nil
-    rsp.at_css('Status').content.should eq('Succeeded')
+  it "create" do
+    rsp = @connection.ags.create(azure_ag_name: "func-test-new-ag",
+                                 azure_location: "West US")
+    rsp.at_css("Status").should_not be_nil
+    rsp.at_css("Status").content.should eq("Succeeded")
   end
 
-  specify { @connection.ags.exists?('notexist').should eq(false) }
-  specify { @connection.ags.exists?('func-test-new-ag').should eq(true) }
+  specify { @connection.ags.exists?("notexist").should eq(false) }
+  specify { @connection.ags.exists?("func-test-new-ag").should eq(true) }
 
-  it 'run through' do
+  it "run through" do
     @connection.ags.all.each do |ag|
       ag.name.should_not be_nil
       ag.location.should_not be_nil

--- a/spec/functional/deploys_test.rb
+++ b/spec/functional/deploys_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe "deploys" do
   before(:all) do
@@ -6,8 +6,8 @@ describe "deploys" do
     @deploys = @connection.deploys.all
   end
 
-  specify {@deploys.length.should be > 0}
-  it 'each deployment should have values' do
+  specify { @deploys.length.should be > 0 }
+  it "each deployment should have values" do
     @deploys.each do |deploy|
       deploy.name.should_not be_nil
       deploy.status.should_not be_nil
@@ -15,22 +15,22 @@ describe "deploys" do
       deploy.roles.length.should be > 0
     end
   end
-  it 'each role should have values' do
+  it "each role should have values" do
     @deploys.each do |deploy|
-        Chef::Log.info '============================='
-      Chef::Log.info 'hosted service: ' + deploy.hostedservicename + '  deployment: ' + deploy.name
+      Chef::Log.info "============================="
+      Chef::Log.info "hosted service: " + deploy.hostedservicename + "  deployment: " + deploy.name
       deploy.roles.each do |role|
         role.name.should_not be_nil
         role.status.should_not be_nil
         role.size.should_not be_nil
         role.ipaddress.should_not be_nil
         role.sshport.should_not be_nil
-        Chef::Log.info '============================='
-        Chef::Log.info 'role: ' + role.name
-        Chef::Log.info 'status: ' + role.status
-        Chef::Log.info 'size: ' + role.size
-        Chef::Log.info 'ip address: ' + role.ipaddress
-        Chef::Log.info 'ssh port: ' + role.sshport
+        Chef::Log.info "============================="
+        Chef::Log.info "role: " + role.name
+        Chef::Log.info "status: " + role.status
+        Chef::Log.info "size: " + role.size
+        Chef::Log.info "ip address: " + role.ipaddress
+        Chef::Log.info "ssh port: " + role.sshport
       end
     end
   end

--- a/spec/functional/host_test.rb
+++ b/spec/functional/host_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe "Connection" do
 
@@ -8,8 +8,8 @@ describe "Connection" do
   end
 
   specify { @items.length.should be > 0 }
-  specify { @connection.hosts.exists?('thisServiceShouldNotBeThere').should == false }
-  specify { @connection.hosts.exists?('service002').should == true }
+  specify { @connection.hosts.exists?("thisServiceShouldNotBeThere").should == false }
+  specify { @connection.hosts.exists?("service002").should == true }
   it "looking for a specific host" do
     foundNamedHost = false
     @items.each do |host|
@@ -19,4 +19,3 @@ describe "Connection" do
     foundNamedHost.should == true
   end
 end
-

--- a/spec/functional/images_list_test.rb
+++ b/spec/functional/images_list_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe "Connection" do
 
@@ -19,7 +19,6 @@ describe "Connection" do
     end
   end
 
-
   #  it "should get services" do
   #    @demo.DemoGet
   #  end
@@ -39,4 +38,3 @@ describe "Connection" do
   #    expect{@demo.DemoGet}.to raise_error(RuntimeError, /ResourceNotFound/)
   #  end
 end
-

--- a/spec/functional/role_test.rb
+++ b/spec/functional/role_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe "roles" do
   before(:all) do
@@ -6,9 +6,9 @@ describe "roles" do
     @roles = @connection.roles.all
   end
 
-  specify { @connection.roles.exists?('notexist').should == false }
-  specify { @connection.roles.exists?('role126').should == true }
-  it 'run through roles' do
+  specify { @connection.roles.exists?("notexist").should == false }
+  specify { @connection.roles.exists?("role126").should == true }
+  it "run through roles" do
     @connection.roles.roles.each do |role|
       role.name.should_not be_nil
     end

--- a/spec/functional/vnet_test.rb
+++ b/spec/functional/vnet_test.rb
@@ -1,25 +1,25 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
-describe 'vnets' do
+describe "vnets" do
   before(:all) do
     @connection = Azure::Connection.new(TEST_PARAMS)
-    @connection.ags.create(azure_ag_name: 'func-test-agforvnet',
-                           azure_location: 'West US')
+    @connection.ags.create(azure_ag_name: "func-test-agforvnet",
+                           azure_location: "West US")
   end
 
-  it 'create' do
+  it "create" do
     rsp = @connection.vnets.create(
-      azure_vnet_name: 'func-test-new-vnet',
-      azure_ag_name: 'func-test-agforvnet',
-      azure_address_space: '10.0.0.0/16')
-    rsp.at_css('Status').should_not be_nil
-    rsp.at_css('Status').content.should eq('Succeeded')
+      azure_vnet_name: "func-test-new-vnet",
+      azure_ag_name: "func-test-agforvnet",
+      azure_address_space: "10.0.0.0/16")
+    rsp.at_css("Status").should_not be_nil
+    rsp.at_css("Status").content.should eq("Succeeded")
   end
 
-  specify { @connection.vnets.exists?('notexist').should eq(false) }
-  specify { @connection.vnets.exists?('func-test-new-vnet').should eq(true) }
+  specify { @connection.vnets.exists?("notexist").should eq(false) }
+  specify { @connection.vnets.exists?("func-test-new-vnet").should eq(true) }
 
-  it 'run through' do
+  it "run through" do
     @connection.vnets.all.each do |vnet|
       vnet.name.should_not be_nil
       vnet.affinity_group.should_not be_nil

--- a/spec/integration/azure_spec.rb
+++ b/spec/integration/azure_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2013 Opscode, Inc.
+# Copyright: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/integration/azure_spec.rb
+++ b/spec/integration/azure_spec.rb
@@ -1,3 +1,5 @@
+#
+# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
 # Copyright: Copyright 2013-2018 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
@@ -13,23 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author:: Siddheshwar More (<siddheshwar.more@clogeny.com>)
-
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 def append_azure_creds(*options)
-  is_publishsettings_file = options.include?("publishsettings_file") ?  true : false
+  is_publishsettings_file = options.include?("publishsettings_file") ? true : false
   is_list_cmd = options.include?("list_cmd") ? true : false
 
-  if(is_publishsettings_file)
+  if is_publishsettings_file
     azure_creds_cmd = " --azure-publish-settings-file '#{ENV['AZURE_PUBLISH_SETTINGS_FILE']}'"
   else
     azure_creds_cmd = " --azure-subscription-id '#{ENV['AZURE_SUBSCRIPTION_ID']}' --azure-api-host-name '#{ENV['AZURE_API_HOST_NAME']}' --azure-mgmt-cert '#{ENV['AZURE_MGMT_CERT']}'"
   end
 
-  azure_creds_cmd = azure_creds_cmd + " --config #{temp_dir}/knife.rb"
+  azure_creds_cmd += " --config #{temp_dir}/knife.rb"
 
-  azure_creds_cmd = azure_creds_cmd + " --azure-service-location #{@azure_service_location}" if !is_list_cmd
+  azure_creds_cmd += " --azure-service-location #{@azure_service_location}" if !is_list_cmd
 
   azure_creds_cmd
 end
@@ -63,23 +63,23 @@ def get_active_instance_id
       return instance_id
     end
   end
-  return false
+  false
 end
 
-def create_dns_name()
-  @dns_name  = "az-testdns#{SecureRandom.hex(2)}"
+def create_dns_name
+  @dns_name = "az-testdns#{SecureRandom.hex(2)}"
 end
 
-def create_vm_name(name="linux")
-  @vm_name  = (name == "linux") ? "az-testlnx#{SecureRandom.hex(2)}" :  "az-testwin#{SecureRandom.hex(2)}"
+def create_vm_name(name = "linux")
+  @vm_name = (name == "linux") ? "az-testlnx#{SecureRandom.hex(2)}" : "az-testwin#{SecureRandom.hex(2)}"
 end
 
-describe 'knife-azure integration test' , :if => is_config_present do
+describe "knife-azure integration test", if: is_config_present do
   include KnifeTestBed
   include RSpec::KnifeTestUtils
 
   before(:all) do
-    expect(run('gem build knife-azure.gemspec').exitstatus).to be(0)
+    expect(run("gem build knife-azure.gemspec").exitstatus).to be(0)
     expect(run("gem install #{get_gem_file_name}").exitstatus).to be(0)
     init_azure_test
   end
@@ -89,7 +89,7 @@ describe 'knife-azure integration test' , :if => is_config_present do
     cleanup_test_data
   end
 
-  describe 'display help for command' do
+  describe "display help for command" do
     %w{server\ create server\ delete server\ list image\ list server\ show vnet\ create vnet\ list ag\ create ag\ list}.each do |command|
       context "when --help option used with #{command} command" do
         let(:command) { "knife azure #{command} --help" }
@@ -98,36 +98,36 @@ describe 'knife-azure integration test' , :if => is_config_present do
     end
   end
 
-  describe 'display server list' do
-    context 'when standard options specified' do
+  describe "display server list" do
+    context "when standard options specified" do
       let(:command) { "knife azure server list" + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "VM Name")
     end
   end
 
-  describe 'display image list' do
-    context 'when standard options specified' do
+  describe "display image list" do
+    context "when standard options specified" do
       let(:command) { "knife azure image list" + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "Name")
     end
   end
 
-  describe 'display vnet list' do
-    context 'when standard options specified' do
+  describe "display vnet list" do
+    context "when standard options specified" do
       let(:command) { "knife azure vnet list" + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "Name")
     end
   end
 
-  describe 'display ag list' do
-    context 'when standard options specified' do
+  describe "display ag list" do
+    context "when standard options specified" do
       let(:command) { "knife azure ag list" + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "Name")
     end
   end
 
-  describe 'server show' do
-    context 'with valid instance_id' do
+  describe "server show" do
+    context "with valid instance_id" do
       before(:each) do
         @instance_id = get_active_instance_id
       end
@@ -136,177 +136,195 @@ describe 'knife-azure integration test' , :if => is_config_present do
     end
   end
 
-  describe 'create and bootstrap Linux Server'  do
-    before(:each) {rm_known_host}
-    context 'when standard options specified and --azure-dns-name option' do
+  describe "create and bootstrap Linux Server" do
+    before(:each) { rm_known_host }
+    context "when standard options specified and --azure-dns-name option" do
       before(:all) { create_dns_name }
 
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-       append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-       " --template-file " + get_linux_template_file_path +
-       " --server-url http://localhost:8889" + " --yes" }
+      let(:command) do
+        "knife azure server create --azure-dns-name #{@dns_name}" +
+          append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+          " --template-file " + get_linux_template_file_path +
+          " --server-url http://localhost:8889" + " --yes" end
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'delete Linux server by using server name and standard option' do
-      let(:command) { delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd")}
+    context "delete Linux server by using server name and standard option" do
+      let(:command) { delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'when publishsettings file specified and --azure-dns-name option' do
+    context "when publishsettings file specified and --azure-dns-name option" do
       before(:all) { create_dns_name }
 
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-      append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
-      " --template-file " + get_linux_template_file_path + get_ssh_credentials +
-      " --server-url http://localhost:8889" + " --yes" }
+      let(:command) do
+        "knife azure server create --azure-dns-name #{@dns_name}" +
+          append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
+          " --template-file " + get_linux_template_file_path + get_ssh_credentials +
+          " --server-url http://localhost:8889" + " --yes" end
 
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'delete Linux server by using server name and publishsettings file' do
-      let(:command) { delete_instance_cmd(@dns_name) + append_azure_creds("publishsettings_file","list_cmd")}
+    context "delete Linux server by using server name and publishsettings file" do
+      let(:command) { delete_instance_cmd(@dns_name) + append_azure_creds("publishsettings_file", "list_cmd") }
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'skip user specified --tcp-endpoints if its external port is same as ssh external port' do
+    context "skip user specified --tcp-endpoints if its external port is same as ssh external port" do
       before(:all) { create_dns_name }
       after(:all) { run(delete_instance_cmd + append_azure_creds("list_cmd")) }
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-      append_azure_creds("publishsettings_file") + get_ssh_credentials +
-      " --azure-source-image #{@az_linux_image}" + " --template-file " +
-      get_linux_template_file_path + " --server-url http://localhost:8889" +
-      " --tcp-endpoints 22:22,1234:1234" + " --yes" }
+      let(:command) do
+        "knife azure server create --azure-dns-name #{@dns_name}" +
+          append_azure_creds("publishsettings_file") + get_ssh_credentials +
+          " --azure-source-image #{@az_linux_image}" + " --template-file " +
+          get_linux_template_file_path + " --server-url http://localhost:8889" +
+          " --tcp-endpoints 22:22,1234:1234" + " --yes" end
 
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'when azure-connect-to-existing-dns option' do
+    context "when azure-connect-to-existing-dns option" do
       before(:all) { create_dns_name; create_vm_name }
-      context 'create Linux VM for azure-connect-to-existing-dns' do
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-        " --template-file " + get_linux_template_file_path +
-        " --server-url http://localhost:8889" + " --yes" }
+      context "create Linux VM for azure-connect-to-existing-dns" do
+        let(:command) do
+          "knife azure server create --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+            " --template-file " + get_linux_template_file_path +
+            " --server-url http://localhost:8889" + " --yes" end
         run_cmd_check_status_and_output("succeed", "#{@dns_name}")
       end
 
-      context 'create Linux VM by using standard option and connect-to-existing-dns' do
-        let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-        " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
-        " --yes --azure-connect-to-existing-dns" }
+      context "create Linux VM by using standard option and connect-to-existing-dns" do
+        let(:command) do
+          "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+            " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
+            " --yes --azure-connect-to-existing-dns" end
         run_cmd_check_status_and_output("succeed", "#{@vm_name}")
       end
 
-      context 'delete Linux server, Chef node, Chef client by using --purge' do
-        let(:command) { delete_instance_cmd(@dns_name) +
-        append_azure_creds("list_cmd") + " --purge" }
+      context "delete Linux server, Chef node, Chef client by using --purge" do
+        let(:command) do
+          delete_instance_cmd(@dns_name) +
+            append_azure_creds("list_cmd") + " --purge" end
         run_cmd_check_status_and_output("succeed", "#{@dns_name}")
       end
 
-      context 'delete Linux server, Chef node, Chef client by using --purge and preserve dns' do
-        let(:command) { delete_instance_cmd(@vm_name) +
-        append_azure_creds("list_cmd") + " --yes --purge --preserve-azure-dns-name"}
+      context "delete Linux server, Chef node, Chef client by using --purge and preserve dns" do
+        let(:command) do
+          delete_instance_cmd(@vm_name) +
+            append_azure_creds("list_cmd") + " --yes --purge --preserve-azure-dns-name" end
         run_cmd_check_status_and_output("succeed", "#{@vm_name}")
       end
 
-      context 'when having duplicate ssh port ' do
-        before(:each) {run("knife azure server create --azure-vm-name #{@dns_name} --azure-dns-name #{@dns_name}" + append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+      context "when having duplicate ssh port " do
+        before(:each) do
+           run("knife azure server create --azure-vm-name #{@dns_name} --azure-dns-name #{@dns_name}" + append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
           " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
-          " --ssh-port 245 --yes --azure-connect-to-existing-dns")}
+          " --ssh-port 245 --yes --azure-connect-to-existing-dns") end
 
-        after(:each)  { run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") + " --purge")}
+        after(:each)  { run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") + " --purge") }
 
-        let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-        " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
-        " --ssh-port 245 --yes --azure-connect-to-existing-dns" }
+        let(:command) do
+          "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+            " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
+            " --ssh-port 245 --yes --azure-connect-to-existing-dns" end
         run_cmd_check_status_and_output("fail", "")
       end
 
-      context 'when having out of range ssh port' do
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_linux_image}" +
-        " --template-file " + get_linux_template_file_path + get_ssh_credentials +
-        " --server-url http://localhost:8889" + " --ssh-port 900000 --yes" }
+      context "when having out of range ssh port" do
+        let(:command) do
+          "knife azure server create --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_linux_image}" +
+            " --template-file " + get_linux_template_file_path + get_ssh_credentials +
+            " --server-url http://localhost:8889" + " --ssh-port 900000 --yes" end
         run_cmd_check_status_and_output("fail", "")
       end
 
-      context 'when having duplicate dns name option' do
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-        append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
-        " --template-file " + get_linux_template_file_path + get_ssh_credentials +
-        " --server-url http://localhost:8889" + " --yes" }
+      context "when having duplicate dns name option" do
+        let(:command) do
+          "knife azure server create --azure-dns-name #{@dns_name}" +
+            append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
+            " --template-file " + get_linux_template_file_path + get_ssh_credentials +
+            " --server-url http://localhost:8889" + " --yes" end
         run_cmd_check_status_and_output("fail", "")
       end
 
-      context 'when standard option and over write default ssh port ' do
+      context "when standard option and over write default ssh port " do
         after(:each)  { run(delete_instance_cmd(@vm_name) + append_azure_creds("list_cmd")) }
 
-        let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-        " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
-        " --ssh-port 3245 --yes --azure-connect-to-existing-dns" }
+        let(:command) do
+          "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
+            " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
+            " --ssh-port 3245 --yes --azure-connect-to-existing-dns" end
 
         run_cmd_check_status_and_output("succeed", "#{@vm_name}")
       end
     end
   end
 
-  describe 'create and bootstrap Windows Server'  do
-    before(:each) {rm_known_host}
+  describe "create and bootstrap Windows Server" do
+    before(:each) { rm_known_host }
 
-    context 'create Windows VM by using standard and --azure-dns-name option' do
+    context "create Windows VM by using standard and --azure-dns-name option" do
       before(:all) { create_dns_name }
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-      append_azure_creds + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
-      " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" + " --yes" }
+      let(:command) do
+        "knife azure server create --azure-dns-name #{@dns_name}" +
+          append_azure_creds + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
+          " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" + " --yes" end
 
       run_cmd_check_status_and_output("succeed", @dns_name)
     end
 
-    context 'delete Windows server by using server name and standard option' do
+    context "delete Windows server by using server name and standard option" do
       let(:command) { delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") }
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'create Windows VM by using publishsettings file and skip user specified --tcp-endpoints if its external port is same as winrm external port' do
+    context "create Windows VM by using publishsettings file and skip user specified --tcp-endpoints if its external port is same as winrm external port" do
       before(:all) { create_dns_name }
       after(:each) { run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd")) }
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
-      append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_windows_image}" +
-      get_winrm_credentials + " --template-file " + get_windows_msi_template_file_path +
-      " --server-url http://localhost:8889" + " --tcp-endpoints 5985:5985,1234:1234"  + " --yes" }
+      let(:command) do
+        "knife azure server create --azure-dns-name #{@dns_name}" +
+          append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_windows_image}" +
+          get_winrm_credentials + " --template-file " + get_windows_msi_template_file_path +
+          " --server-url http://localhost:8889" + " --tcp-endpoints 5985:5985,1234:1234" + " --yes" end
 
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
-    context 'when azure-connect-to-existing-dns' do
+    context "when azure-connect-to-existing-dns" do
       before(:all) { create_dns_name; create_vm_name("windows") }
 
-      context 'create Windows VM for azure-connect-to-existing-dns' do
+      context "create Windows VM for azure-connect-to-existing-dns" do
 
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + append_azure_creds +
-        " --azure-source-image #{@az_windows_image}" + " --template-file " + get_windows_msi_template_file_path +
-        " --server-url http://localhost:8889" + get_winrm_credentials + " --yes" }
+        let(:command) do
+          "knife azure server create --azure-dns-name #{@dns_name}" + append_azure_creds +
+            " --azure-source-image #{@az_windows_image}" + " --template-file " + get_windows_msi_template_file_path +
+            " --server-url http://localhost:8889" + get_winrm_credentials + " --yes" end
         run_cmd_check_status_and_output("succeed", "#{@dns_name}")
       end
 
-      context 'create Windows VM by using standard option and connect-to-existing-dns and having duplicate winrm port' do
-        after(:each)  { run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") +
-        " --purge --preserve-azure-dns-name") }
-        let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
-        append_azure_creds + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
-        " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" +
-        " --winrm-port 5682 --yes --azure-connect-to-existing-dns" }
+      context "create Windows VM by using standard option and connect-to-existing-dns and having duplicate winrm port" do
+        after(:each)  do
+          run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") +
+        " --purge --preserve-azure-dns-name") end
+        let(:command) do
+          "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
+            append_azure_creds + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
+            " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" +
+            " --winrm-port 5682 --yes --azure-connect-to-existing-dns" end
         run_cmd_check_status_and_output("fail", "")
       end
 
-      context 'create Windows VM by using standard option and connect-to-existing-dns and over write default winrm port ' do
+      context "create Windows VM by using standard option and connect-to-existing-dns and over write default winrm port " do
         after(:each)  { run(delete_instance_cmd(@vm_name) + append_azure_creds("list_cmd")) }
-        let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" + append_azure_creds_for_windows + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
-         " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" + " --winrm-port 5682 --yes --azure-connect-to-existing-dns" }
+        let(:command) do
+          "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" + append_azure_creds_for_windows + " --azure-source-image #{@az_windows_image}" + get_winrm_credentials +
+            " --template-file " + get_windows_msi_template_file_path + " --server-url http://localhost:8889" + " --winrm-port 5682 --yes --azure-connect-to-existing-dns" end
         run_cmd_check_status_and_output("succeed", "#{@vm_name}")
       end
     end

--- a/spec/integration/azure_spec.rb
+++ b/spec/integration/azure_spec.rb
@@ -56,7 +56,7 @@ def get_active_instance_id
   else
     servers = server_list_output.stdout
   end
-  
+
   servers.each_line do |line|
     if line.include?("ready")
       instance_id = line.split(" ")[1]
@@ -81,7 +81,7 @@ describe 'knife-azure integration test' , :if => is_config_present do
   before(:all) do
     expect(run('gem build knife-azure.gemspec').exitstatus).to be(0)
     expect(run("gem install #{get_gem_file_name}").exitstatus).to be(0)
-    init_azure_test 
+    init_azure_test
   end
 
   after(:all) do
@@ -140,10 +140,10 @@ describe 'knife-azure integration test' , :if => is_config_present do
     before(:each) {rm_known_host}
     context 'when standard options specified and --azure-dns-name option' do
       before(:all) { create_dns_name }
-      
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + 
+
+      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
        append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-       " --template-file " + get_linux_template_file_path + 
+       " --template-file " + get_linux_template_file_path +
        " --server-url http://localhost:8889" + " --yes" }
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
@@ -156,7 +156,7 @@ describe 'knife-azure integration test' , :if => is_config_present do
     context 'when publishsettings file specified and --azure-dns-name option' do
       before(:all) { create_dns_name }
 
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + 
+      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
       append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
       " --template-file " + get_linux_template_file_path + get_ssh_credentials +
       " --server-url http://localhost:8889" + " --yes" }
@@ -172,12 +172,12 @@ describe 'knife-azure integration test' , :if => is_config_present do
     context 'skip user specified --tcp-endpoints if its external port is same as ssh external port' do
       before(:all) { create_dns_name }
       after(:all) { run(delete_instance_cmd + append_azure_creds("list_cmd")) }
-      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + 
+      let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
       append_azure_creds("publishsettings_file") + get_ssh_credentials +
       " --azure-source-image #{@az_linux_image}" + " --template-file " +
-      get_linux_template_file_path + " --server-url http://localhost:8889" + 
+      get_linux_template_file_path + " --server-url http://localhost:8889" +
       " --tcp-endpoints 22:22,1234:1234" + " --yes" }
-      
+
       run_cmd_check_status_and_output("succeed", "#{@dns_name}")
     end
 
@@ -200,33 +200,33 @@ describe 'knife-azure integration test' , :if => is_config_present do
       end
 
       context 'delete Linux server, Chef node, Chef client by using --purge' do
-        let(:command) { delete_instance_cmd(@dns_name) + 
+        let(:command) { delete_instance_cmd(@dns_name) +
         append_azure_creds("list_cmd") + " --purge" }
         run_cmd_check_status_and_output("succeed", "#{@dns_name}")
       end
 
       context 'delete Linux server, Chef node, Chef client by using --purge and preserve dns' do
-        let(:command) { delete_instance_cmd(@vm_name) + 
+        let(:command) { delete_instance_cmd(@vm_name) +
         append_azure_creds("list_cmd") + " --yes --purge --preserve-azure-dns-name"}
         run_cmd_check_status_and_output("succeed", "#{@vm_name}")
       end
-      
+
       context 'when having duplicate ssh port ' do
         before(:each) {run("knife azure server create --azure-vm-name #{@dns_name} --azure-dns-name #{@dns_name}" + append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-          " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" + 
+          " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
           " --ssh-port 245 --yes --azure-connect-to-existing-dns")}
-        
+
         after(:each)  { run(delete_instance_cmd(@dns_name) + append_azure_creds("list_cmd") + " --purge")}
 
         let(:command) { "knife azure server create --azure-vm-name #{@vm_name} --azure-dns-name #{@dns_name}" +
         append_azure_creds + " --azure-source-image #{@az_linux_image}" + get_ssh_credentials +
-        " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" + 
+        " --template-file " + get_linux_template_file_path + " --server-url http://localhost:8889" +
         " --ssh-port 245 --yes --azure-connect-to-existing-dns" }
         run_cmd_check_status_and_output("fail", "")
       end
 
       context 'when having out of range ssh port' do
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + 
+        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
         append_azure_creds + " --azure-source-image #{@az_linux_image}" +
         " --template-file " + get_linux_template_file_path + get_ssh_credentials +
         " --server-url http://localhost:8889" + " --ssh-port 900000 --yes" }
@@ -234,8 +234,8 @@ describe 'knife-azure integration test' , :if => is_config_present do
       end
 
       context 'when having duplicate dns name option' do
-        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + 
-        append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" + 
+        let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" +
+        append_azure_creds("publishsettings_file") + " --azure-source-image #{@az_linux_image}" +
         " --template-file " + get_linux_template_file_path + get_ssh_credentials +
         " --server-url http://localhost:8889" + " --yes" }
         run_cmd_check_status_and_output("fail", "")
@@ -286,7 +286,7 @@ describe 'knife-azure integration test' , :if => is_config_present do
       before(:all) { create_dns_name; create_vm_name("windows") }
 
       context 'create Windows VM for azure-connect-to-existing-dns' do
-        
+
         let(:command) { "knife azure server create --azure-dns-name #{@dns_name}" + append_azure_creds +
         " --azure-source-image #{@az_windows_image}" + " --template-file " + get_windows_msi_template_file_path +
         " --server-url http://localhost:8889" + get_winrm_credentials + " --yes" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,40 +1,38 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
+require "chef/knife/azure_ag_create"
+require "chef/knife/azure_ag_list"
+require "chef/knife/azure_image_list"
+require "chef/knife/azure_internal-lb_create"
+require "chef/knife/azure_internal-lb_list"
+require "chef/knife/azure_server_create"
+require "chef/knife/azure_server_delete"
+require "chef/knife/azure_server_show"
+require "chef/knife/azure_server_list"
+require "chef/knife/azure_vnet_create"
+require "chef/knife/azure_vnet_list"
 
-require 'chef/knife/azure_ag_create'
-require 'chef/knife/azure_ag_list'
-require 'chef/knife/azure_image_list'
-require 'chef/knife/azure_internal-lb_create'
-require 'chef/knife/azure_internal-lb_list'
-require 'chef/knife/azure_server_create'
-require 'chef/knife/azure_server_delete'
-require 'chef/knife/azure_server_show'
-require 'chef/knife/azure_server_list'
-require 'chef/knife/azure_vnet_create'
-require 'chef/knife/azure_vnet_list'
+require "chef/knife/azurerm_server_list"
+require "chef/knife/azurerm_server_show"
+require "chef/knife/azurerm_server_delete"
+require "chef/knife/azurerm_server_create"
+require "chef/knife/bootstrap_azure"
 
-require 'chef/knife/azurerm_server_list'
-require 'chef/knife/azurerm_server_show'
-require 'chef/knife/azurerm_server_delete'
-require 'chef/knife/azurerm_server_create'
-require 'chef/knife/bootstrap_azure'
-
-require 'chef/knife/bootstrap_azurerm'
+require "chef/knife/bootstrap_azurerm"
 
 if Chef::Platform.windows?
-  require 'azure/resource_management/windows_credentials'
+  require "azure/resource_management/windows_credentials"
 end
 
-require 'fileutils'
+require "fileutils"
 require "securerandom"
-require 'knife-azure/version'
-
+require "knife-azure/version"
 
 def temp_dir
   @_temp_dir ||= Dir.mktmpdir
 end
 
-def tmpFile filename
+def tmpFile(filename)
   temp_dir + "/" + filename
 end
 
@@ -45,10 +43,10 @@ RSpec.configure do |c|
 
   c.before(:all) do
     #Create an empty mock certificate file
-    @cert_file = tmpFile('AzureLinuxCert.pem')
+    @cert_file = tmpFile("AzureLinuxCert.pem")
     FileUtils.touch(@cert_file)
-    Chef::Log.init(tmpFile('debug.log'))
-    Chef::Log.level=:debug
+    Chef::Log.init(tmpFile("debug.log"))
+    Chef::Log.level = :debug
   end
 
   c.after(:all) do
@@ -64,17 +62,17 @@ TEST_PARAMS = {
 }
 
 module AzureSpecHelper
-  def readFile filename
+  def readFile(filename)
     File.read(File.dirname(__FILE__) + "/unit/assets/#{filename}")
   end
 
-  def get_publish_settings_file_path filename
+  def get_publish_settings_file_path(filename)
     File.dirname(__FILE__) + "/unit/assets/publish-settings-files/#{filename}"
   end
 end
 
 def is_config_present
-  if ! ENV['RUN_INTEGRATION_TESTS']
+  if ! ENV["RUN_INTEGRATION_TESTS"]
     puts("\nPlease set RUN_INTEGRATION_TESTS environment variable to run integration tests")
     return false
   end
@@ -85,9 +83,9 @@ def is_config_present
   config_file_exist = File.exist?(File.expand_path("../integration/config/environment.yml", __FILE__))
   azure_config = YAML.load(File.read(File.expand_path("../integration/config/environment.yml", __FILE__))) if config_file_exist
 
-  %w(AZURE_PUBLISH_SETTINGS_FILE AZURE_MGMT_CERT AZURE_SUBSCRIPTION_ID AZURE_API_HOST_NAME).each do |az_env_var|
+  %w{AZURE_PUBLISH_SETTINGS_FILE AZURE_MGMT_CERT AZURE_SUBSCRIPTION_ID AZURE_API_HOST_NAME}.each do |az_env_var|
     if ENV[az_env_var].nil?
-      unset_env_var <<  az_env_var
+      unset_env_var << az_env_var
       is_config = false
     end
   end
@@ -96,8 +94,7 @@ def is_config_present
   err_msg = err_msg + ( unset_env_var.length > 1 ? " variables " : " variable " ) + "for integration tests."
   puts err_msg unless unset_env_var.empty?
 
-
-  %w(AZ_SSH_USER  AZ_SSH_PASSWORD AZ_WINDOWS_SSH_USER AZ_WINDOWS_SSH_PASSWORD AZ_WINRM_USER AZ_WINRM_PASSWORD AZ_LINUX_IMAGE AZ_LINUX_VM_SIZE AZ_INVALID_VM_SIZE AZ_WINDOWS_VM_SIZE AZ_WINDOWS_IMAGE AZ_WINDOWS_SSH_IMAGE  AZURE_SERVICE_LOCATION).each do |os_config_opt|
+  %w{AZ_SSH_USER AZ_SSH_PASSWORD AZ_WINDOWS_SSH_USER AZ_WINDOWS_SSH_PASSWORD AZ_WINRM_USER AZ_WINRM_PASSWORD AZ_LINUX_IMAGE AZ_LINUX_VM_SIZE AZ_INVALID_VM_SIZE AZ_WINDOWS_VM_SIZE AZ_WINDOWS_IMAGE AZ_WINDOWS_SSH_IMAGE AZURE_SERVICE_LOCATION}.each do |os_config_opt|
     option_value = ENV[os_config_opt] || (azure_config[os_config_opt] if azure_config)
     if option_value.nil?
       unset_config_options << os_config_opt
@@ -129,16 +126,16 @@ def delete_instance_cmd(vm_name)
 end
 
 def create_node_name(name)
-  @name_node  = (name == "linux") ? "az-lnxtest#{SecureRandom.hex(4)}" :  "az-wintest-#{SecureRandom.hex(4)}"
+  @name_node = (name == "linux") ? "az-lnxtest#{SecureRandom.hex(4)}" : "az-wintest-#{SecureRandom.hex(4)}"
 end
 
 def init_azure_test
   init_test
 
   begin
-    %w(azure_invalid.publishsettings).each do |file_name|
+    %w{azure_invalid.publishsettings}.each do |file_name|
       data_to_write = File.read(File.expand_path("../integration/config/#{file_name}", __FILE__))
-      File.open("#{temp_dir}/#{file_name}", 'w') {|f| f.write(data_to_write)}
+      File.open("#{temp_dir}/#{file_name}", "w") { |f| f.write(data_to_write) }
     end
   rescue
     puts "Error while creating file - azure invalid"
@@ -147,17 +144,17 @@ def init_azure_test
   config_file_exist = File.exist?(File.expand_path("../integration/config/environment.yml", __FILE__))
   azure_config = YAML.load(File.read(File.expand_path("../integration/config/environment.yml", __FILE__))) if config_file_exist
 
-  %w(AZ_SSH_USER AZ_SSH_PASSWORD AZ_WINDOWS_SSH_USER AZ_WINDOWS_SSH_PASSWORD AZ_WINRM_USER AZ_WINRM_PASSWORD AZ_LINUX_IMAGE AZ_LINUX_VM_SIZE AZ_INVALID_VM_SIZE AZ_WINDOWS_VM_SIZE AZ_WINDOWS_IMAGE AZ_WINDOWS_SSH_IMAGE AZURE_SERVICE_LOCATION).each do |az_config_opt|
+  %w{AZ_SSH_USER AZ_SSH_PASSWORD AZ_WINDOWS_SSH_USER AZ_WINDOWS_SSH_PASSWORD AZ_WINRM_USER AZ_WINRM_PASSWORD AZ_LINUX_IMAGE AZ_LINUX_VM_SIZE AZ_INVALID_VM_SIZE AZ_WINDOWS_VM_SIZE AZ_WINDOWS_IMAGE AZ_WINDOWS_SSH_IMAGE AZURE_SERVICE_LOCATION}.each do |az_config_opt|
     instance_variable_set("@#{az_config_opt.downcase}", (azure_config[az_config_opt] if azure_config) || ENV[az_config_opt])
   end
 end
 
 def chef_gte_12?
-  Chef::VERSION.split('.').first.to_i >= 12
+  Chef::VERSION.split(".").first.to_i >= 12
 end
 
 def chef_lt_12?
-  Chef::VERSION.split('.').first.to_i < 12
+  Chef::VERSION.split(".").first.to_i < 12
 end
 
 def is_windows?

--- a/spec/unit/ags_spec.rb
+++ b/spec/unit/ags_spec.rb
@@ -1,16 +1,16 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
-describe 'ags' do
+describe "ags" do
   include AzureSpecHelper
   include QueryAzureMock
 
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -19,8 +19,8 @@ describe 'ags' do
     @connection = @server_instance.service.connection
   end
 
-  context 'mock with actually retrieved values' do
-    it 'should find strings' do
+  context "mock with actually retrieved values" do
+    it "should find strings" do
       items = @connection.ags.all
       expect(items.length).to be > 1
       items.each do |ag|
@@ -29,27 +29,27 @@ describe 'ags' do
         expect(ag.location).not_to be_nil
       end
     end
-    it 'should contain West US ag' do
+    it "should contain West US ag" do
       items = @connection.ags.all
       found_us = false
       items.each do |item|
-        found_us = true if item.location == 'West US'
+        found_us = true if item.location == "West US"
       end
       expect(found_us).to be true
     end
   end
 
-  context 'create a new affinity group' do
-    it 'using explicity parameters it should pass in expected body' do
+  context "create a new affinity group" do
+    it "using explicity parameters it should pass in expected body" do
       params = {
-        azure_ag_name: 'new-ag',
-        azure_ag_desc: 'ag description',
-        azure_location: 'West US'
+        azure_ag_name: "new-ag",
+        azure_ag_desc: "ag description",
+        azure_location: "West US"
       }
       @connection.ags.create(params)
-      expect(@postname).to eq('affinitygroups')
-      expect(@postverb).to eq('post')
-      expect(@postbody).to eq(readFile('create_ag_for_new-ag.xml'))
+      expect(@postname).to eq("affinitygroups")
+      expect(@postverb).to eq("post")
+      expect(@postbody).to eq(readFile("create_ag_for_new-ag.xml"))
     end
   end
 end

--- a/spec/unit/azure_ag_create_spec.rb
+++ b/spec/unit/azure_ag_create_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureAgCreate do
   include AzureSpecHelper
@@ -13,19 +13,19 @@ describe Chef::Knife::AzureAgCreate do
     allow(@server_instance).to receive(:print)
   end
 
-  it 'should fail missing args.' do
+  it "should fail missing args." do
     expect(@connection.ags).to_not receive(:create)
     expect(@server_instance.ui).to receive(:error).twice
     expect { @server_instance.run }.to raise_error(SystemExit)
   end
 
-  it 'should succeed.' do
-    Chef::Config[:knife][:azure_affinity_group] = 'new-ag'
-    Chef::Config[:knife][:azure_service_location] = 'West US'
+  it "should succeed." do
+    Chef::Config[:knife][:azure_affinity_group] = "new-ag"
+    Chef::Config[:knife][:azure_service_location] = "West US"
     expect(@connection.ags).to receive(:create).with(
-      azure_ag_name: 'new-ag',
+      azure_ag_name: "new-ag",
       azure_ag_desc: nil,
-      azure_location: 'West US',
+      azure_location: "West US"
     ).and_call_original
     expect(@server_instance.ui).to_not receive(:warn)
     expect(@server_instance.ui).to_not receive(:error)

--- a/spec/unit/azure_ag_list_spec.rb
+++ b/spec/unit/azure_ag_list_spec.rb
@@ -1,40 +1,40 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureAgList do
   include AzureSpecHelper
   include QueryAzureMock
   before do
     @server_instance = Chef::Knife::AzureAgList.new
-      {
-        :azure_subscription_id => 'azure_subscription_id',
-        :azure_mgmt_cert => @cert_file,
-        :azure_api_host_name => 'preview.core.windows-int.net',
-        :azure_service_location => 'West Europe',
-        :azure_source_image =>
-            'SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd',
-        :azure_dns_name => 'service001',
-        :azure_vm_name => 'vm01',
-        :azure_storage_account => 'ka001testeurope',
-        :azure_vm_size => 'Small'
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      :azure_subscription_id => "azure_subscription_id",
+      :azure_mgmt_cert => @cert_file,
+      :azure_api_host_name => "preview.core.windows-int.net",
+      :azure_service_location => "West Europe",
+      :azure_source_image =>
+          "SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd",
+      :azure_dns_name => "service001",
+      :azure_vm_name => "vm01",
+      :azure_storage_account => "ka001testeurope",
+      :azure_vm_size => "Small"
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
     stub_query_azure(@server_instance.service.connection)
     allow(@server_instance).to receive(:items).and_return(:true)
     allow(@server_instance).to receive(:puts)
   end
 
-    it 'should display Name, Location, and Description columns.' do
-      expect(@server_instance.ui).to receive(:list).with(
-        ['Name', 'Location', 'Description',
-         'agname', 'West US', 'agdesc',
-         'jm-affinity-group', 'West US', '',
-         'test', 'West US', 'testdesc',
-        ],
-        :uneven_columns_across,
-        3)
-      @server_instance.run
-    end
+  it "should display Name, Location, and Description columns." do
+    expect(@server_instance.ui).to receive(:list).with(
+      ["Name", "Location", "Description",
+       "agname", "West US", "agdesc",
+       "jm-affinity-group", "West US", "",
+       "test", "West US", "testdesc",
+      ],
+      :uneven_columns_across,
+      3)
+    @server_instance.run
+  end
 
 end

--- a/spec/unit/azure_base_spec.rb
+++ b/spec/unit/azure_base_spec.rb
@@ -2,227 +2,227 @@
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.#
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe Chef::Knife::AzureBase do
-	include AzureSpecHelper
-	class Chef
-  		class Knife
-			class DummyClass < Knife
-				include Knife::AzureBase
-  			end
-  		end
-  	end
-	before do
-		@dummy = Chef::Knife::DummyClass.new
-		Chef::Config[:knife][:azure_api_host_name] = 'preview.core.windows-int.net'
-		Chef::Config[:knife][:azure_subscription_id] = 'azure_subscription_id'
-		Chef::Config[:knife][:azure_mgmt_cert] = @cert_file
-		allow(@dummy.ui).to receive(:error)
-	end
-	describe "azure base tests - " do
-		context "Tests for publish settings file" do
-			before do
-				Chef::Config[:knife][:azure_api_host_name] = nil
-				Chef::Config[:knife][:azure_subscription_id] = nil
-			end
+  include AzureSpecHelper
+  class Chef
+    class Knife
+      class DummyClass < Knife
+        include Knife::AzureBase
+       end
+   end
+    end
+  before do
+    @dummy = Chef::Knife::DummyClass.new
+    Chef::Config[:knife][:azure_api_host_name] = "preview.core.windows-int.net"
+    Chef::Config[:knife][:azure_subscription_id] = "azure_subscription_id"
+    Chef::Config[:knife][:azure_mgmt_cert] = @cert_file
+    allow(@dummy.ui).to receive(:error)
+  end
+  describe "azure base tests - " do
+    context "Tests for publish settings file" do
+      before do
+        Chef::Config[:knife][:azure_api_host_name] = nil
+        Chef::Config[:knife][:azure_subscription_id] = nil
+      end
 
-			def validate_cert()
-				expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN CERTIFICATE-----")
-				expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----END CERTIFICATE-----")
-				expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN RSA PRIVATE KEY-----")
-				expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----END RSA PRIVATE KEY-----")
-			end
+      def validate_cert
+        expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN CERTIFICATE-----")
+        expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----END CERTIFICATE-----")
+        expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN RSA PRIVATE KEY-----")
+        expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----END RSA PRIVATE KEY-----")
+      end
 
-			it "- should continue to regular flow if publish settings file not provided" do
-				allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/C_account_azure_arm_profile.json")
-				Chef::Config[:knife][:azure_api_host_name] = "preview.core.windows-int.net"
-				Chef::Config[:knife][:azure_subscription_id] = "azure_subscription_id"
-				@dummy.validate_asm_keys!
-				expect(Chef::Config[:knife][:azure_api_host_name]).to be == "preview.core.windows-int.net"
-				expect(Chef::Config[:knife][:azure_subscription_id]).to be == "azure_subscription_id"
-			end
+      it "- should continue to regular flow if publish settings file not provided" do
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/C_account_azure_arm_profile.json")
+        Chef::Config[:knife][:azure_api_host_name] = "preview.core.windows-int.net"
+        Chef::Config[:knife][:azure_subscription_id] = "azure_subscription_id"
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "preview.core.windows-int.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "azure_subscription_id"
+      end
 
-			it "- should validate extract parameters" do
-				Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
-				@dummy.validate_asm_keys!
-				expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-				expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
-				validate_cert()
-			end
+      it "- should validate extract parameters" do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
+        validate_cert()
+      end
 
-			it "- should validate parse method" do
-				@dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValid.publishsettings"))
-				expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-				expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
-				validate_cert()
-			end
+      it "- should validate parse method" do
+        @dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValid.publishsettings"))
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
+        validate_cert()
+      end
 
-			it "- should validate parse method for SchemaVersion2-0 publishsettings file" do
-				@dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValidSchemaVersion-2.0.publishsettings"))
-				expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-				expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
-				validate_cert()
-			end
+      it "- should validate parse method for SchemaVersion2-0 publishsettings file" do
+        @dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValidSchemaVersion-2.0.publishsettings"))
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
+        validate_cert()
+      end
 
-			it "- should validate settings file and subscrition id" do
-				@dummy.config[:azure_subscription_id] = "azure_subscription_id"
-				Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
-				@dummy.validate_asm_keys!
-				expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-				expect(@dummy.config[:azure_subscription_id]).to be == 'azure_subscription_id'
-				expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
-				validate_cert()
-			end
+      it "- should validate settings file and subscrition id" do
+        @dummy.config[:azure_subscription_id] = "azure_subscription_id"
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(@dummy.config[:azure_subscription_id]).to be == "azure_subscription_id"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
+        validate_cert()
+      end
 
-			it "- should raise error if invalid publish settings provided" do
-				Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureInvalid.publishsettings")
-				expect {@dummy.validate_asm_keys!}.to raise_error(SystemExit)
-			end
+      it "- should raise error if invalid publish settings provided" do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureInvalid.publishsettings")
+        expect { @dummy.validate_asm_keys! }.to raise_error(SystemExit)
+      end
 
-			it "- should raise error if publish settings file does not exists" do
-				Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureNotAvailable.publishsettings")
-				expect {@dummy.validate_asm_keys!}.to raise_error(SystemExit)
-			end
-		end
-	end
+      it "- should raise error if publish settings file does not exists" do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureNotAvailable.publishsettings")
+        expect { @dummy.validate_asm_keys! }.to raise_error(SystemExit)
+      end
+    end
+  end
 
-	describe "azure base tests - for azure profile" do
-	  before(:each) do
-	    Chef::Config[:knife][:azure_mgmt_cert] = nil
-	  end
+  describe "azure base tests - for azure profile" do
+    before(:each) do
+      Chef::Config[:knife][:azure_mgmt_cert] = nil
+    end
 
-	  context "when publishSettings file specified in knife.rb has A account and azureProfile file has B account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("A_account.publishsettings")
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/B_account_azure_profile.json")
-	  	end
+    context "when publishSettings file specified in knife.rb has A account and azureProfile file has B account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("A_account.publishsettings")
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/B_account_azure_profile.json")
+      end
 
-	  	it "selects A account of publishSettings file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('A.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('A_subscription_id')
-	  	end
-	  end
+      it "selects A account of publishSettings file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("A.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("A_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file specified in knife.rb has B account and azureProfile file has A account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("B_account.publishsettings")
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_account_azure_profile.json")
-	  	  Chef::Config[:knife][:azure_api_host_name] = 'preview.core.windows-int.net'
-				Chef::Config[:knife][:azure_subscription_id] = 'azure_subscription_id'
-				Chef::Config[:knife][:azure_mgmt_cert] = @cert_file
-	  	end
+    context "when publishSettings file specified in knife.rb has B account and azureProfile file has A account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("B_account.publishsettings")
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_account_azure_profile.json")
+        Chef::Config[:knife][:azure_api_host_name] = "preview.core.windows-int.net"
+        Chef::Config[:knife][:azure_subscription_id] = "azure_subscription_id"
+        Chef::Config[:knife][:azure_mgmt_cert] = @cert_file
+      end
 
-	  	it "selects B account of publishSettings file" do
-	  		@dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('B.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('B_subscription_id')
-	  	end
-	  end
+      it "selects B account of publishSettings file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("B.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("B_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file is not specified in knife.rb and azureProfile file has A account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = nil
-	  	  Chef::Config[:knife][:azure_api_host_name] = nil
-				Chef::Config[:knife][:azure_subscription_id] = nil
-				Chef::Config[:knife][:azure_mgmt_cert] = nil
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_account_azure_profile.json")
-	  	end
+    context "when publishSettings file is not specified in knife.rb and azureProfile file has A account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = nil
+        Chef::Config[:knife][:azure_api_host_name] = nil
+        Chef::Config[:knife][:azure_subscription_id] = nil
+        Chef::Config[:knife][:azure_mgmt_cert] = nil
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_account_azure_profile.json")
+      end
 
-	  	it "selects A account of azureProfile file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('A.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('A_subscription_id')
-	  	end
-	  end
+      it "selects A account of azureProfile file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("A.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("A_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file is not specified in knife.rb and azureProfile file has B account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = nil
+    context "when publishSettings file is not specified in knife.rb and azureProfile file has B account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = nil
 
-	  	  Chef::Config[:knife][:azure_api_host_name] = nil
-				Chef::Config[:knife][:azure_subscription_id] = nil
-				Chef::Config[:knife][:azure_mgmt_cert] = nil
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/B_account_azure_profile.json")
-	  	end
+        Chef::Config[:knife][:azure_api_host_name] = nil
+        Chef::Config[:knife][:azure_subscription_id] = nil
+        Chef::Config[:knife][:azure_mgmt_cert] = nil
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/B_account_azure_profile.json")
+      end
 
-	  	it "selects B account of azureProfile file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('B.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('B_subscription_id')
-	  	end
-	  end
+      it "selects B account of azureProfile file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("B.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("B_subscription_id")
+      end
+    end
 
-	  context "when neither publishSettings file is specified in knife.rb nor azureProfile file exist" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = nil
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/C_account_azure_profile.json")
-	  	end
+    context "when neither publishSettings file is specified in knife.rb nor azureProfile file exist" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = nil
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/C_account_azure_profile.json")
+      end
 
-	  	it "gives error and exits" do
-	  	  expect { @dummy.validate_asm_keys! }.to raise_error SystemExit
-	  	end
-	  end
+      it "gives error and exits" do
+        expect { @dummy.validate_asm_keys! }.to raise_error SystemExit
+      end
+    end
 
-	  context "when publishSettings file is not specified in knife.rb and azureProfile file has both A and B account with B as the default account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = nil
+    context "when publishSettings file is not specified in knife.rb and azureProfile file has both A and B account with B as the default account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = nil
 
-	  	  Chef::Config[:knife][:azure_api_host_name] = nil
-				Chef::Config[:knife][:azure_subscription_id] = nil
-				Chef::Config[:knife][:azure_mgmt_cert] = nil
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_Bd_account_azure_profile.json")
-	  	end
+        Chef::Config[:knife][:azure_api_host_name] = nil
+        Chef::Config[:knife][:azure_subscription_id] = nil
+        Chef::Config[:knife][:azure_mgmt_cert] = nil
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_Bd_account_azure_profile.json")
+      end
 
-	  	it "selects B account of azureProfile file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('B.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('B_subscription_id')
-	  	end
-	  end
+      it "selects B account of azureProfile file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("B.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("B_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file is not specified in knife.rb and azureProfile file has both A and B account with A as the default account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = nil
-	  	  Chef::Config[:knife][:azure_api_host_name] = nil
-				Chef::Config[:knife][:azure_subscription_id] = nil
-				Chef::Config[:knife][:azure_mgmt_cert] = nil
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/Ad_B_account_azure_profile.json")
-	  	end
+    context "when publishSettings file is not specified in knife.rb and azureProfile file has both A and B account with A as the default account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = nil
+        Chef::Config[:knife][:azure_api_host_name] = nil
+        Chef::Config[:knife][:azure_subscription_id] = nil
+        Chef::Config[:knife][:azure_mgmt_cert] = nil
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/Ad_B_account_azure_profile.json")
+      end
 
-	  	it "selects A account of azureProfile file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('A.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('A_subscription_id')
-	  	end
-	  end
+      it "selects A account of azureProfile file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("A.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("A_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file specified in knife.rb has A account and azureProfile file has both A and B account with B as the default account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("A_account.publishsettings")
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_Bd_account_azure_profile.json")
-	  	end
+    context "when publishSettings file specified in knife.rb has A account and azureProfile file has both A and B account with B as the default account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("A_account.publishsettings")
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/A_Bd_account_azure_profile.json")
+      end
 
-	  	it "selects A account of publishSettings file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('A.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('A_subscription_id')
-	  	end
-	  end
+      it "selects A account of publishSettings file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("A.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("A_subscription_id")
+      end
+    end
 
-	  context "when publishSettings file specified in knife.rb has B account and azureProfile file has both A and B account with A as the default account" do
-	  	before do
-	  	  Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("B_account.publishsettings")
-	  	  allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/Ad_B_account_azure_profile.json")
-	  	end
+    context "when publishSettings file specified in knife.rb has B account and azureProfile file has both A and B account with A as the default account" do
+      before do
+        Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("B_account.publishsettings")
+        allow(@dummy).to receive(:get_azure_profile_file_path).and_return(File.dirname(__FILE__) + "/assets/azure-profile-files/Ad_B_account_azure_profile.json")
+      end
 
-	  	it "selects B account of publishSettings file" do
-	  	  @dummy.validate_asm_keys!
-	  	  expect(Chef::Config[:knife][:azure_api_host_name]).to eq('B.endpoint.net')
-	  	  expect(Chef::Config[:knife][:azure_subscription_id]).to eq('B_subscription_id')
-	  	end
-	  end
+      it "selects B account of publishSettings file" do
+        @dummy.validate_asm_keys!
+        expect(Chef::Config[:knife][:azure_api_host_name]).to eq("B.endpoint.net")
+        expect(Chef::Config[:knife][:azure_subscription_id]).to eq("B_subscription_id")
+      end
+    end
 
     context "find_file" do
       it "finds the file with given path" do
@@ -231,5 +231,5 @@ describe Chef::Knife::AzureBase do
         expect(@dummy.find_file(Chef::Config[:knife][:azure_publish_settings_file])).to eq file_path
       end
     end
-	end
+  end
 end

--- a/spec/unit/azure_base_spec.rb
+++ b/spec/unit/azure_base_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Ameya Varade (<ameya.varade@clogeny.com>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.#
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 

--- a/spec/unit/azure_image_list_spec.rb
+++ b/spec/unit/azure_image_list_spec.rb
@@ -1,25 +1,25 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
-require 'pry'
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
+require "pry"
 
 describe Chef::Knife::AzureImageList do
   include AzureSpecHelper
   include QueryAzureMock
   before do
     @server_instance = Chef::Knife::AzureImageList.new
-      {
-        :azure_subscription_id => 'azure_subscription_id',
-        :azure_mgmt_cert => @cert_file,
-        :azure_api_host_name => 'preview.core.windows-int.net',
-        :azure_service_location => 'West Europe',
-        :azure_source_image => 'SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd',
-        :azure_dns_name => 'service001',
-        :azure_vm_name => 'vm01',
-        :azure_storage_account => 'ka001testeurope',
-        :azure_vm_size => 'Small'
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      :azure_subscription_id => "azure_subscription_id",
+      :azure_mgmt_cert => @cert_file,
+      :azure_api_host_name => "preview.core.windows-int.net",
+      :azure_service_location => "West Europe",
+      :azure_source_image => "SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd",
+      :azure_dns_name => "service001",
+      :azure_vm_name => "vm01",
+      :azure_storage_account => "ka001testeurope",
+      :azure_vm_size => "Small"
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
     stub_query_azure(@server_instance.service.connection)
     allow(@server_instance).to receive(:items).and_return(:true)
     allow(@server_instance).to receive(:puts)

--- a/spec/unit/azure_internal-lb_create_spec.rb
+++ b/spec/unit/azure_internal-lb_create_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureInternalLbCreate do
   include AzureSpecHelper
@@ -13,22 +13,22 @@ describe Chef::Knife::AzureInternalLbCreate do
     allow(@server_instance).to receive(:print)
   end
 
-  it 'should fail missing args.' do
+  it "should fail missing args." do
     expect(@connection.lbs).to_not receive(:create)
     expect(@server_instance.ui).to receive(:error)
     expect { @server_instance.run }.to raise_error(SystemExit)
   end
 
-  it 'should succeed.' do
-    Chef::Config[:knife][:azure_load_balancer] = 'new-lb'
-    Chef::Config[:knife][:azure_lb_static_vip] = '10.3.3.3'
-    Chef::Config[:knife][:azure_subnet_name] = 'vnet'
-    Chef::Config[:knife][:azure_dns_name] = 'vmname'
+  it "should succeed." do
+    Chef::Config[:knife][:azure_load_balancer] = "new-lb"
+    Chef::Config[:knife][:azure_lb_static_vip] = "10.3.3.3"
+    Chef::Config[:knife][:azure_subnet_name] = "vnet"
+    Chef::Config[:knife][:azure_dns_name] = "vmname"
     expect(@server_instance.service.connection.lbs).to receive(:create).with(
-      azure_load_balancer: 'new-lb',
-      azure_lb_static_vip: '10.3.3.3',
-      azure_subnet_name: 'vnet',
-      azure_dns_name: 'vmname'
+      azure_load_balancer: "new-lb",
+      azure_lb_static_vip: "10.3.3.3",
+      azure_subnet_name: "vnet",
+      azure_dns_name: "vmname"
     ).and_call_original
     expect(@server_instance.ui).to_not receive(:warn)
     expect(@server_instance.ui).to_not receive(:error)

--- a/spec/unit/azure_internal-lb_list_spec.rb
+++ b/spec/unit/azure_internal-lb_list_spec.rb
@@ -1,38 +1,38 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureInternalLbList do
   include AzureSpecHelper
   include QueryAzureMock
   before do
     @server_instance = Chef::Knife::AzureInternalLbList.new
-      {
-        :azure_subscription_id => 'azure_subscription_id',
-        :azure_mgmt_cert => @cert_file,
-        :azure_api_host_name => 'preview.core.windows-int.net',
-        :azure_service_location => 'West Europe',
-        :azure_source_image =>
-            'SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd',
-        :azure_dns_name => 'service001',
-        :azure_vm_name => 'vm01',
-        :azure_storage_account => 'ka001testeurope',
-        :azure_vm_size => 'Small'
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      :azure_subscription_id => "azure_subscription_id",
+      :azure_mgmt_cert => @cert_file,
+      :azure_api_host_name => "preview.core.windows-int.net",
+      :azure_service_location => "West Europe",
+      :azure_source_image =>
+          "SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd",
+      :azure_dns_name => "service001",
+      :azure_vm_name => "vm01",
+      :azure_storage_account => "ka001testeurope",
+      :azure_vm_size => "Small"
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
     stub_query_azure(@server_instance.service.connection)
     allow(@server_instance).to receive(:items).and_return(:true)
     allow(@server_instance).to receive(:puts)
   end
 
-    it 'should display Name, Service, Subnet, and VIP columns.' do
-      expect(@server_instance.ui).to receive(:list).with(
-        ['Name', 'Service', 'Subnet', 'VIP',
-         'lb_name', 'service001', 'vnet1', '10.4.4.4'
-        ],
-        :uneven_columns_across,
-        4)
-      @server_instance.run
-    end
+  it "should display Name, Service, Subnet, and VIP columns." do
+    expect(@server_instance.ui).to receive(:list).with(
+      ["Name", "Service", "Subnet", "VIP",
+       "lb_name", "service001", "vnet1", "10.4.4.4"
+      ],
+      :uneven_columns_across,
+      4)
+    @server_instance.run
+  end
 
 end

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Mukta Aphale (<mukta.aphale@clogeny.com>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")

--- a/spec/unit/azure_server_create_spec.rb
+++ b/spec/unit/azure_server_create_spec.rb
@@ -3,12 +3,12 @@
 # Copyright:: Copyright (c) 2013 Opscode, Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
-require 'chef/knife/bootstrap'
-require 'chef/knife/bootstrap_windows_winrm'
-require 'chef/knife/bootstrap_windows_ssh'
-require 'active_support/core_ext/hash/conversions'
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
+require "chef/knife/bootstrap"
+require "chef/knife/bootstrap_windows_winrm"
+require "chef/knife/bootstrap_windows_ssh"
+require "active_support/core_ext/hash/conversions"
 
 describe Chef::Knife::AzureServerCreate do
   include AzureSpecHelper
@@ -18,16 +18,16 @@ describe Chef::Knife::AzureServerCreate do
   before do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net',
-      :azure_service_location => 'West Europe',
-      :azure_source_image => 'SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd',
-      :azure_dns_name => 'service001',
-      :azure_vm_name => 'vm002',
-      :azure_storage_account => 'ka001testeurope',
-      :azure_vm_size => 'Small',
-      :ssh_user => 'test-user'
+      :azure_api_host_name => "preview.core.windows-int.net",
+      :azure_service_location => "West Europe",
+      :azure_source_image => "SUSE__SUSE-Linux-Enterprise-Server-11SP2-20120521-en-us-30GB.vhd",
+      :azure_dns_name => "service001",
+      :azure_vm_name => "vm002",
+      :azure_storage_account => "ka001testeurope",
+      :azure_vm_size => "Small",
+      :ssh_user => "test-user"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -43,12 +43,12 @@ describe Chef::Knife::AzureServerCreate do
   end
 
   def test_params(testxml, chef_config, role_name, host_name)
-    expect(xml_content(testxml, 'UserName')).to be == chef_config[:ssh_user]
-    expect(xml_content(testxml, 'UserPassword')).to be == chef_config[:ssh_password]
-    expect(xml_content(testxml, 'SourceImageName')).to be == chef_config[:azure_source_image]
-    expect(xml_content(testxml, 'RoleSize')).to be == chef_config[:azure_vm_size]
-    expect(xml_content(testxml, 'HostName')).to be == host_name
-    expect(xml_content(testxml, 'RoleName')).to be == role_name
+    expect(xml_content(testxml, "UserName")).to be == chef_config[:ssh_user]
+    expect(xml_content(testxml, "UserPassword")).to be == chef_config[:ssh_password]
+    expect(xml_content(testxml, "SourceImageName")).to be == chef_config[:azure_source_image]
+    expect(xml_content(testxml, "RoleSize")).to be == chef_config[:azure_vm_size]
+    expect(xml_content(testxml, "HostName")).to be == host_name
+    expect(xml_content(testxml, "RoleName")).to be == role_name
   end
 
   describe "parameter test:" do
@@ -56,66 +56,66 @@ describe Chef::Knife::AzureServerCreate do
       it "azure_subscription_id" do
         Chef::Config[:knife].delete(:azure_subscription_id)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_mgmt_cert" do
         Chef::Config[:knife].delete(:azure_mgmt_cert)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_api_host_name" do
         Chef::Config[:knife].delete(:azure_api_host_name)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_source_image" do
         Chef::Config[:knife].delete(:azure_source_image)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_vm_size" do
         Chef::Config[:knife].delete(:azure_vm_size)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_service_location and azure_affinity_group not allowed" do
-        Chef::Config[:knife][:azure_affinity_group] = 'test-affinity'
+        Chef::Config[:knife][:azure_affinity_group] = "test-affinity"
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_service_location or azure_affinity_group must be provided" do
         Chef::Config[:knife].delete(:azure_service_location)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "raises an error if neither --azure-dns-name or --azure-vm-name are provided" do
         Chef::Config[:knife].delete(:azure_dns_name)
         Chef::Config[:knife].delete(:azure_vm_name)
         expect(@server_instance.ui).to receive(:error)
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       context "when winrm authentication protocol invalid" do
         it "raise error" do
           Chef::Config[:knife][:winrm_authentication_protocol] = "invalide"
           expect(@server_instance.ui).to receive(:error)
-          expect {@server_instance.run}.to raise_error(SystemExit)
+          expect { @server_instance.run }.to raise_error(SystemExit)
         end
       end
 
       context "when winrm-transport ssl and missing thumbprint" do
         it "raise error on :winrm_ssl_verify_mode verify_peer" do
-          Chef::Config[:knife][:winrm_transport] = 'ssl'
+          Chef::Config[:knife][:winrm_transport] = "ssl"
           Chef::Config[:knife][:winrm_ssl_verify_mode] = :verify_peer
           expect(@server_instance.ui).to receive(:error)
-          expect {@server_instance.run}.to raise_error(SystemExit)
+          expect { @server_instance.run }.to raise_error(SystemExit)
         end
       end
     end
@@ -123,7 +123,7 @@ describe Chef::Knife::AzureServerCreate do
     context "validate parameters" do
       it "raise error if daemon option is not provided for windows node" do
         Chef::Config[:knife][:daemon] = "service"
-        expect {@server_instance.run}.to raise_error(
+        expect { @server_instance.run }.to raise_error(
           ArgumentError, "The daemon option is only supported for Windows nodes.")
       end
 
@@ -131,7 +131,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "foo"
         Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
-        expect {@server_instance.run}.to raise_error(
+        expect { @server_instance.run }.to raise_error(
           ArgumentError, "Invalid value for --daemon option. Valid values are 'none', 'service' and 'task'."
           )
       end
@@ -139,7 +139,7 @@ describe Chef::Knife::AzureServerCreate do
       it "raises error if bootstrap_protocol is not cloud-api for daemon option" do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "service"
-        expect {@server_instance.run}.to raise_error(
+        expect { @server_instance.run }.to raise_error(
           ArgumentError, "The --daemon option requires the use of --bootstrap-protocol cloud-api"
         )
       end
@@ -148,7 +148,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "service"
         Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
-        expect {@server_instance.run}.not_to raise_error(
+        expect { @server_instance.run }.not_to raise_error(
           ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
         )
       end
@@ -157,7 +157,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "none"
         Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
-        expect {@server_instance.run}.not_to raise_error(
+        expect { @server_instance.run }.not_to raise_error(
           ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
         )
       end
@@ -166,7 +166,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
         Chef::Config[:knife][:daemon] = "task"
         Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
-        expect {@server_instance.run}.not_to raise_error(
+        expect { @server_instance.run }.not_to raise_error(
           ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
         )
       end
@@ -189,9 +189,9 @@ describe Chef::Knife::AzureServerCreate do
 
     context "server create options" do
       before do
-        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
-        Chef::Config[:knife][:ssh_user] = 'ssh_user'
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
+        Chef::Config[:knife][:bootstrap_protocol] = "ssh"
+        Chef::Config[:knife][:ssh_user] = "ssh_user"
+        Chef::Config[:knife][:ssh_password] = "ssh_password"
         Chef::Config[:knife].delete(:azure_vm_name)
         Chef::Config[:knife].delete(:azure_storage_account)
         @bootstrap = Chef::Knife::Bootstrap.new
@@ -202,43 +202,43 @@ describe Chef::Knife::AzureServerCreate do
 
       it "quick create" do
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-        Chef::Config[:knife][:azure_dns_name] = 'vmname' # service name to be used as vm name
+        Chef::Config[:knife][:azure_dns_name] = "vmname" # service name to be used as vm name
         expect(@server_instance).to receive(:get_dns_name)
         @server_instance.run
         expect(@server_instance.config[:azure_vm_name]).to be == "vmname"
         testxml = Nokogiri::XML(@receivedXML)
-        expect(xml_content(testxml, 'MediaLink')).to_not be nil
-        expect(xml_content(testxml, 'DiskName')).to_not be nil
+        expect(xml_content(testxml, "MediaLink")).to_not be nil
+        expect(xml_content(testxml, "DiskName")).to_not be nil
         test_params(testxml, Chef::Config[:knife], Chef::Config[:knife][:azure_dns_name],
         Chef::Config[:knife][:azure_dns_name])
       end
 
       it "quick create with wirm - API check" do
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(true)
-        Chef::Config[:knife][:azure_dns_name] = 'vmname' # service name to be used as vm name
-        Chef::Config[:knife][:winrm_user] = 'opscodechef'
-        Chef::Config[:knife][:winrm_password] = 'Opscode123'
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
+        Chef::Config[:knife][:azure_dns_name] = "vmname" # service name to be used as vm name
+        Chef::Config[:knife][:winrm_user] = "opscodechef"
+        Chef::Config[:knife][:winrm_password] = "Opscode123"
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
         expect(@server_instance).to receive(:get_dns_name)
         @server_instance.run
         expect(@server_instance.config[:azure_vm_name]).to be == "vmname"
         testxml = Nokogiri::XML(@receivedXML)
-        expect(xml_content(testxml, 'WinRM')).to_not be nil
-        expect(xml_content(testxml, 'Listeners')).to_not be nil
-        expect(xml_content(testxml, 'Listener')).to_not be nil
-        expect(xml_content(testxml, 'Protocol')).to be == "Http"
+        expect(xml_content(testxml, "WinRM")).to_not be nil
+        expect(xml_content(testxml, "Listeners")).to_not be nil
+        expect(xml_content(testxml, "Listener")).to_not be nil
+        expect(xml_content(testxml, "Protocol")).to be == "Http"
       end
 
       it "generate unique OS DiskName" do
         os_disks = []
         allow(@bootstrap).to receive(:run)
         allow(@server_instance).to receive(:validate_asm_keys!)
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
 
         5.times do
           @server_instance.run
           testxml = Nokogiri::XML(@receivedXML)
-          disklink = xml_content(testxml, 'MediaLink')
+          disklink = xml_content(testxml, "MediaLink")
           expect(os_disks).to_not include(disklink)
           os_disks.push(disklink)
         end
@@ -248,10 +248,10 @@ describe Chef::Knife::AzureServerCreate do
         # Default external port for ssh endpoint is 22.
         @server_instance.config[:tcp_endpoints] = "12:22"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
-        Chef::Config[:knife][:azure_dns_name] = 'vmname' # service name to be used as vm name
+        Chef::Config[:knife][:azure_dns_name] = "vmname" # service name to be used as vm name
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
+        testxml.css('InputEndpoint Protocol:contains("TCP")').each do |port|
           # Test data in @server_instance.config[:tcp_endpoints]:=> "12:22" this endpoints external port 22 is already use by ssh endpoint. So it should skip endpoint "12:22".
           expect(port.parent.css("LocalPort").text).to_not eq("12")
         end
@@ -259,223 +259,223 @@ describe Chef::Knife::AzureServerCreate do
 
       it "advanced create" do
         # set all params
-        Chef::Config[:knife][:azure_dns_name] = 'service001'
-        Chef::Config[:knife][:azure_vm_name] = 'vm002'
-        Chef::Config[:knife][:azure_storage_account] = 'ka001testeurope'
-        Chef::Config[:knife][:azure_os_disk_name] = 'os-disk'
+        Chef::Config[:knife][:azure_dns_name] = "service001"
+        Chef::Config[:knife][:azure_vm_name] = "vm002"
+        Chef::Config[:knife][:azure_storage_account] = "ka001testeurope"
+        Chef::Config[:knife][:azure_os_disk_name] = "os-disk"
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        expect(xml_content(testxml, 'MediaLink')).to be == 'http://ka001testeurope.blob.core.windows-int.net/vhds/os-disk.vhd'
-        expect(xml_content(testxml, 'DiskName')).to be == Chef::Config[:knife][:azure_os_disk_name]
+        expect(xml_content(testxml, "MediaLink")).to be == "http://ka001testeurope.blob.core.windows-int.net/vhds/os-disk.vhd"
+        expect(xml_content(testxml, "DiskName")).to be == Chef::Config[:knife][:azure_os_disk_name]
         test_params(testxml, Chef::Config[:knife], Chef::Config[:knife][:azure_vm_name],
         Chef::Config[:knife][:azure_vm_name])
       end
 
       it "create with availability set" do
         # set all params
-        Chef::Config[:knife][:azure_dns_name] = 'service001'
-        Chef::Config[:knife][:azure_vm_name] = 'vm002'
-        Chef::Config[:knife][:azure_storage_account] = 'ka001testeurope'
-        Chef::Config[:knife][:azure_os_disk_name] = 'os-disk'
-        Chef::Config[:knife][:azure_availability_set] = 'test-availability-set'
+        Chef::Config[:knife][:azure_dns_name] = "service001"
+        Chef::Config[:knife][:azure_vm_name] = "vm002"
+        Chef::Config[:knife][:azure_storage_account] = "ka001testeurope"
+        Chef::Config[:knife][:azure_os_disk_name] = "os-disk"
+        Chef::Config[:knife][:azure_availability_set] = "test-availability-set"
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        expect(xml_content(testxml, 'AvailabilitySetName')).to be == 'test-availability-set'
+        expect(xml_content(testxml, "AvailabilitySetName")).to be == "test-availability-set"
       end
 
       it "server create with virtual network and subnet" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
-        Chef::Config[:knife][:azure_network_name] = 'test-network'
-        Chef::Config[:knife][:azure_subnet_name] = 'test-subnet'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
+        Chef::Config[:knife][:azure_network_name] = "test-network"
+        Chef::Config[:knife][:azure_subnet_name] = "test-subnet"
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        expect(xml_content(testxml, 'SubnetName')).to be == 'test-subnet'
+        expect(xml_content(testxml, "SubnetName")).to be == "test-subnet"
       end
 
       it "creates new load balanced endpoints" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         @server_instance.config[:tcp_endpoints] = "80:80:EXTERNAL:lb_set,443:443:EXTERNAL:lb_set_ssl:/healthcheck" #TODO is this a good way of specifying this?
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        endpoints = testxml.css('InputEndpoint')
+        endpoints = testxml.css("InputEndpoint")
 
         # Should be 3 endpoints, 1 for SSH, 1 for port 80 using LB set name lb_set, and 1 for port 443 using lb_set2 and with healtcheck path.
-        expect(endpoints.count).to be  == 3
+        expect(endpoints.count).to be == 3
 
         # Convert it to a hash as it's easier to test.
         eps = []
-        endpoints.each do | ep |
+        endpoints.each do |ep|
           eps << Hash.from_xml(ep.to_s)
         end
 
-        expect(eps[0]['InputEndpoint']['Name']).to be == 'SSH'
+        expect(eps[0]["InputEndpoint"]["Name"]).to be == "SSH"
 
-        lb_set_ep = eps[1]['InputEndpoint']
-        expect(lb_set_ep['LoadBalancedEndpointSetName']).to be == 'lb_set'
-        expect(lb_set_ep['LocalPort']).to be == '80'
-        expect(lb_set_ep['Port']).to be == '80'
-        expect(lb_set_ep['Protocol']).to be == 'TCP'
-        expect(lb_set_ep['LoadBalancerProbe']['Port']).to be == '80'
-        expect(lb_set_ep['LoadBalancerProbe']['Protocol']).to be == 'TCP'
+        lb_set_ep = eps[1]["InputEndpoint"]
+        expect(lb_set_ep["LoadBalancedEndpointSetName"]).to be == "lb_set"
+        expect(lb_set_ep["LocalPort"]).to be == "80"
+        expect(lb_set_ep["Port"]).to be == "80"
+        expect(lb_set_ep["Protocol"]).to be == "TCP"
+        expect(lb_set_ep["LoadBalancerProbe"]["Port"]).to be == "80"
+        expect(lb_set_ep["LoadBalancerProbe"]["Protocol"]).to be == "TCP"
 
-        lb_set2_ep = eps[2]['InputEndpoint']
-        expect(lb_set2_ep['LoadBalancedEndpointSetName']).to be == 'lb_set_ssl'
-        expect(lb_set2_ep['LocalPort']).to be == '443'
-        expect(lb_set2_ep['Port']).to be == '443'
-        expect(lb_set2_ep['Protocol']).to be == 'TCP'
-        expect(lb_set2_ep['LoadBalancerProbe']['Path']).to be == '/healthcheck'
-        expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
-        expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'HTTP'
+        lb_set2_ep = eps[2]["InputEndpoint"]
+        expect(lb_set2_ep["LoadBalancedEndpointSetName"]).to be == "lb_set_ssl"
+        expect(lb_set2_ep["LocalPort"]).to be == "443"
+        expect(lb_set2_ep["Port"]).to be == "443"
+        expect(lb_set2_ep["Protocol"]).to be == "TCP"
+        expect(lb_set2_ep["LoadBalancerProbe"]["Path"]).to be == "/healthcheck"
+        expect(lb_set2_ep["LoadBalancerProbe"]["Port"]).to be == "443"
+        expect(lb_set2_ep["LoadBalancerProbe"]["Protocol"]).to be == "HTTP"
       end
 
       it "re-uses existing load balanced endpoints" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         @server_instance.config[:tcp_endpoints] = "443:443:EXTERNAL:lb_set2:/healthcheck"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
 
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        endpoints = testxml.css('InputEndpoint')
+        endpoints = testxml.css("InputEndpoint")
 
-        expect(endpoints.count).to be  == 2
+        expect(endpoints.count).to be == 2
 
         # Convert it to a hash as it's easier to test.
         eps = []
-        endpoints.each do | ep |
+        endpoints.each do |ep|
           eps << Hash.from_xml(ep.to_s)
         end
-        expect(eps[0]['InputEndpoint']['Name']).to be == 'SSH'
+        expect(eps[0]["InputEndpoint"]["Name"]).to be == "SSH"
 
-        lb_set2_ep = eps[1]['InputEndpoint']
-        expect(lb_set2_ep['LoadBalancedEndpointSetName']).to be == 'lb_set2'
-        expect(lb_set2_ep['LocalPort']).to be == '443'
-        expect(lb_set2_ep['Port']).to be == '443'
-        expect(lb_set2_ep['Protocol']).to be == 'tcp'
-        expect(lb_set2_ep['LoadBalancerProbe']['Path']).to be == '/healthcheck2' # The existing one wins. The 'healthcheck2' value is defined in the stub.
-        expect(lb_set2_ep['LoadBalancerProbe']['Port']).to be == '443'
-        expect(lb_set2_ep['LoadBalancerProbe']['Protocol']).to be == 'http'
+        lb_set2_ep = eps[1]["InputEndpoint"]
+        expect(lb_set2_ep["LoadBalancedEndpointSetName"]).to be == "lb_set2"
+        expect(lb_set2_ep["LocalPort"]).to be == "443"
+        expect(lb_set2_ep["Port"]).to be == "443"
+        expect(lb_set2_ep["Protocol"]).to be == "tcp"
+        expect(lb_set2_ep["LoadBalancerProbe"]["Path"]).to be == "/healthcheck2" # The existing one wins. The 'healthcheck2' value is defined in the stub.
+        expect(lb_set2_ep["LoadBalancerProbe"]["Port"]).to be == "443"
+        expect(lb_set2_ep["LoadBalancerProbe"]["Protocol"]).to be == "http"
 
       end
 
       it "allows internal load balancer to be specified" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         @server_instance.config[:tcp_endpoints] = "80:80:internal-lb-name:lb_set" #TODO is this a good way of specifying this?
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(false)
 
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        endpoints = testxml.css('InputEndpoint')
-        expect(endpoints.count).to be  == 2
+        endpoints = testxml.css("InputEndpoint")
+        expect(endpoints.count).to be == 2
 
         # Convert it to a hash as it's easier to test.
         eps = []
-        endpoints.each do | ep |
+        endpoints.each do |ep|
           eps << Hash.from_xml(ep.to_s)
         end
-        expect(eps[0]['InputEndpoint']['Name']).to be == 'SSH'
+        expect(eps[0]["InputEndpoint"]["Name"]).to be == "SSH"
 
-        lb_set_ep = eps[1]['InputEndpoint']
-        expect(lb_set_ep['LoadBalancedEndpointSetName']).to be == 'lb_set'
-        expect(lb_set_ep['LocalPort']).to be == '80'
-        expect(lb_set_ep['Port']).to be == '80'
-        expect(lb_set_ep['Protocol']).to be == 'TCP'
-        expect(lb_set_ep['LoadBalancerProbe']['Port']).to be == '80'
-        expect(lb_set_ep['LoadBalancerProbe']['Protocol']).to be == 'TCP'
-        expect(lb_set_ep['LoadBalancerName']).to be == 'internal-lb-name'
+        lb_set_ep = eps[1]["InputEndpoint"]
+        expect(lb_set_ep["LoadBalancedEndpointSetName"]).to be == "lb_set"
+        expect(lb_set_ep["LocalPort"]).to be == "80"
+        expect(lb_set_ep["Port"]).to be == "80"
+        expect(lb_set_ep["Protocol"]).to be == "TCP"
+        expect(lb_set_ep["LoadBalancerProbe"]["Port"]).to be == "80"
+        expect(lb_set_ep["LoadBalancerProbe"]["Protocol"]).to be == "TCP"
+        expect(lb_set_ep["LoadBalancerName"]).to be == "internal-lb-name"
       end
 
       it "server create display server summary" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         expect(@server_instance).to receive(:msg_server_summary)
         @server_instance.run
       end
 
       context "Domain join:" do
         before do
-          Chef::Config[:knife][:azure_dns_name] = 'vmname'
+          Chef::Config[:knife][:azure_dns_name] = "vmname"
           allow(@server_instance).to receive(:is_image_windows?).and_return(true)
-          Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-          Chef::Config[:knife][:winrm_user] = 'testuser'
-          Chef::Config[:knife][:winrm_password] = 'winrm_password'
+          Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+          Chef::Config[:knife][:winrm_user] = "testuser"
+          Chef::Config[:knife][:winrm_password] = "winrm_password"
         end
 
         it "server create with domain join options" do
-          Chef::Config[:knife][:azure_domain_name] = 'testad.com'
-          Chef::Config[:knife][:azure_domain_user] = 'domainuser'
-          Chef::Config[:knife][:azure_domain_passwd] = 'domainuserpass'
+          Chef::Config[:knife][:azure_domain_name] = "testad.com"
+          Chef::Config[:knife][:azure_domain_user] = "domainuser"
+          Chef::Config[:knife][:azure_domain_passwd] = "domainuserpass"
           @server_instance.run
           testxml = Nokogiri::XML(@receivedXML)
-          expect(xml_content(testxml, 'DomainJoin Credentials Domain')).to eq('testad.com')
-          expect(xml_content(testxml, 'DomainJoin Credentials Username')).to eq('domainuser')
-          expect(xml_content(testxml, 'DomainJoin Credentials Password')).to eq('domainuserpass')
-          expect(xml_content(testxml, 'JoinDomain')).to eq('testad.com')
+          expect(xml_content(testxml, "DomainJoin Credentials Domain")).to eq("testad.com")
+          expect(xml_content(testxml, "DomainJoin Credentials Username")).to eq("domainuser")
+          expect(xml_content(testxml, "DomainJoin Credentials Password")).to eq("domainuserpass")
+          expect(xml_content(testxml, "JoinDomain")).to eq("testad.com")
         end
 
         it "server create with domain join options in user principal name (UPN) format (user@fully-qualified-DNS-domain)" do
-          Chef::Config[:knife][:azure_domain_user] = 'domainuser@testad.com'
-          Chef::Config[:knife][:azure_domain_passwd] = 'domainuserpass'
+          Chef::Config[:knife][:azure_domain_user] = "domainuser@testad.com"
+          Chef::Config[:knife][:azure_domain_passwd] = "domainuserpass"
           @server_instance.run
           testxml = Nokogiri::XML(@receivedXML)
-          expect(xml_content(testxml, 'DomainJoin Credentials Domain')).to eq('testad.com')
-          expect(xml_content(testxml, 'DomainJoin Credentials Username')).to eq('domainuser')
-          expect(xml_content(testxml, 'DomainJoin Credentials Password')).to eq('domainuserpass')
-          expect(xml_content(testxml, 'JoinDomain')).to eq('testad.com')
+          expect(xml_content(testxml, "DomainJoin Credentials Domain")).to eq("testad.com")
+          expect(xml_content(testxml, "DomainJoin Credentials Username")).to eq("domainuser")
+          expect(xml_content(testxml, "DomainJoin Credentials Password")).to eq("domainuserpass")
+          expect(xml_content(testxml, "JoinDomain")).to eq("testad.com")
         end
 
         it "server create with domain join options in fully-qualified-DNS-domain\\username format" do
           Chef::Config[:knife][:azure_domain_user] = 'testad.com\\domainuser'
-          Chef::Config[:knife][:azure_domain_passwd] = 'domainuserpass'
+          Chef::Config[:knife][:azure_domain_passwd] = "domainuserpass"
           @server_instance.run
           testxml = Nokogiri::XML(@receivedXML)
-          expect(xml_content(testxml, 'DomainJoin Credentials Domain')).to eq('testad.com')
-          expect(xml_content(testxml, 'DomainJoin Credentials Username')).to eq('domainuser')
-          expect(xml_content(testxml, 'DomainJoin Credentials Password')).to eq('domainuserpass')
-          expect(xml_content(testxml, 'JoinDomain')).to eq('testad.com')
+          expect(xml_content(testxml, "DomainJoin Credentials Domain")).to eq("testad.com")
+          expect(xml_content(testxml, "DomainJoin Credentials Username")).to eq("domainuser")
+          expect(xml_content(testxml, "DomainJoin Credentials Password")).to eq("domainuserpass")
+          expect(xml_content(testxml, "JoinDomain")).to eq("testad.com")
         end
 
         it "server create with domain join options including name of the organizational unit (OU) in which the computer account is created" do
           Chef::Config[:knife][:azure_domain_user] = 'testad.com\\domainuser'
-          Chef::Config[:knife][:azure_domain_passwd] = 'domainuserpass'
-          Chef::Config[:knife][:azure_domain_ou_dn] = 'OU=HR,dc=opscode,dc=com'
+          Chef::Config[:knife][:azure_domain_passwd] = "domainuserpass"
+          Chef::Config[:knife][:azure_domain_ou_dn] = "OU=HR,dc=opscode,dc=com"
           @server_instance.run
           testxml = Nokogiri::XML(@receivedXML)
-          expect(xml_content(testxml, 'DomainJoin Credentials Domain')).to eq('testad.com')
-          expect(xml_content(testxml, 'DomainJoin Credentials Username')).to eq('domainuser')
-          expect(xml_content(testxml, 'DomainJoin Credentials Password')).to eq('domainuserpass')
-          expect(xml_content(testxml, 'DomainJoin MachineObjectOU')).to eq("OU=HR,dc=opscode,dc=com")
-          expect(xml_content(testxml, 'JoinDomain')).to eq('testad.com')
+          expect(xml_content(testxml, "DomainJoin Credentials Domain")).to eq("testad.com")
+          expect(xml_content(testxml, "DomainJoin Credentials Username")).to eq("domainuser")
+          expect(xml_content(testxml, "DomainJoin Credentials Password")).to eq("domainuserpass")
+          expect(xml_content(testxml, "DomainJoin MachineObjectOU")).to eq("OU=HR,dc=opscode,dc=com")
+          expect(xml_content(testxml, "JoinDomain")).to eq("testad.com")
         end
       end
     end
 
     context "missing create options" do
       before do
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-        Chef::Config[:knife][:winrm_user] = 'testuser'
-        Chef::Config[:knife][:winrm_password] = 'winrm_password'
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+        Chef::Config[:knife][:winrm_user] = "testuser"
+        Chef::Config[:knife][:winrm_password] = "winrm_password"
         Chef::Config[:knife].delete(:azure_vm_name)
         Chef::Config[:knife].delete(:azure_storage_account)
       end
 
       it "should error if domain user is not specified for domain join" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
 
-        Chef::Config[:knife][:azure_domain_name] = 'testad.com'
-        Chef::Config[:knife][:azure_domain_passwd] = 'domainuserpass'
-        expect(@server_instance.ui).to receive(:error).with('Must specify both --azure-domain-user and --azure-domain-passwd.')
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        Chef::Config[:knife][:azure_domain_name] = "testad.com"
+        Chef::Config[:knife][:azure_domain_passwd] = "domainuserpass"
+        expect(@server_instance.ui).to receive(:error).with("Must specify both --azure-domain-user and --azure-domain-passwd.")
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
 
       it "should error if password for domain user is not specified for domain join" do
-        Chef::Config[:knife][:azure_dns_name] = 'vmname'
+        Chef::Config[:knife][:azure_dns_name] = "vmname"
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
 
-        Chef::Config[:knife][:azure_domain_name] = 'testad.com'
-        Chef::Config[:knife][:azure_domain_user] = 'domainuser'
-        expect(@server_instance.ui).to receive(:error).with('Must specify both --azure-domain-user and --azure-domain-passwd.')
-        expect {@server_instance.run}.to raise_error(SystemExit)
+        Chef::Config[:knife][:azure_domain_name] = "testad.com"
+        Chef::Config[:knife][:azure_domain_user] = "domainuser"
+        expect(@server_instance.ui).to receive(:error).with("Must specify both --azure-domain-user and --azure-domain-passwd.")
+        expect { @server_instance.run }.to raise_error(SystemExit)
       end
     end
 
@@ -504,30 +504,30 @@ describe Chef::Knife::AzureServerCreate do
 
     context "#cleanup_and_exit" do
       it "service leak cleanup" do
-        expect {@server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc")}.to raise_error(NoMethodError)
+        expect { @server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc") }.to raise_error(NoMethodError)
       end
 
       it "service leak cleanup with nil params" do
         expect(@server_instance.service.connection.hosts).to_not receive(:delete)
         expect(@server_instance.service.connection.storageaccounts).to_not receive(:delete)
-        expect {@server_instance.service.cleanup_and_exit(nil, nil)}.to raise_error(SystemExit)
+        expect { @server_instance.service.cleanup_and_exit(nil, nil) }.to raise_error(SystemExit)
       end
 
       it "service leak cleanup with valid params" do
         ret_val = Object.new
-        ret_val.define_singleton_method(:content){""}
+        ret_val.define_singleton_method(:content) { "" }
         expect(@server_instance.service.connection.hosts).to receive(:delete).with("hosted_srvc").and_return(ret_val)
         expect(@server_instance.service.connection.storageaccounts).to receive(:delete).with("storage_srvc").and_return(ret_val)
-        expect {@server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc")}.to raise_error(SystemExit)
+        expect { @server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc") }.to raise_error(SystemExit)
       end
 
       it "display proper warn messages on cleanup fails" do
         ret_val = Object.new
-        ret_val.define_singleton_method(:content){ "ConflictError" }
-        ret_val.define_singleton_method(:text){ "ConflictError" }
+        ret_val.define_singleton_method(:content) { "ConflictError" }
+        ret_val.define_singleton_method(:text) { "ConflictError" }
         expect(@server_instance.service.connection.hosts).to receive(:delete).with("hosted_srvc").and_return(ret_val)
         expect(@server_instance.service.connection.storageaccounts).to receive(:delete).with("storage_srvc").and_return(ret_val)
-        expect {@server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc")}.to raise_error(SystemExit)
+        expect { @server_instance.service.cleanup_and_exit("hosted_srvc", "storage_srvc") }.to raise_error(SystemExit)
       end
     end
 
@@ -537,81 +537,81 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "should throw error when DNS does not exist" do
-        Chef::Config[:knife][:azure_dns_name] = 'does-not-exist'
-        Chef::Config[:knife][:ssh_user] = 'azureuser'
-        Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
-        expect {@server_instance.run}.to raise_error(NoMethodError)
+        Chef::Config[:knife][:azure_dns_name] = "does-not-exist"
+        Chef::Config[:knife][:ssh_user] = "azureuser"
+        Chef::Config[:knife][:ssh_password] = "Jetstream123!"
+        expect { @server_instance.run }.to raise_error(NoMethodError)
       end
 
       it "port should be unique number when winrm-port not specified for winrm", :chef_lt_12_only do
         Chef::Config[:knife][:winrm_port] = nil
-        Chef::Config[:knife][:azure_dns_name] = 'service001'
-        Chef::Config[:knife][:azure_vm_name] = 'newvm01'
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-        Chef::Config[:knife][:winrm_user] = 'testuser'
-        Chef::Config[:knife][:winrm_password] = 'Jetstream123!'
+        Chef::Config[:knife][:azure_dns_name] = "service001"
+        Chef::Config[:knife][:azure_vm_name] = "newvm01"
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+        Chef::Config[:knife][:winrm_user] = "testuser"
+        Chef::Config[:knife][:winrm_password] = "Jetstream123!"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to be == '5985'
+        expect(@server_params[:port]).to be == "5985"
       end
 
       it "port should be winrm-port value specified in the option" do
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-        Chef::Config[:knife][:winrm_user] = 'testuser'
-        Chef::Config[:knife][:winrm_password] = 'Jetstream123!'
-        Chef::Config[:knife][:winrm_port] = '5990'
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+        Chef::Config[:knife][:winrm_user] = "testuser"
+        Chef::Config[:knife][:winrm_password] = "Jetstream123!"
+        Chef::Config[:knife][:winrm_port] = "5990"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to be == '5990'
+        expect(@server_params[:port]).to be == "5990"
       end
 
       it "extract user name when winrm_user contains domain name" do
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
         Chef::Config[:knife][:winrm_user] = 'domain\\testuser'
-        Chef::Config[:knife][:winrm_password] = 'Jetstream123!'
-        Chef::Config[:knife][:winrm_port] = '5990'
+        Chef::Config[:knife][:winrm_password] = "Jetstream123!"
+        Chef::Config[:knife][:winrm_port] = "5990"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:winrm_user]).to be == 'testuser'
+        expect(@server_params[:winrm_user]).to be == "testuser"
       end
 
       it "port should be unique number when ssh-port not specified for linux image" do
-        Chef::Config[:knife][:ssh_user] = 'azureuser'
-        Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
-        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
+        Chef::Config[:knife][:ssh_user] = "azureuser"
+        Chef::Config[:knife][:ssh_password] = "Jetstream123!"
+        Chef::Config[:knife][:bootstrap_protocol] = "ssh"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(false)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to_not be == '22'
+        expect(@server_params[:port]).to_not be == "22"
       end
 
       it "port should be ssh-port value specified in the option" do
-        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
-        Chef::Config[:knife][:ssh_user] = 'azureuser'
-        Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
-        Chef::Config[:knife][:ssh_port] = '24'
+        Chef::Config[:knife][:bootstrap_protocol] = "ssh"
+        Chef::Config[:knife][:ssh_user] = "azureuser"
+        Chef::Config[:knife][:ssh_password] = "Jetstream123!"
+        Chef::Config[:knife][:ssh_port] = "24"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(false)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to be == '24'
+        expect(@server_params[:port]).to be == "24"
       end
 
       it "port should be 22 if user specified --ssh-port 22" do
-        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
-        Chef::Config[:knife][:ssh_user] = 'azureuser'
-        Chef::Config[:knife][:ssh_password] = 'Jetstream123!'
-        Chef::Config[:knife][:ssh_port] = '22'
+        Chef::Config[:knife][:bootstrap_protocol] = "ssh"
+        Chef::Config[:knife][:ssh_user] = "azureuser"
+        Chef::Config[:knife][:ssh_password] = "Jetstream123!"
+        Chef::Config[:knife][:ssh_port] = "22"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(false)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to be == '22'
+        expect(@server_params[:port]).to be == "22"
       end
 
       it "port should be 5985 if user specified --winrm-port 5985" do
-        Chef::Config[:knife][:winrm_user] = 'azureuser'
-        Chef::Config[:knife][:winrm_password] = 'Jetstream123!'
-        Chef::Config[:knife][:winrm_port] = '5985'
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
+        Chef::Config[:knife][:winrm_user] = "azureuser"
+        Chef::Config[:knife][:winrm_password] = "Jetstream123!"
+        Chef::Config[:knife][:winrm_port] = "5985"
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:port]).to be == '5985'
+        expect(@server_params[:port]).to be == "5985"
       end
     end
   end
@@ -623,11 +623,11 @@ describe Chef::Knife::AzureServerCreate do
         allow(Chef::Knife::BootstrapWindowsWinrm).to receive(:new).and_return(@bootstrap)
         expect(@bootstrap).to receive(:run)
         allow(@server_instance).to receive(:is_image_windows?).and_return(true)
-        Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-        Chef::Config[:knife][:winrm_user] = 'testuser'
-        Chef::Config[:knife][:winrm_password] = 'winrm_password'
-        Chef::Config[:knife][:azure_dns_name] = 'service004'
-        Chef::Config[:knife][:azure_vm_name] = 'winrm-vm'
+        Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+        Chef::Config[:knife][:winrm_user] = "testuser"
+        Chef::Config[:knife][:winrm_password] = "winrm_password"
+        Chef::Config[:knife][:azure_dns_name] = "service004"
+        Chef::Config[:knife][:azure_vm_name] = "winrm-vm"
         Chef::Config[:knife][:hints] = nil # reset as this is loaded only once for app(test here)
         allow(@server_instance).to receive(:msg_server_summary)
         @server_instance.run
@@ -649,11 +649,11 @@ describe Chef::Knife::AzureServerCreate do
         allow(Chef::Knife::Bootstrap).to receive(:new).and_return(@bootstrap)
         expect(@bootstrap).to receive(:run)
         allow(@server_instance).to receive(:is_image_windows?).and_return(false)
-        Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
-        Chef::Config[:knife][:ssh_user] = 'ssh_user'
-        Chef::Config[:knife][:azure_dns_name] = 'service004'
-        Chef::Config[:knife][:azure_vm_name] = 'ssh-vm'
+        Chef::Config[:knife][:bootstrap_protocol] = "ssh"
+        Chef::Config[:knife][:ssh_password] = "ssh_password"
+        Chef::Config[:knife][:ssh_user] = "ssh_user"
+        Chef::Config[:knife][:azure_dns_name] = "service004"
+        Chef::Config[:knife][:azure_vm_name] = "ssh-vm"
         Chef::Config[:knife][:hints] = nil # reset as this is loaded only once for app(test here)
         allow(@server_instance).to receive(:msg_server_summary)
         @server_instance.run
@@ -664,7 +664,7 @@ describe Chef::Knife::AzureServerCreate do
         expect(cloud_attributes["public_ip"]).to be == "65.52.251.57"
         expect(cloud_attributes["vm_name"]).to be == "ssh-vm"
         expect(cloud_attributes["public_fqdn"]).to be == "service004.cloudapp.net"
-        expect(cloud_attributes["public_ssh_port"]).to be  == "22"
+        expect(cloud_attributes["public_ssh_port"]).to be == "22"
         expect(cloud_attributes["public_winrm_port"]).to be nil
       end
     end
@@ -672,9 +672,9 @@ describe Chef::Knife::AzureServerCreate do
 
   describe "for bootstrap protocol winrm:" do
     before do
-      Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
-      Chef::Config[:knife][:winrm_user] = 'testuser'
-      Chef::Config[:knife][:winrm_password] = 'winrm_password'
+      Chef::Config[:knife][:bootstrap_protocol] = "winrm"
+      Chef::Config[:knife][:winrm_user] = "testuser"
+      Chef::Config[:knife][:winrm_password] = "winrm_password"
       allow(@server_instance.ui).to receive(:error)
       allow(@server_instance).to receive(:msg_server_summary)
     end
@@ -682,25 +682,25 @@ describe Chef::Knife::AzureServerCreate do
     it "check if all server params are set correctly" do
       expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(true)
       @server_params = @server_instance.create_server_def
-      expect(@server_params[:os_type]).to be == 'Windows'
-      expect(@server_params[:admin_password]).to be == 'winrm_password'
-      expect(@server_params[:bootstrap_proto]).to be == 'winrm'
-      expect(@server_params[:azure_dns_name]).to be == 'service001'
-      expect(@server_params[:azure_vm_name]).to be == 'vm002'
-      expect(@server_params[:winrm_user]).to be == 'testuser'
-      expect(@server_params[:port]).to be == '5985'
+      expect(@server_params[:os_type]).to be == "Windows"
+      expect(@server_params[:admin_password]).to be == "winrm_password"
+      expect(@server_params[:bootstrap_proto]).to be == "winrm"
+      expect(@server_params[:azure_dns_name]).to be == "service001"
+      expect(@server_params[:azure_vm_name]).to be == "vm002"
+      expect(@server_params[:winrm_user]).to be == "testuser"
+      expect(@server_params[:port]).to be == "5985"
     end
 
     it "winrm_user cannot be 'administrator'" do
       expect(@server_instance).to receive(:is_image_windows?).and_return(true)
-      Chef::Config[:knife][:winrm_user] = 'administrator'
-      expect {@server_instance.create_server_def}.to raise_error(SystemExit)
+      Chef::Config[:knife][:winrm_user] = "administrator"
+      expect { @server_instance.create_server_def }.to raise_error(SystemExit)
     end
 
     it "winrm_user cannot be 'admin*'" do
       expect(@server_instance).to receive(:is_image_windows?).and_return(true)
-      Chef::Config[:knife][:winrm_user] = 'Admin12'
-      expect {@server_instance.create_server_def}.to raise_error(SystemExit)
+      Chef::Config[:knife][:winrm_user] = "Admin12"
+      expect { @server_instance.create_server_def }.to raise_error(SystemExit)
     end
 
     context "bootstrap node" do
@@ -717,24 +717,24 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "sets encrypted data bag secret parameter" do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'test_encrypted_data_bag_secret'
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "test_encrypted_data_bag_secret"
         expect(@server_instance).to receive(:is_image_windows?).exactly(6).times.and_return(true)
         @server_instance.run
-        expect(@bootstrap.config[:encrypted_data_bag_secret]).to be == 'test_encrypted_data_bag_secret'
+        expect(@bootstrap.config[:encrypted_data_bag_secret]).to be == "test_encrypted_data_bag_secret"
       end
 
       it "sets encrypted data bag secret file parameter" do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'test_encrypted_data_bag_secret_file'
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "test_encrypted_data_bag_secret_file"
         expect(@server_instance).to receive(:is_image_windows?).exactly(6).times.and_return(true)
         @server_instance.run
-        expect(@bootstrap.config[:encrypted_data_bag_secret_file]).to be == 'test_encrypted_data_bag_secret_file'
+        expect(@bootstrap.config[:encrypted_data_bag_secret_file]).to be == "test_encrypted_data_bag_secret_file"
       end
 
       it "sets winrm authentication protocol for windows vm" do
         Chef::Config[:knife][:winrm_authentication_protocol] = "negotiate"
         expect(@server_instance).to receive(:is_image_windows?).at_least(:twice).and_return(true)
         @server_instance.run
-        expect(@bootstrap.config[:winrm_authentication_protocol]).to be == 'negotiate'
+        expect(@bootstrap.config[:winrm_authentication_protocol]).to be == "negotiate"
       end
 
       it "sets 'msi_url' correctly" do
@@ -755,7 +755,7 @@ describe Chef::Knife::AzureServerCreate do
 
   describe "for bootstrap protocol ssh:" do
     before do
-      Chef::Config[:knife][:bootstrap_protocol] = 'ssh'
+      Chef::Config[:knife][:bootstrap_protocol] = "ssh"
       allow(@server_instance).to receive(:msg_server_summary)
     end
 
@@ -765,26 +765,26 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "sets 'forward_agent' correctly" do
-        expect(@server_instance.send(:locate_config_value,:forward_agent)).to be(true)
+        expect(@server_instance.send(:locate_config_value, :forward_agent)).to be(true)
       end
     end
 
     context "linux instance" do
       before do
-        Chef::Config[:knife][:ssh_user] = 'ssh_user'
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
+        Chef::Config[:knife][:ssh_user] = "ssh_user"
+        Chef::Config[:knife][:ssh_password] = "ssh_password"
       end
 
       it "check if all server params are set correctly" do
         expect(@server_instance).to receive(:is_image_windows?).exactly(3).and_return(false)
         @server_params = @server_instance.create_server_def
-        expect(@server_params[:os_type]).to be == 'Linux'
-        expect(@server_params[:ssh_user]).to be == 'ssh_user'
-        expect(@server_params[:ssh_password]).to be == 'ssh_password'
-        expect(@server_params[:bootstrap_proto]).to be == 'ssh'
-        expect(@server_params[:azure_dns_name]).to be == 'service001'
-        expect(@server_params[:azure_vm_name]).to be == 'vm002'
-        expect(@server_params[:port]).to be == '22'
+        expect(@server_params[:os_type]).to be == "Linux"
+        expect(@server_params[:ssh_user]).to be == "ssh_user"
+        expect(@server_params[:ssh_password]).to be == "ssh_password"
+        expect(@server_params[:bootstrap_proto]).to be == "ssh"
+        expect(@server_params[:azure_dns_name]).to be == "service001"
+        expect(@server_params[:azure_vm_name]).to be == "vm002"
+        expect(@server_params[:port]).to be == "22"
       end
 
       it "successful bootstrap" do
@@ -798,18 +798,18 @@ describe Chef::Knife::AzureServerCreate do
 
       context "ssh key" do
         before do
-          Chef::Config[:knife][:ssh_password] = ''
-          Chef::Config[:knife][:identity_file] = 'path_to_rsa_private_key'
+          Chef::Config[:knife][:ssh_password] = ""
+          Chef::Config[:knife][:identity_file] = "path_to_rsa_private_key"
         end
 
         it "check if ssh-key set correctly" do
           expect(@server_instance).to receive(:is_image_windows?).exactly(3).times.and_return(false)
           @server_params = @server_instance.create_server_def
-          expect(@server_params[:os_type]).to be == 'Linux'
-          expect(@server_params[:identity_file]).to be == 'path_to_rsa_private_key'
-          expect(@server_params[:ssh_user]).to be == 'ssh_user'
-          expect(@server_params[:bootstrap_proto]).to be == 'ssh'
-          expect(@server_params[:azure_dns_name]).to be == 'service001'
+          expect(@server_params[:os_type]).to be == "Linux"
+          expect(@server_params[:identity_file]).to be == "path_to_rsa_private_key"
+          expect(@server_params[:ssh_user]).to be == "ssh_user"
+          expect(@server_params[:bootstrap_proto]).to be == "ssh"
+          expect(@server_params[:azure_dns_name]).to be == "service001"
         end
 
         it "successful bootstrap with ssh key" do
@@ -838,30 +838,30 @@ describe Chef::Knife::AzureServerCreate do
 
         it "does not enable sudo password when ssh_user is root" do
           expect(@bootstrap).to receive(:run)
-          Chef::Config[:knife][:ssh_user] = 'root'
+          Chef::Config[:knife][:ssh_user] = "root"
           @server_instance.run
           expect(@bootstrap.config[:use_sudo_password]).to_not be true
         end
 
         it "sets secret parameter" do
           expect(@bootstrap).to receive(:run)
-          Chef::Config[:knife][:encrypted_data_bag_secret] = 'test_secret'
+          Chef::Config[:knife][:encrypted_data_bag_secret] = "test_secret"
           @server_instance.run
-          expect(@bootstrap.config[:secret]).to be == 'test_secret'
+          expect(@bootstrap.config[:secret]).to be == "test_secret"
         end
 
         it "sets secret file parameter" do
           expect(@bootstrap).to receive(:run)
-          Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'test_secret_file'
+          Chef::Config[:knife][:encrypted_data_bag_secret_file] = "test_secret_file"
           @server_instance.run
-          expect(@bootstrap.config[:secret_file]).to be == 'test_secret_file'
+          expect(@bootstrap.config[:secret_file]).to be == "test_secret_file"
         end
 
         it "sets secret file parameter" do
           expect(@bootstrap).to receive(:run)
-          Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'test_secret_file'
+          Chef::Config[:knife][:encrypted_data_bag_secret_file] = "test_secret_file"
           @server_instance.run
-          expect(@bootstrap.config[:secret_file]).to be == 'test_secret_file'
+          expect(@bootstrap.config[:secret_file]).to be == "test_secret_file"
         end
 
         it "sets first_boot_attributes to empty hash when json_attributes parameter not specified" do
@@ -882,7 +882,7 @@ describe Chef::Knife::AzureServerCreate do
 
   describe "for bootstrap protocol cloud-api:" do
     before do
-      Chef::Config[:knife][:bootstrap_protocol] = 'cloud-api'
+      Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
       allow(@server_instance).to receive(:msg_server_summary)
       Chef::Config[:knife][:run_list] = ["getting-started"]
       Chef::Config[:knife][:validation_client_name] = "testorg-validator"
@@ -898,22 +898,23 @@ describe Chef::Knife::AzureServerCreate do
 
     context "get_chef_extension_public_params" do
       before do
-        @server_instance.config[:bootstrap_version] = '12.4.2'
+        @server_instance.config[:bootstrap_version] = "12.4.2"
         @server_instance.config[:extended_logs] = true
-        @server_instance.config[:chef_daemon_interval] = '16'
+        @server_instance.config[:chef_daemon_interval] = "16"
       end
 
-      let(:public_config) { {
-        :client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"",
-        :runlist=>"\"getting-started\"",
-        :extendedLogs=>"true",
-        :custom_json_attr=>{},
-        :chef_daemon_interval=>"16",
-        :bootstrap_options=>{:chef_server_url=>"https://localhost:443",
-          :validation_client_name=>"chef-validator",
-          :bootstrap_version=>"12.4.2"
+      let(:public_config) do
+        {
+        :client_rb => "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"",
+        :runlist => "\"getting-started\"",
+        :extendedLogs => "true",
+        :custom_json_attr => {},
+        :chef_daemon_interval => "16",
+        :bootstrap_options => { :chef_server_url => "https://localhost:443",
+                                :validation_client_name => "chef-validator",
+                                :bootstrap_version => "12.4.2"
         }
-      } }
+      } end
 
       it "should set public config properly" do
         expect(@server_instance).to receive(:get_chef_extension_name)
@@ -925,8 +926,8 @@ describe Chef::Knife::AzureServerCreate do
       end
 
       it "should add daemon in public config if daemon options is given" do
-        @server_instance.config[:daemon] = 'service'
-        public_config[:daemon] = 'service'
+        @server_instance.config[:daemon] = "service"
+        public_config[:daemon] = "service"
         expect(@server_instance).to receive(:get_chef_extension_name)
         expect(@server_instance).to receive(:get_chef_extension_publisher)
         expect(@server_instance).to receive(:get_chef_extension_version)
@@ -954,16 +955,16 @@ describe Chef::Knife::AzureServerCreate do
         expect(@server_instance).to receive(:wait_until_virtual_machine_ready).exactly(1).times.and_return(true)
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
+        testxml.css('InputEndpoint Protocol:contains("TCP")').each do |port|
           expect(port.parent.css("LocalPort").text).to_not eq("5985")
         end
       end
 
       it "check if all server params are set correctly" do
         version = Nokogiri::XML::Builder.new do |xml|
-          xml.ResourceExtensionReferences {
+          xml.ResourceExtensionReferences do
             xml.Version "11.12"
-          }
+          end
         end
         expect(@server_instance).to_not receive(:bootstrap_exec)
 
@@ -990,16 +991,16 @@ describe Chef::Knife::AzureServerCreate do
         expect(@server_instance).to receive(:wait_until_virtual_machine_ready).exactly(1).times.and_return(true)
         @server_instance.run
         testxml = Nokogiri::XML(@receivedXML)
-        testxml.css('InputEndpoint Protocol:contains("TCP")').each do | port |
+        testxml.css('InputEndpoint Protocol:contains("TCP")').each do |port|
           expect(port.parent.css("LocalPort").text).to eq("22")
         end
       end
 
       it "check if all server params are set correctly" do
         version = Nokogiri::XML::Builder.new do |xml|
-          xml.ResourceExtensionReferences {
+          xml.ResourceExtensionReferences do
             xml.Version "11.12"
-          }
+          end
         end
         expect(@server_instance).to_not receive(:bootstrap_exec)
         allow(@server_instance.service.connection).to receive(:query_azure).and_return(version.doc)
@@ -1017,10 +1018,10 @@ describe Chef::Knife::AzureServerCreate do
 
     shared_context "private config contents" do
       before do
-        allow(File).to receive(:read).and_return('my_client_pem')
+        allow(File).to receive(:read).and_return("my_client_pem")
       end
 
-      it 'uses Chef ClientBuilder to generate client_pem and sets private config properly' do
+      it "uses Chef ClientBuilder to generate client_pem and sets private config properly" do
         expect_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:run)
         expect_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:client_path)
         response = @server_instance.get_chef_extension_private_params
@@ -1028,43 +1029,45 @@ describe Chef::Knife::AzureServerCreate do
       end
     end
 
-    context 'when validation key is not present', :chef_gte_12_only do
-      context 'when encrypted_data_bag_secret option is passed' do
-        let(:private_config) { {:client_pem=>'my_client_pem',
-          :encrypted_data_bag_secret=>'my_encrypted_data_bag_secret'
-        } }
+    context "when validation key is not present", :chef_gte_12_only do
+      context "when encrypted_data_bag_secret option is passed" do
+        let(:private_config) do
+          { :client_pem => "my_client_pem",
+            :encrypted_data_bag_secret => "my_encrypted_data_bag_secret"
+        } end
 
         before do
-          @server_instance.config[:encrypted_data_bag_secret] = 'my_encrypted_data_bag_secret'
+          @server_instance.config[:encrypted_data_bag_secret] = "my_encrypted_data_bag_secret"
         end
 
-        include_context 'private config contents'
+        include_context "private config contents"
       end
 
-      context 'when encrypted_data_bag_secret_file option is passed' do
-        let(:private_config) { {:client_pem=>'my_client_pem',
-          :encrypted_data_bag_secret=>'PgIxStCmMDsuIw3ygRhmdMtStpc9EMiWisQXoP'
-        } }
+      context "when encrypted_data_bag_secret_file option is passed" do
+        let(:private_config) do
+          { :client_pem => "my_client_pem",
+            :encrypted_data_bag_secret => "PgIxStCmMDsuIw3ygRhmdMtStpc9EMiWisQXoP"
+        } end
 
         before do
           @server_instance.config[:encrypted_data_bag_secret_file] = File.dirname(__FILE__) + "/assets/secret_file"
         end
 
-        include_context 'private config contents'
+        include_context "private config contents"
       end
     end
 
-    context 'when SSL certificate file option is passed but file does not exist physically' do
+    context "when SSL certificate file option is passed but file does not exist physically" do
       before do
         allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:run)
         allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:client_path)
         allow(File).to receive(:exist?).and_return(false)
-        allow(File).to receive(:read).and_return('foo')
-        @server_instance.config[:cert_path] = '~/my_cert.crt'
+        allow(File).to receive(:read).and_return("foo")
+        @server_instance.config[:cert_path] = "~/my_cert.crt"
       end
 
-      it 'raises an error and exits' do
-        expect(@server_instance.ui).to receive(:error).with('Specified SSL certificate does not exist.')
+      it "raises an error and exits" do
+        expect(@server_instance.ui).to receive(:error).with("Specified SSL certificate does not exist.")
         expect { @server_instance.get_chef_extension_private_params }.to raise_error(SystemExit)
       end
     end
@@ -1074,7 +1077,7 @@ describe Chef::Knife::AzureServerCreate do
         allow(File).to receive(:exist?).and_return(false)
       end
 
-      it 'raises an exception if validation_key is not present in chef 11' do
+      it "raises an exception if validation_key is not present in chef 11" do
         expect(@server_instance.ui).to receive(:error)
         expect { @server_instance.run }.to raise_error(SystemExit)
       end
@@ -1084,7 +1087,7 @@ describe Chef::Knife::AzureServerCreate do
   describe "extended_logs feature for cloud-api bootstrap protocol" do
     describe "run" do
       before do
-        Chef::Config[:knife][:ssh_password] = 'ssh_password'
+        Chef::Config[:knife][:ssh_password] = "ssh_password"
         allow(Chef::Log).to receive(:info)
         allow(@server_instance).to receive(:validate_asm_keys!)
         allow(@server_instance).to receive(:validate_params!)
@@ -1099,7 +1102,7 @@ describe Chef::Knife::AzureServerCreate do
 
       context "bootstrap_protocol is not cloud-api and extended_logs is false" do
         before do
-          Chef::Config[:knife][:bootstrap_protocol] = 'winrm'
+          Chef::Config[:knife][:bootstrap_protocol] = "winrm"
           @server_instance.config[:extended_logs] = false
         end
 
@@ -1111,7 +1114,7 @@ describe Chef::Knife::AzureServerCreate do
 
       context "bootstrap_protocol is cloud-api" do
         before do
-          Chef::Config[:knife][:bootstrap_protocol] = 'cloud-api'
+          Chef::Config[:knife][:bootstrap_protocol] = "cloud-api"
         end
 
         context "extended_logs is false" do
@@ -1155,7 +1158,7 @@ describe Chef::Knife::AzureServerCreate do
       context "extension not found" do
         before do
           allow(@server_instance).to receive(
-            :fetch_role).and_return('vm002')
+            :fetch_role).and_return("vm002")
           allow(@server_instance).to receive(
             :fetch_extension).and_return(nil)
         end
@@ -1170,9 +1173,9 @@ describe Chef::Knife::AzureServerCreate do
       context "substatus not found in server role response" do
         before do
           allow(@server_instance).to receive(
-            :fetch_role).and_return('vm002')
+            :fetch_role).and_return("vm002")
           allow(@server_instance).to receive(
-            :fetch_extension).and_return('extension')
+            :fetch_extension).and_return("extension")
           allow(@server_instance).to receive(
             :fetch_substatus).and_return(nil)
           @start_time = Time.now
@@ -1204,10 +1207,10 @@ describe Chef::Knife::AzureServerCreate do
 
       context "substatus found in server role response" do
         before do
-          Chef::Config[:knife][:azure_vm_name] = 'vm04'
+          Chef::Config[:knife][:azure_vm_name] = "vm04"
           allow(@server_instance.service).to receive(
-            :deployment_name).and_return('deploymentExtension')
-          deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+            :deployment_name).and_return("deploymentExtension")
+          deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
           allow(@server_instance.service).to receive(
             :deployment).and_return(deployment)
         end
@@ -1224,7 +1227,7 @@ describe Chef::Knife::AzureServerCreate do
     describe "fetch_role" do
       context "role not found" do
         before do
-          Chef::Config[:knife][:azure_vm_name] = 'vm09'
+          Chef::Config[:knife][:azure_vm_name] = "vm09"
         end
 
         it "returns nil" do
@@ -1235,23 +1238,23 @@ describe Chef::Knife::AzureServerCreate do
 
       context "role found" do
         before do
-          Chef::Config[:knife][:azure_vm_name] = 'vm01'
+          Chef::Config[:knife][:azure_vm_name] = "vm01"
         end
 
         it "returns the role" do
           response = fetch_role_from_xml
           expect(response).to_not be nil
-          expect(response.at_css('RoleName').text).to eq 'vm01'
+          expect(response.at_css("RoleName").text).to eq "vm01"
         end
       end
     end
 
     describe "fetch_extension" do
       context "Chef Extension not found" do
-        context 'other extension(s) available' do
-          context 'example-1' do
+        context "other extension(s) available" do
+          context "example-1" do
             before do
-              Chef::Config[:knife][:azure_vm_name] = 'vm01'
+              Chef::Config[:knife][:azure_vm_name] = "vm01"
               @role = fetch_role_from_xml
             end
 
@@ -1261,9 +1264,9 @@ describe Chef::Knife::AzureServerCreate do
             end
           end
 
-          context 'example-2' do
+          context "example-2" do
             before do
-              Chef::Config[:knife][:azure_vm_name] = 'vm07'
+              Chef::Config[:knife][:azure_vm_name] = "vm07"
               @role = fetch_role_from_xml
             end
 
@@ -1274,9 +1277,9 @@ describe Chef::Knife::AzureServerCreate do
           end
         end
 
-        context 'none of the extension available' do
+        context "none of the extension available" do
           before do
-            Chef::Config[:knife][:azure_vm_name] = 'vm06'
+            Chef::Config[:knife][:azure_vm_name] = "vm06"
             @role = fetch_role_from_xml
           end
 
@@ -1290,29 +1293,29 @@ describe Chef::Knife::AzureServerCreate do
       context "Chef Extension found" do
         context "for Windows platform" do
           before do
-            Chef::Config[:knife][:azure_vm_name] = 'vm02'
+            Chef::Config[:knife][:azure_vm_name] = "vm02"
             @role = fetch_role_from_xml
           end
 
           it "returns the Windows Chef Extension" do
             response = @server_instance.fetch_extension(@role)
             expect(response).to_not be nil
-            expect(response.at_css('HandlerName').text).to eq \
-              'Chef.Bootstrap.WindowsAzure.ChefClient'
+            expect(response.at_css("HandlerName").text).to eq \
+              "Chef.Bootstrap.WindowsAzure.ChefClient"
           end
         end
 
         context "for Linux platform" do
           before do
-            Chef::Config[:knife][:azure_vm_name] = 'vm03'
+            Chef::Config[:knife][:azure_vm_name] = "vm03"
             @role = fetch_role_from_xml
           end
 
           it "returns the Linux Chef Extension" do
             response = @server_instance.fetch_extension(@role)
             expect(response).to_not be nil
-            expect(response.at_css('HandlerName').text).to eq \
-              'Chef.Bootstrap.WindowsAzure.LinuxChefClient'
+            expect(response.at_css("HandlerName").text).to eq \
+              "Chef.Bootstrap.WindowsAzure.LinuxChefClient"
           end
         end
       end
@@ -1321,7 +1324,7 @@ describe Chef::Knife::AzureServerCreate do
     describe "fetch_substatus" do
       context "substatus list not found" do
         before do
-          Chef::Config[:knife][:azure_vm_name] = 'vm02'
+          Chef::Config[:knife][:azure_vm_name] = "vm02"
           role = fetch_role_from_xml
           @extension = @server_instance.fetch_extension(role)
         end
@@ -1335,7 +1338,7 @@ describe Chef::Knife::AzureServerCreate do
       context "substatus list found" do
         context "but it does not contain chef-client run logs substatus" do
           before do
-            Chef::Config[:knife][:azure_vm_name] = 'vm03'
+            Chef::Config[:knife][:azure_vm_name] = "vm03"
             role = fetch_role_from_xml
             @extension = @server_instance.fetch_extension(role)
           end
@@ -1348,7 +1351,7 @@ describe Chef::Knife::AzureServerCreate do
 
         context "and it do contain chef-client run logs substatus" do
           before do
-            Chef::Config[:knife][:azure_vm_name] = 'vm04'
+            Chef::Config[:knife][:azure_vm_name] = "vm04"
             role = fetch_role_from_xml
             @extension = @server_instance.fetch_extension(role)
           end
@@ -1356,87 +1359,76 @@ describe Chef::Knife::AzureServerCreate do
           it "returns the substatus" do
             response = @server_instance.fetch_substatus(@extension)
             expect(response).to_not be nil
-            expect(response.at_css('Name').text).to eq 'Chef Client run logs'
-            expect(response.at_css('Status').text).to eq 'Success'
-            expect(response.at_css('Message').text).to eq 'MyChefClientRunLogs'
+            expect(response.at_css("Name").text).to eq "Chef Client run logs"
+            expect(response.at_css("Status").text).to eq "Success"
+            expect(response.at_css("Message").text).to eq "MyChefClientRunLogs"
           end
         end
       end
     end
   end
 
-  describe '#load_correct_secret' do
-    context 'when encrypted_data_bag_secret_file is passed in knife.rb' do
-      it 'returns the encrypted_data_bag_secret_file passed from the knife.rb' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
+  describe "#load_correct_secret" do
+    context "when encrypted_data_bag_secret_file is passed in knife.rb" do
+      it "returns the encrypted_data_bag_secret_file passed from the knife.rb" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == Chef::Config[:knife][:encrypted_data_bag_secret_file]
       end
     end
 
-    context 'when encrypted_data_bag_secret is passed in knife.rb' do
-      it 'returns the encrypted_data_bag_secret passed from the knife.rb' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
+    context "when encrypted_data_bag_secret is passed in knife.rb" do
+      it "returns the encrypted_data_bag_secret passed from the knife.rb" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
         secret = @server_instance.load_correct_secret
         expect(secret).to be == Chef::Config[:knife][:encrypted_data_bag_secret]
       end
     end
 
-    context 'when both encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb' do
-      it 'returns the encrypted_data_bag_secret_file passed from the knife.rb' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
+    context "when both encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb" do
+      it "returns the encrypted_data_bag_secret_file passed from the knife.rb" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == Chef::Config[:knife][:encrypted_data_bag_secret_file]
       end
     end
 
-    context 'when encrypted_data_bag_secret_file is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
+    context "when encrypted_data_bag_secret_file is passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
       end
     end
 
-    context 'when encrypted_data_bag_secret is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret passed from the CLI' do
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
+    context "when encrypted_data_bag_secret is passed from CLI" do
+      it "returns the encrypted_data_bag_secret passed from the CLI" do
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret]
       end
     end
 
-    context 'when both encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from CLI' do
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
+    context "when both encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from CLI" do
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
       end
     end
 
-    context 'when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed from both knife.rb file and CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
-        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
-        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
-        secret = @server_instance.load_correct_secret
-        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
-      end
-    end
-
-    context 'when encrypted_data_bag_secret_file is passed from both knife.rb file and CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
+    context "when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed from both knife.rb file and CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
@@ -1444,63 +1436,51 @@ describe Chef::Knife::AzureServerCreate do
       end
     end
 
-    context 'when encrypted_data_bag_secret is passed from both knife.rb file and CLI' do
-      it 'returns the encrypted_data_bag_secret passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
+    context "when encrypted_data_bag_secret_file is passed from both knife.rb file and CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
+        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
+        secret = @server_instance.load_correct_secret
+        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
+      end
+    end
+
+    context "when encrypted_data_bag_secret is passed from both knife.rb file and CLI" do
+      it "returns the encrypted_data_bag_secret passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret]
       end
     end
 
-    context 'when encrypted_data_bag_secret_file is passed in knife.rb and encrypted_data_bag_secret is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
+    context "when encrypted_data_bag_secret_file is passed in knife.rb and encrypted_data_bag_secret is passed from CLI" do
+      it "returns the encrypted_data_bag_secret passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret]
       end
     end
 
-    context 'when encrypted_data_bag_secret is passed in knife.rb and encrypted_data_bag_secret_file is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
+    context "when encrypted_data_bag_secret is passed in knife.rb and encrypted_data_bag_secret_file is passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
       end
     end
 
-    context 'when encrypted_data_bag_secret_file is passed in knife.rb and encrypted_data_bag_secret_file, encrypted_data_bag_secret are passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
-        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
-        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
-        secret = @server_instance.load_correct_secret
-        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
-      end
-    end
-
-    context 'when encrypted_data_bag_secret is passed in knife.rb and encrypted_data_bag_secret_file, encrypted_data_bag_secret are passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
-        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
-        secret = @server_instance.load_correct_secret
-        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
-      end
-    end
-
-    context 'when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb and encrypted_data_bag_secret_file is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret_file passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        @server_instance.config[:encrypted_data_bag_secret_file] = 'cli/path'
+    context "when encrypted_data_bag_secret_file is passed in knife.rb and encrypted_data_bag_secret_file, encrypted_data_bag_secret are passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
@@ -1508,11 +1488,34 @@ describe Chef::Knife::AzureServerCreate do
       end
     end
 
-    context 'when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb and encrypted_data_bag_secret is passed from CLI' do
-      it 'returns the encrypted_data_bag_secret passed from the CLI' do
-        Chef::Config[:knife][:encrypted_data_bag_secret] = 'knife_secret'
-        Chef::Config[:knife][:encrypted_data_bag_secret_file] = 'knife/path'
-        @server_instance.config[:encrypted_data_bag_secret] = 'cli_secret'
+    context "when encrypted_data_bag_secret is passed in knife.rb and encrypted_data_bag_secret_file, encrypted_data_bag_secret are passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
+        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
+        secret = @server_instance.load_correct_secret
+        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
+      end
+    end
+
+    context "when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb and encrypted_data_bag_secret_file is passed from CLI" do
+      it "returns the encrypted_data_bag_secret_file passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        @server_instance.config[:encrypted_data_bag_secret_file] = "cli/path"
+        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(@server_instance.config[:encrypted_data_bag_secret_file]).and_return(@server_instance.config[:encrypted_data_bag_secret_file])
+        allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
+        secret = @server_instance.load_correct_secret
+        expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret_file]
+      end
+    end
+
+    context "when encrypted_data_bag_secret_file and encrypted_data_bag_secret are passed in knife.rb and encrypted_data_bag_secret is passed from CLI" do
+      it "returns the encrypted_data_bag_secret passed from the CLI" do
+        Chef::Config[:knife][:encrypted_data_bag_secret] = "knife_secret"
+        Chef::Config[:knife][:encrypted_data_bag_secret_file] = "knife/path"
+        @server_instance.config[:encrypted_data_bag_secret] = "cli_secret"
         allow(Chef::EncryptedDataBagItem).to receive(:load_secret).with(Chef::Config[:knife][:encrypted_data_bag_secret_file]).and_return(Chef::Config[:knife][:encrypted_data_bag_secret_file])
         secret = @server_instance.load_correct_secret
         expect(secret).to be == @server_instance.config[:encrypted_data_bag_secret]
@@ -1522,8 +1525,8 @@ describe Chef::Knife::AzureServerCreate do
 
   def fetch_role_from_xml
     allow(@server_instance.service).to receive(
-      :deployment_name).and_return('deploymentExtension')
-    deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+      :deployment_name).and_return("deploymentExtension")
+    deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
     allow(@server_instance.service).to receive(
       :deployment).and_return(deployment)
     @server_instance.fetch_role

--- a/spec/unit/azure_server_delete_spec.rb
+++ b/spec/unit/azure_server_delete_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureServerDelete do
   include AzureSpecHelper
@@ -7,19 +7,19 @@ describe Chef::Knife::AzureServerDelete do
 
   before do
     @server_instance = Chef::Knife::AzureServerDelete.new
-      {
-        :azure_subscription_id => 'azure_subscription_id',
-        :azure_mgmt_cert => @cert_file,
-        :azure_api_host_name => 'preview.core.windows-int.net',
-        :name => 'vm01',
-        :azure_service_location => 'West Europe',
-        :azure_source_image => 'azure_source_image',
-        :azure_vm_size => 'Small',
-        :azure_dns_name => 'service001',
-        :azure_storage_account => 'ka001testeurope'
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      :azure_subscription_id => "azure_subscription_id",
+      :azure_mgmt_cert => @cert_file,
+      :azure_api_host_name => "preview.core.windows-int.net",
+      :name => "vm01",
+      :azure_service_location => "West Europe",
+      :azure_source_image => "azure_source_image",
+      :azure_vm_size => "Small",
+      :azure_dns_name => "service001",
+      :azure_storage_account => "ka001testeurope"
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
     @connection = @server_instance.service.connection
     stub_query_azure(@connection)
 
@@ -32,7 +32,7 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "delete server" do
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -41,7 +41,7 @@ describe Chef::Knife::AzureServerDelete do
 
   it "wait for server delete" do
     Chef::Config[:knife][:wait] = true
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -55,7 +55,7 @@ describe Chef::Knife::AzureServerDelete do
   it "wait for server delete and preserve_azure_vhd" do
     Chef::Config[:knife][:wait] = true
     Chef::Config[:knife][:preserve_azure_vhd] = true
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -69,7 +69,7 @@ describe Chef::Knife::AzureServerDelete do
   it "delete everything if cloud service contains only one role and no wait and no preserve option set" do
     Chef::Config[:knife][:wait] = false
     Chef::Config[:knife][:azure_dns_name] = "service002"
-    @server_instance.name_args = ['vm01']
+    @server_instance.name_args = ["vm01"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -83,11 +83,10 @@ describe Chef::Knife::AzureServerDelete do
     Chef::Config[:knife][:wait] = false
     Chef::Config[:knife][:azure_dns_name] = "service002"
     Chef::Config[:knife][:preserve_azure_dns_name] = true
-    @server_instance.name_args = ['vm01']
+    @server_instance.name_args = ["vm01"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
-
 
     # comp=media deletes role and associated disks
     expect(@connection).to receive(:query_azure).with("hostedservices/service002/deployments/testrequest", "delete", "", "comp=media", false)
@@ -95,7 +94,7 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "display valid nomenclature in delete output" do
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:msg_pair).with(@server_instance.service.ui, "DNS Name", Chef::Config[:knife][:azure_dns_name] + ".cloudapp.net")
     expect(@server_instance.service).to receive(:msg_pair).with(@server_instance.service.ui, "VM Name", "role001")
@@ -106,9 +105,8 @@ describe Chef::Knife::AzureServerDelete do
     @server_instance.run
   end
 
-
   it "test hosted service cleanup with shared service" do
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -118,7 +116,7 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "dont cleanup hosted service when --preserve-azure-dns-name param set" do
-    @server_instance.name_args = ['role001']
+    @server_instance.name_args = ["role001"]
     Chef::Config[:knife][:preserve_azure_dns_name] = true
     expect(@server_instance.ui).to receive(:warn).twice
     expect(@server_instance.service).to receive(:delete_server).and_call_original
@@ -129,14 +127,13 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "delete vm within a hosted service when --azure-dns-name param set" do
-    test_hostname = 'vm002'
+    test_hostname = "vm002"
     @server_instance.name_args = [test_hostname]
 
-    Chef::Config[:knife][:azure_dns_name] = 'service001'
+    Chef::Config[:knife][:azure_dns_name] = "service001"
     Chef::Config[:knife][:preserve_azure_os_disk] = true
     expect(@server_instance.service).to receive(:delete_server).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
-
 
     # test correct params are passed to azure API.
     expect(@connection).to receive(:query_azure).with("hostedservices/#{Chef::Config[:knife][:azure_dns_name]}/deployments/deployment001/roles/#{test_hostname}", "delete")
@@ -145,10 +142,10 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "delete multiple vm's within a hosted service when --azure-dns-name param set" do
-    test_hostnames = ['vm002', 'role002', 'role001']
+    test_hostnames = %w{vm002 role002 role001}
     @server_instance.name_args = test_hostnames
 
-    Chef::Config[:knife][:azure_dns_name] = 'service001'
+    Chef::Config[:knife][:azure_dns_name] = "service001"
     Chef::Config[:knife][:preserve_azure_os_disk] = true
 
     expect(@server_instance.service).to receive(:delete_server).exactly(3).times.and_call_original
@@ -163,8 +160,8 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "should preserve OS Disk when --preserve-azure-os-disk is set." do
-    test_hostname = 'role002'
-    test_diskname = 'disk1'
+    test_hostname = "role002"
+    test_diskname = "disk1"
     @server_instance.name_args = [test_hostname]
     Chef::Config[:knife][:preserve_azure_os_disk] = true
     expect(@server_instance.service).to receive(:delete_server).exactly(:once).and_call_original
@@ -177,8 +174,8 @@ describe Chef::Knife::AzureServerDelete do
 
   it "should delete OS Disk and VHD when --wait set and --preserve-azure-os-disk, --preserve-azure-vhd are not set." do
     Chef::Config[:knife][:wait] = true
-    test_hostname = 'role001'
-    test_diskname = 'deployment001-role002-0-201241722728'
+    test_hostname = "role001"
+    test_diskname = "deployment001-role002-0-201241722728"
     @server_instance.name_args = [test_hostname]
     expect(@server_instance.service).to receive(:delete_server).exactly(1).and_call_original
     expect(@server_instance.service).to receive(:msg_pair).exactly(4).times
@@ -188,8 +185,8 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "should preserve VHD when --preserve-azure-vhd is set." do
-    test_hostname = 'role001'
-    test_diskname = 'deployment001-role002-0-201241722728'
+    test_hostname = "role001"
+    test_diskname = "deployment001-role002-0-201241722728"
     Chef::Config[:knife][:preserve_azure_vhd] = true
     @server_instance.name_args = [test_hostname]
     expect(@server_instance.service).to receive(:delete_server).exactly(1).and_call_original
@@ -201,8 +198,8 @@ describe Chef::Knife::AzureServerDelete do
 
   describe "Storage Account" do
     before(:each) do
-      test_hostname = 'role001'
-      @test_storage_account = 'auxpreview104imagestore'
+      test_hostname = "role001"
+      @test_storage_account = "auxpreview104imagestore"
       @server_instance.name_args = [test_hostname]
     end
 
@@ -223,12 +220,12 @@ describe Chef::Knife::AzureServerDelete do
   end
 
   it "should give a warning and exit when both --preserve-azure-os-disk and --delete-azure-storage-account are set." do
-    test_hostname = 'role001'
+    test_hostname = "role001"
     Chef::Config[:knife][:preserve_azure_os_disk] = true
     Chef::Config[:knife][:delete_azure_storage_account] = true
     @server_instance.name_args = [test_hostname]
-    test_storage_account = 'auxpreview104imagestore'
-    test_diskname = 'deployment001-role002-0-201241722728'
+    test_storage_account = "auxpreview104imagestore"
+    test_diskname = "deployment001-role002-0-201241722728"
     expect(@connection).to_not receive(:query_azure).with("disks/#{test_diskname}", "delete")
     expect(@connection).to_not receive(:query_azure).with("storageservices/#{test_storage_account}", "delete")
     expect(@server_instance.ui).to receive(:warn).with("Cannot delete storage account while keeping OS Disk. Please set any one option.")

--- a/spec/unit/azure_server_list_spec.rb
+++ b/spec/unit/azure_server_list_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureServerList do
   include AzureSpecHelper
@@ -25,16 +25,16 @@ describe Chef::Knife::AzureServerList do
     @server_instance.run
   end
 
-  it "should return public port for Remote Desktop if set" do 
-    arr_hash = [{"Name"=>"PowerShell", "Vip"=>"13.92.236.37", "PublicPort"=>"5986", "LocalPort"=>"5986"},
-                {"Name"=>"Remote Desktop", "Vip"=>"13.92.236.37", "PublicPort"=>"3389", "LocalPort"=>"3389"}]
+  it "should return public port for Remote Desktop if set" do
+    arr_hash = [{ "Name" => "PowerShell", "Vip" => "13.92.236.37", "PublicPort" => "5986", "LocalPort" => "5986" },
+                { "Name" => "Remote Desktop", "Vip" => "13.92.236.37", "PublicPort" => "3389", "LocalPort" => "3389" }]
     rdp_port = @server_management_instance.rdp_port(arr_hash)
-    expect(rdp_port).to be ==  "3389"
+    expect(rdp_port).to be == "3389"
   end
 
   it "should return empty port for Remote Desktop if not set" do
-    arr_hash = [{"Name"=>"PowerShell", "Vip"=>"13.92.236.37", "PublicPort"=>"5986", "LocalPort"=>"5986"}]
+    arr_hash = [{ "Name" => "PowerShell", "Vip" => "13.92.236.37", "PublicPort" => "5986", "LocalPort" => "5986" }]
     rdp_port = @server_management_instance.rdp_port(arr_hash)
-    expect(rdp_port).to be ==  ""
+    expect(rdp_port).to be == ""
   end
 end

--- a/spec/unit/azure_server_show_spec.rb
+++ b/spec/unit/azure_server_show_spec.rb
@@ -1,119 +1,119 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureServerShow do
   include AzureSpecHelper
   include QueryAzureMock
   before do
     @server_instance = create_instance(Chef::Knife::AzureServerShow)
-    
+
     stub_query_azure(@server_instance.service.connection)
     allow(@server_instance).to receive(:puts)
   end
 
-  it 'should display server information.' do
-    @server_instance.name_args = %w(role206 role001 role002 vm002 vm01 ssh-vm
-                                    winrm-vm vmname)
+  it "should display server information." do
+    @server_instance.name_args = %w{role206 role001 role002 vm002 vm01 ssh-vm
+                                    winrm-vm vmname}
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'role001',
-       'Status', 'ReadyRole',
-       'Size', 'Small',
-       'Hosted service name', 'service001',
-       'Deployment name', 'deployment001',
-       'Host name', 'role001',
-       'SSH port', '22',
-       'Public IP', '65.52.249.191',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "role001",
+       "Status", "ReadyRole",
+       "Size", "Small",
+       "Hosted service name", "service001",
+       "Deployment name", "deployment001",
+       "Host name", "role001",
+       "SSH port", "22",
+       "Public IP", "65.52.249.191",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'role002',
-       'Status', 'RoleStateUnknown',
-       'Size', 'Small',
-       'Hosted service name', 'service001',
-       'Deployment name', 'deployment001',
-       'Host name', 'role002',
-       'SSH port', '23',
-       'Public IP', '65.52.249.191',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "role002",
+       "Status", "RoleStateUnknown",
+       "Size", "Small",
+       "Hosted service name", "service001",
+       "Deployment name", "deployment001",
+       "Host name", "role002",
+       "SSH port", "23",
+       "Public IP", "65.52.249.191",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'vm002',
-       'Status', 'ReadyRole',
-       'Size', 'ExtraSmall',
-       'Hosted service name', 'service001',
-       'Deployment name', 'deployment001',
-       'Host name', 'myVm2',
-       'SSH port', '22',
-       'Public IP', '65.52.251.57',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "vm002",
+       "Status", "ReadyRole",
+       "Size", "ExtraSmall",
+       "Hosted service name", "service001",
+       "Deployment name", "deployment001",
+       "Host name", "myVm2",
+       "SSH port", "22",
+       "Public IP", "65.52.251.57",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Ports open', 'Local port', 'IP', 'Public port',
-       'tcp', '66', '65.52.251.57', '66'],
+      ["Ports open", "Local port", "IP", "Public port",
+       "tcp", "66", "65.52.251.57", "66"],
       :columns_across,
       4
     ).exactly(3).times
     expect(@server_instance.ui).to receive(:list).with(
-      ['Ports open', 'Local port', 'IP', 'Public port',
-       'tcp', '3389', '65.52.249.191', '3389'],
+      ["Ports open", "Local port", "IP", "Public port",
+       "tcp", "3389", "65.52.249.191", "3389"],
       :columns_across,
       4
     ).exactly(1).times
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'vm01',
-       'Status', 'ReadyRole',
-       'Size', 'ExtraSmall',
-       'Hosted service name', 'service002',
-       'Deployment name', 'testrequest',
-       'Host name', 'myVm',
-       'SSH port', '54047',
-       'Public IP', '65.52.251.144',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "vm01",
+       "Status", "ReadyRole",
+       "Size", "ExtraSmall",
+       "Hosted service name", "service002",
+       "Deployment name", "testrequest",
+       "Host name", "myVm",
+       "SSH port", "54047",
+       "Public IP", "65.52.251.144",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'ssh-vm',
-       'Status', 'ReadyRole',
-       'Size', 'ExtraSmall',
-       'Hosted service name', 'service004',
-       'Deployment name', 'deployment004',
-       'Host name', 'ssh-vm',
-       'SSH port', '22',
-       'Public IP', '65.52.251.57',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "ssh-vm",
+       "Status", "ReadyRole",
+       "Size", "ExtraSmall",
+       "Hosted service name", "service004",
+       "Deployment name", "deployment004",
+       "Host name", "ssh-vm",
+       "SSH port", "22",
+       "Public IP", "65.52.251.57",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'winrm-vm',
-       'Status', 'ReadyRole',
-       'Size', 'Small',
-       'Hosted service name', 'service004',
-       'Deployment name', 'deployment004',
-       'Host name', 'winrm-vm',
-       'WinRM port', '5985',
-       'Public IP', '65.52.249.191',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "winrm-vm",
+       "Status", "ReadyRole",
+       "Size", "Small",
+       "Hosted service name", "service004",
+       "Deployment name", "deployment004",
+       "Host name", "winrm-vm",
+       "WinRM port", "5985",
+       "Public IP", "65.52.249.191",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )
     expect(@server_instance.ui).to receive(:list).with(
-      ['Role name', 'vmname',
-       'Status', 'ReadyRole',
-       'Size', 'ExtraSmall',
-       'Hosted service name', 'vmname',
-       'Deployment name', 'deployment001',
-       'Host name', 'myVm2',
-       'SSH port', '22',
-       'Public IP', '65.52.251.57',
-       'Thumbprint', '4BAE99A617B7B4F975C51A572CB8420F66477F4C'],
+      ["Role name", "vmname",
+       "Status", "ReadyRole",
+       "Size", "ExtraSmall",
+       "Hosted service name", "vmname",
+       "Deployment name", "deployment001",
+       "Host name", "myVm2",
+       "SSH port", "22",
+       "Public IP", "65.52.251.57",
+       "Thumbprint", "4BAE99A617B7B4F975C51A572CB8420F66477F4C"],
       :columns_across,
       2
     )

--- a/spec/unit/azure_vnet_create_spec.rb
+++ b/spec/unit/azure_vnet_create_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureVnetCreate do
   include AzureSpecHelper
@@ -13,22 +13,22 @@ describe Chef::Knife::AzureVnetCreate do
     allow(@server_instance).to receive(:print)
   end
 
-  it 'should fail missing args.' do
+  it "should fail missing args." do
     expect(@connection.vnets).to_not receive(:create)
     expect(@server_instance.ui).to receive(:error).exactly(3).times
     expect { @server_instance.run }.to raise_error(SystemExit)
   end
 
-  it 'should succeed.' do
-    Chef::Config[:knife][:azure_network_name] = 'new-net'
-    Chef::Config[:knife][:azure_affinity_group] = 'ag'
-    Chef::Config[:knife][:azure_address_space] = '10.0.0.0/24'
-    Chef::Config[:knife][:azure_subnet_name] = 'Subnet-7'
+  it "should succeed." do
+    Chef::Config[:knife][:azure_network_name] = "new-net"
+    Chef::Config[:knife][:azure_affinity_group] = "ag"
+    Chef::Config[:knife][:azure_address_space] = "10.0.0.0/24"
+    Chef::Config[:knife][:azure_subnet_name] = "Subnet-7"
     expect(@connection.vnets).to receive(:create).with(
-      azure_vnet_name: 'new-net',
-      azure_ag_name: 'ag',
-      azure_address_space: '10.0.0.0/24',
-      azure_subnet_name:"Subnet-7"
+      azure_vnet_name: "new-net",
+      azure_ag_name: "ag",
+      azure_address_space: "10.0.0.0/24",
+      azure_subnet_name: "Subnet-7"
     ).and_call_original
     expect(@server_instance.ui).to_not receive(:warn)
     expect(@server_instance.ui).to_not receive(:error)

--- a/spec/unit/azure_vnet_list_spec.rb
+++ b/spec/unit/azure_vnet_list_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzureAgList do
   include AzureSpecHelper
@@ -10,12 +10,12 @@ describe Chef::Knife::AzureAgList do
     allow(@server_instance).to receive(:puts)
   end
 
-  it 'should display Name, Affinity Group, and State columns.' do
+  it "should display Name, Affinity Group, and State columns." do
     expect(@server_instance.ui).to receive(:list).with(
-      ['Name', 'Affinity Group', 'State',
-       'jm-vnet-test', 'jm-affinity-group', 'Created',
-       'vnet-test-2', 'test', 'Created',
-       'vnname', 'agname', 'Created'],
+      ["Name", "Affinity Group", "State",
+       "jm-vnet-test", "jm-affinity-group", "Created",
+       "vnet-test-2", "test", "Created",
+       "vnname", "agname", "Created"],
       :uneven_columns_across,
       3
     )

--- a/spec/unit/azurerm_base_spec.rb
+++ b/spec/unit/azurerm_base_spec.rb
@@ -3,8 +3,8 @@
 # Copyright:: Copyright 2008-2018, Chef Software Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzurermBase do
   include AzureSpecHelper
@@ -18,8 +18,8 @@ describe Chef::Knife::AzurermBase do
   end
   before do
     @dummy = Chef::Knife::DummyClass.new
-    Chef::Config[:knife][:azure_api_host_name] = 'preview.core.windows-int.net'
-    Chef::Config[:knife][:azure_subscription_id] = 'azure_subscription_id'
+    Chef::Config[:knife][:azure_api_host_name] = "preview.core.windows-int.net"
+    Chef::Config[:knife][:azure_subscription_id] = "azure_subscription_id"
     Chef::Config[:knife][:azure_mgmt_cert] = @cert_file
     allow(@dummy.ui).to receive(:error)
     @arm_server_instance = create_arm_instance(Chef::Knife::AzurermServerList)
@@ -35,7 +35,7 @@ describe Chef::Knife::AzurermBase do
         Chef::Config[:knife][:azure_subscription_id] = nil
       end
 
-      def validate_cert()
+      def validate_cert
         expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN CERTIFICATE-----")
         expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----END CERTIFICATE-----")
         expect(Chef::Config[:knife][:azure_mgmt_cert]).to include("-----BEGIN RSA PRIVATE KEY-----")
@@ -54,22 +54,22 @@ describe Chef::Knife::AzurermBase do
       it "- should validate extract parameters" do
         Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
         @dummy.validate_arm_keys!
-        expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-        expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
         validate_cert()
       end
 
       it "- should validate parse method" do
         @dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValid.publishsettings"))
-        expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-        expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
         validate_cert()
       end
 
       it "- should validate parse method for SchemaVersion2-0 publishsettings file" do
         @dummy.parse_publish_settings_file(get_publish_settings_file_path("azureValidSchemaVersion-2.0.publishsettings"))
-        expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-        expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
         validate_cert()
       end
 
@@ -77,33 +77,33 @@ describe Chef::Knife::AzurermBase do
         @dummy.config[:azure_subscription_id] = "azure_subscription_id"
         Chef::Config[:knife][:azure_publish_settings_file] = get_publish_settings_file_path("azureValid.publishsettings")
         @dummy.validate_arm_keys!
-        expect(Chef::Config[:knife][:azure_api_host_name]).to be == 'management.core.windows.net'
-        expect(@dummy.config[:azure_subscription_id]).to be == 'azure_subscription_id'
-        expect(Chef::Config[:knife][:azure_subscription_id]).to be == 'id1'
+        expect(Chef::Config[:knife][:azure_api_host_name]).to be == "management.core.windows.net"
+        expect(@dummy.config[:azure_subscription_id]).to be == "azure_subscription_id"
+        expect(Chef::Config[:knife][:azure_subscription_id]).to be == "id1"
         validate_cert()
       end
     end
   end
 
   describe "Token related test cases" do
-    context 'Xplat Azure login validation' do
+    context "Xplat Azure login validation" do
       context "Platform is Linux" do
-        let (:azure_prefix) {  @dummy.instance_variable_get(:@azure_prefix) }
+        let (:azure_prefix) { @dummy.instance_variable_get(:@azure_prefix) }
         before(:each) do
           allow(Chef::Platform).to receive(:windows?).and_return(false)
         end
-        it 'Accesstoken file doesnt exist for Linux' do
+        it "Accesstoken file doesnt exist for Linux" do
           allow(File).to receive(:exists?).and_return(false)
           expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
-        it 'Accesstoken file exist for Linux' do
+        it "Accesstoken file exist for Linux" do
           allow(File).to receive(:exists?).and_return(true)
           allow(File).to receive(:size?).and_return(4)
           expect { @arm_server_instance.validate_azure_login }.not_to raise_error
         end
 
-        it 'Accesstoken file contain [] value upon running azure logout command for Linux' do
+        it "Accesstoken file contain [] value upon running azure logout command for Linux" do
           allow(File).to receive(:size?).and_return(2)
           expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
@@ -179,7 +179,7 @@ describe Chef::Knife::AzurermBase do
 
               it "raises error" do
                 expect(Mixlib::ShellOut).to_not receive(:new)
-                expect(File).to receive(:expand_path).and_return('user_home_path')
+                expect(File).to receive(:expand_path).and_return("user_home_path")
                 expect { @arm_server_instance.validate_azure_login }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
               end
             end
@@ -192,7 +192,7 @@ describe Chef::Knife::AzurermBase do
 
               it "does not raise error" do
                 expect(Mixlib::ShellOut).to_not receive(:new)
-                expect(File).to receive(:expand_path).and_return('user_home_path')
+                expect(File).to receive(:expand_path).and_return("user_home_path")
                 expect { @arm_server_instance.validate_azure_login }.to_not raise_error
               end
             end
@@ -203,11 +203,11 @@ describe Chef::Knife::AzurermBase do
 
     context "Token Validation test cases" do
       before do
-         allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command)
+        allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command)
       end
 
       it "raises exception if token is expired for Linux" do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
         allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
@@ -215,70 +215,70 @@ describe Chef::Knife::AzurermBase do
       end
 
       it "raises exception if token is expired for Windows" do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
         allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
         expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'azure login' command")
       end
 
-      it 'Token is valid, no exception is raised' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "Token is valid, no exception is raised" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
       end
 
-      it 'New token is got using refresh token for Linux when token has expired' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        token_details1 = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "New token is got using refresh token for Linux when token has expired" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+        token_details1 = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
         allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
         expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
       end
 
-      it 'New valid token is got using refresh token for Windows when token has expired' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        token_details1 = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "New valid token is got using refresh token for Windows when token has expired" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+        token_details1 = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
         allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
         expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
       end
 
-      it 'Mixlib shellout command for xplat raises Timeout error' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "Mixlib shellout command for xplat raises Timeout error" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(true)
-        allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
+        allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
         allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
         expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'azure login' command")
       end
 
-      it 'Mixlib shellout command for xplat raises exception' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "Mixlib shellout command for xplat raises exception" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         allow(Chef::Platform).to receive(:windows?).and_return(false)
-        allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command).and_raise(Exception)
+        allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command).and_raise(Exception)
         allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
         expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'azure login' command")
       end
     end
 
     context "is_token_valid?" do
-      it 'returns true if token is valid' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "returns true if token is valid" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         token_valid = @arm_server_instance.is_token_valid?(token_details)
         expect(token_valid).to be == true
       end
 
-      it 'returns false if token has expired' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "returns false if token has expired" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         token_valid = @arm_server_instance.is_token_valid?(token_details)
         expect(token_valid).to be == false
       end
 
-      it 'raises exception if token is about to expire within 10 minutes' do
+      it "raises exception if token is about to expire within 10 minutes" do
         time_after_5_min = (Time.now + 300).to_s #300sec = 5min
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => time_after_5_min, :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        expect{ @arm_server_instance.is_token_valid?(token_details) }.to raise_error("Token will expire within 10 minutes. Please run 'azure login' command")
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => time_after_5_min, :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+        expect { @arm_server_instance.is_token_valid?(token_details) }.to raise_error("Token will expire within 10 minutes. Please run 'azure login' command")
       end
     end
 
@@ -289,37 +289,37 @@ describe Chef::Knife::AzurermBase do
         Chef::Config[:knife][:azure_client_secret] = "xyz@123"
       end
 
-      it 'using AD App creds for authentication' do
+      it "using AD App creds for authentication" do
         @authentication_details = @arm_server_instance.authentication_details
         expect(@authentication_details[:azure_tenant_id]).to be ==  "abeb039a-rfrgrggb48f-0c99bdc99d15"
         expect(@authentication_details[:azure_client_id]).to be ==  "54dsdwe-3e2f36-e9f11d7f88a1"
-        expect(@authentication_details[:azure_client_secret]).to be ==  "xyz@123"
+        expect(@authentication_details[:azure_client_secret]).to be == "xyz@123"
       end
 
-      it 'using Token Authentication for Linux Platform' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "using Token Authentication for Linux Platform" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         Chef::Config[:knife].delete(:azure_tenant_id)
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
         @authentication_details = @arm_server_instance.authentication_details
-        expect(@authentication_details[:clientid]).to be ==  "dsff-8df-sd45e-34345f7b46"
+        expect(@authentication_details[:clientid]).to be == "dsff-8df-sd45e-34345f7b46"
       end
 
-      it 'using Token Authentication for Windows Platform' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
+      it "using Token Authentication for Windows Platform" do
+        token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
         Chef::Config[:knife].delete(:azure_tenant_id)
         allow(Chef::Platform).to receive(:windows?).and_return(true)
         allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
         @authentication_details = @arm_server_instance.authentication_details
-        expect(@authentication_details[:clientid]).to be ==  "dsff-8df-sd45e-34345f7b46"
+        expect(@authentication_details[:clientid]).to be == "dsff-8df-sd45e-34345f7b46"
       end
 
-      it 'Get token details from Accesstoken file for Linux platform' do
+      it "Get token details from Accesstoken file for Linux platform" do
         allow(Chef::Platform).to receive(:windows?).and_return(false)
         file_data = File.read(File.dirname(__FILE__) + "/assets/accessTokens.json")
         allow(File).to receive(:read).and_return(file_data)
         @authentication_details = @arm_server_instance.token_details_for_linux
-        expect(@authentication_details[:clientid]).to be ==  "dsff-8df-sd45e-34345f7b46"
+        expect(@authentication_details[:clientid]).to be == "dsff-8df-sd45e-34345f7b46"
       end
     end
 
@@ -333,12 +333,12 @@ describe Chef::Knife::AzurermBase do
   end
 
   describe "current_xplat_cli_version" do
-    let(:mixlib_object) { double('MixlibObject', :stdout => '0.10.4') }
+    let(:mixlib_object) { double("MixlibObject", :stdout => "0.10.4") }
 
     it "returns the version of xplat_cli" do
       expect(@arm_server_instance).to receive(:shell_out!).and_return(mixlib_object)
       response = @arm_server_instance.get_azure_cli_version
-      expect(response).to be == '0.10.4'
+      expect(response).to be == "0.10.4"
     end
   end
 
@@ -346,7 +346,7 @@ describe Chef::Knife::AzurermBase do
     context "old version of xplat_cli is installed" do
       before do
         allow(@arm_server_instance).to receive(
-          :current_xplat_cli_version).and_return('0.10.3')
+          :current_xplat_cli_version).and_return("0.10.3")
       end
 
       it "returns true" do
@@ -357,7 +357,7 @@ describe Chef::Knife::AzurermBase do
 
     context "new version of xplat_cli is installed" do
       before do
-        allow(@arm_server_instance).to receive(:get_azure_cli_version).and_return('2.0.0')
+        allow(@arm_server_instance).to receive(:get_azure_cli_version).and_return("2.0.0")
       end
 
       it "returns true" do
@@ -378,7 +378,7 @@ describe Chef::Knife::AzurermBase do
     context "environment variable is set" do
       before do
         allow(ENV).to receive(:[]).with(
-          'AZURE_USE_SECURE_TOKEN_STORAGE').and_return('true')
+          "AZURE_USE_SECURE_TOKEN_STORAGE").and_return("true")
       end
 
       it "returns true" do
@@ -434,64 +434,64 @@ describe Chef::Knife::AzurermBase do
   end
 
   context "Token Validation test cases for Azure CLI 2.0" do
-      before do
-        @arm_server_instance.instance_variable_set(:@azure_prefix, "az")
-        allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command)
-      end
-
-      it "raises exception if token is expired for Linux" do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(false)
-        allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
-        allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
-      end
-
-      it "raises exception if token is expired for Windows" do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(true)
-        allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
-        allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
-      end
-
-      it 'Token is valid, no exception is raised' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
-      end
-
-      it 'New token is got using refresh token for Linux when token has expired' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        token_details1 = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(false)
-        allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
-        allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
-      end
-
-      it 'New valid token is got using refresh token for Windows when token has expired' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        token_details1 = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(true)
-        allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
-        allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
-      end
-
-      it 'Mixlib shellout command for xplat raises Timeout error' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(true)
-        allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
-        allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
-      end
-
-      it 'Mixlib shellout command for xplat raises exception' do
-        token_details = {:tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA"}
-        allow(Chef::Platform).to receive(:windows?).and_return(false)
-        allow(Mixlib::ShellOut).to receive_message_chain(:new,:run_command).and_raise(Exception)
-        allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
-        expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
-      end
+    before do
+      @arm_server_instance.instance_variable_set(:@azure_prefix, "az")
+      allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command)
     end
+
+    it "raises exception if token is expired for Linux" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(false)
+      allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
+      allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
+    end
+
+    it "raises exception if token is expired for Windows" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+      allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details)
+      allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
+    end
+
+    it "Token is valid, no exception is raised" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
+    end
+
+    it "New token is got using refresh token for Linux when token has expired" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      token_details1 = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(false)
+      allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
+      allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
+    end
+
+    it "New valid token is got using refresh token for Windows when token has expired" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      token_details1 = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2116-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+      allow(@arm_server_instance).to receive(:refresh_token).and_return(token_details1)
+      allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.not_to raise_error
+    end
+
+    it "Mixlib shellout command for xplat raises Timeout error" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(true)
+      allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command).and_raise(Mixlib::ShellOut::CommandTimeout)
+      allow(@arm_server_instance).to receive(:token_details_for_windows).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
+    end
+
+    it "Mixlib shellout command for xplat raises exception" do
+      token_details = { :tokentype => "Bearer", :user => "xxx@outlook.com", :token => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1iIxLjAifQ.hZjHXXjbSdMmMs9oSZxGKa62EnNG6jkTY4RSmq8dQMvmwHgDCF4KoT_sOIsrAJTVwXuCdxYa5Jr83sfydFwiO2QWWOaSgyRXGPouex4NXFI_LFdnRzhLBoN0ONwUWHrV12N4LBgHyNLiyfeZQJFCbD0LTcPdjh7qQZ5aVgcoz_CB33PGD_z2L_6ynWrlAoihLEmYD6vbebMDSSFazvzoVg", :expiry_time => "2016-05-31T09:42:15.617Z", :clientid => "dsff-8df-sd45e-34345f7b46", :refreshtoken => "FPbm0gXiszvV_cMwGkgACwMBZ26fWA6fH3ToRLTHYU3wvvTWiU74ukRhMHhv20OJOtZBOtbckh3kTMT7QvzUYfd4uHFzwAYCtsh2SOY-dCAA" }
+      allow(Chef::Platform).to receive(:windows?).and_return(false)
+      allow(Mixlib::ShellOut).to receive_message_chain(:new, :run_command).and_raise(Exception)
+      allow(@arm_server_instance).to receive(:token_details_for_linux).and_return(token_details)
+      expect { @arm_server_instance.check_token_validity(token_details) }.to raise_error("Token has expired. Please run 'az login' command")
+    end
+  end
 end

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -3,9 +3,9 @@
 # Copyright:: Copyright (c) 2016 Opscode, Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
-require 'chef/knife/bootstrap'
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
+require "chef/knife/bootstrap"
 
 describe Chef::Knife::AzurermServerCreate do
   include AzureSpecHelper
@@ -20,34 +20,34 @@ describe Chef::Knife::AzurermServerCreate do
       :azure_resource_group_name => Chef::Config[:knife][:azure_resource_group_name],
       :azure_service_location => Chef::Config[:knife][:azure_service_location],
       :azure_vm_name => Chef::Config[:knife][:azure_vm_name],
-      :winrm_user => 'winrm_user',
+      :winrm_user => "winrm_user",
       :ssh_user => Chef::Config[:knife][:ssh_user],
-      :ssh_password => 'ssh_password',
-      :azure_vm_size => 'small',
-      :azure_storage_account => 'azurestorageaccount',
-      :azure_storage_account_type => 'azure_storage_account_type',
-      :azure_os_disk_name => 'azureosdiskname',
-      :azure_os_disk_caching => 'azure_os_disk_caching',
-      :azure_os_disk_create_option => 'azure_os_disk_create_option',
-      :azure_vnet_name => 'azure_virtual_network_name',
-      :azure_vnet_subnet_name => 'azure_subnet_name',
-      :rdp_port => '3389',
-      :ssh_port => '22',
-      :chef_extension_publisher => 'chef_extension_publisher',
-      :chef_extension => 'chef_extension',
-      :chef_extension_version => '11.10.1',
-      :chef_extension_private_param => { :validation_key => '37284723sdjfhsdkfsfd' },
-      :latest_chef_extension_version => '1210.12',
+      :ssh_password => "ssh_password",
+      :azure_vm_size => "small",
+      :azure_storage_account => "azurestorageaccount",
+      :azure_storage_account_type => "azure_storage_account_type",
+      :azure_os_disk_name => "azureosdiskname",
+      :azure_os_disk_caching => "azure_os_disk_caching",
+      :azure_os_disk_create_option => "azure_os_disk_create_option",
+      :azure_vnet_name => "azure_virtual_network_name",
+      :azure_vnet_subnet_name => "azure_subnet_name",
+      :rdp_port => "3389",
+      :ssh_port => "22",
+      :chef_extension_publisher => "chef_extension_publisher",
+      :chef_extension => "chef_extension",
+      :chef_extension_version => "11.10.1",
+      :chef_extension_private_param => { :validation_key => "37284723sdjfhsdkfsfd" },
+      :latest_chef_extension_version => "1210.12",
       :chef_extension_public_param => {
-        :hints => ['vm_name', 'public_fqdn', 'platform'],
-        :bootstrap_options => { :bootstrap_version => '12.8.1'}
+        :hints => %w{vm_name public_fqdn platform},
+        :bootstrap_options => { :bootstrap_version => "12.8.1" }
       },
       :vnet_config => {
-        :virtualNetworkName => 'vnet1',
-        :addressPrefixes => [ '10.0.0.0/16' ],
-        :subnets => [{'name'=> 'sbn1',
-          'properties'=> {
-            'addressPrefix'=> '10.0.0.0/24'
+        :virtualNetworkName => "vnet1",
+        :addressPrefixes => [ "10.0.0.0/16" ],
+        :subnets => [{ "name" => "sbn1",
+                       "properties" => {
+            "addressPrefix" => "10.0.0.0/24"
           }
         }]
       }
@@ -56,7 +56,7 @@ describe Chef::Knife::AzurermServerCreate do
     allow(@service.ui).to receive(:log)
     allow(Chef::Log).to receive(:info)
     allow(File).to receive(:exist?).and_return(true)
-    allow(File).to receive(:read).and_return('foo')
+    allow(File).to receive(:read).and_return("foo")
     allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
   end
 
@@ -66,101 +66,101 @@ describe Chef::Knife::AzurermServerCreate do
       it "azure_subscription_id" do
         Chef::Config[:knife].delete(:azure_subscription_id)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_resource_group_name" do
         Chef::Config[:knife].delete(:azure_resource_group_name)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_vm_name" do
         Chef::Config[:knife].delete(:azure_vm_name)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "vm name validation success for Linux" do
-        Chef::Config[:knife][:azure_vm_name] = 'test-vm1234'
+        Chef::Config[:knife][:azure_vm_name] = "test-vm1234"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(false)
-        expect{@arm_server_instance.validate_params!}.not_to raise_error
+        expect { @arm_server_instance.validate_params! }.not_to raise_error
       end
 
       it "vm name validation success for Windows" do
-        Chef::Config[:knife][:azure_vm_name] = 'test-vm1234'
+        Chef::Config[:knife][:azure_vm_name] = "test-vm1234"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-        expect{@arm_server_instance.validate_params!}.not_to raise_error
+        expect { @arm_server_instance.validate_params! }.not_to raise_error
       end
 
       it "vm name validation failure for name containing special characters for Linux" do
-        Chef::Config[:knife][:azure_vm_name] = 'test_vm1234!@#'
+        Chef::Config[:knife][:azure_vm_name] = "test_vm1234!@#"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(false)
-        expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
+        expect { @arm_server_instance.validate_params! }.to raise_error(ArgumentError)
       end
 
       it "vm name validation failure for name containing special characters for Windows" do
-        Chef::Config[:knife][:azure_vm_name] = 'test_vm1234!@#'
+        Chef::Config[:knife][:azure_vm_name] = "test_vm1234!@#"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-        expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
+        expect { @arm_server_instance.validate_params! }.to raise_error(ArgumentError)
       end
 
       it "vm name validation failure for name containing more than 15 characters for Windows" do
-        Chef::Config[:knife][:azure_vm_name] = 'testvm123123123123'
+        Chef::Config[:knife][:azure_vm_name] = "testvm123123123123"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-        expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
+        expect { @arm_server_instance.validate_params! }.to raise_error(ArgumentError)
       end
 
       it "vm name validation failure for name containing more than 64 characters for Linux" do
-        Chef::Config[:knife][:azure_vm_name] = 'testvm123123123123123123123123123123123123123123123123123123123123123123123123123123123123123'
+        Chef::Config[:knife][:azure_vm_name] = "testvm123123123123123123123123123123123123123123123123123123123123123123123123123123123123123"
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(false)
-        expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
+        expect { @arm_server_instance.validate_params! }.to raise_error(ArgumentError)
       end
 
       it "azure_service_location" do
         Chef::Config[:knife].delete(:azure_service_location)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_image_reference_publisher" do
         Chef::Config[:knife].delete(:azure_image_reference_publisher)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_image_reference_offer" do
         Chef::Config[:knife].delete(:azure_image_reference_offer)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "azure_image_reference_sku" do
         Chef::Config[:knife].delete(:azure_image_reference_sku)
         expect(@arm_server_instance.ui).to receive(:error)
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
 
       it "winrm user and password error if not provided for windows image" do
         Chef::Config[:knife].delete(:winrm_user)
         Chef::Config[:knife].delete(:winrm_password)
         allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-        expect{@arm_server_instance.validate_params!}.to raise_error(ArgumentError)
+        expect { @arm_server_instance.validate_params! }.to raise_error(ArgumentError)
       end
 
       it "exits when incorrect Ohai Hints are given by the user" do
-        @arm_server_instance.config[:ohai_hints] = 'vm_name,mac_address'
+        @arm_server_instance.config[:ohai_hints] = "vm_name,mac_address"
         expect(@arm_server_instance.ui).to receive(:error).twice
-        expect {@arm_server_instance.run}.to raise_error(SystemExit)
+        expect { @arm_server_instance.run }.to raise_error(SystemExit)
       end
     end
 
     context "optional parameters" do
       context "when not given by user" do
         before do
-          @vm_name_with_no_special_chars = 'testvm'
-          Chef::Config[:knife][:ssh_password] = 'ssh_password'
-          @azure_vm_size_default_value = 'Small'
+          @vm_name_with_no_special_chars = "testvm"
+          Chef::Config[:knife][:ssh_password] = "ssh_password"
+          @azure_vm_size_default_value = "Small"
           @xplat_creds_cmd = double(:run_command => double)
           @result = double(:stdout => "")
           allow(Mixlib::ShellOut).to receive(:new).and_return(@xplat_creds_cmd)
@@ -173,42 +173,42 @@ describe Chef::Knife::AzurermServerCreate do
           allow(Chef::Platform).to receive(:windows?).and_return(false)
           Chef::Config[:knife].delete(:azure_tenant_id)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_client_id not provided for Linux platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(false)
           Chef::Config[:knife].delete(:azure_client_id)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_client_secret not provided for Linux platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(false)
           Chef::Config[:knife].delete(:azure_client_secret)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_tenant_id not provided for Windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
           Chef::Config[:knife].delete(:azure_tenant_id)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_client_id not provided for Windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
           Chef::Config[:knife].delete(:azure_client_id)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_client_secret not provided for windows platform" do
           allow(Chef::Platform).to receive(:windows?).and_return(true)
           Chef::Config[:knife].delete(:azure_client_secret)
           allow(File).to receive(:exists?).and_return(false)
-          expect {@arm_server_instance.run}.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
+          expect { @arm_server_instance.run }.to raise_error("Please run XPLAT's 'azure login' command OR specify azure_tenant_id, azure_subscription_id, azure_client_id, azure_client_secret in your knife.rb")
         end
 
         it "azure_storage_account not provided by user so vm_name gets assigned to it" do
@@ -226,13 +226,13 @@ describe Chef::Knife::AzurermServerCreate do
         it "azure_vnet_name not provided by user so vm_name gets assigned to it" do
           Chef::Config[:knife].delete(:azure_vnet_name)
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_vnet_name]).to be == 'test-vm'
+          expect(@server_params[:azure_vnet_name]).to be == "test-vm"
         end
 
         it "azure_vnet_subnet_name not provided by user so vm_name gets assigned to it" do
           Chef::Config[:knife].delete(:azure_vnet_subnet_name)
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_vnet_subnet_name]).to be == 'test-vm'
+          expect(@server_params[:azure_vnet_subnet_name]).to be == "test-vm"
         end
 
         it "should assign default value 1 to the server_count when not provided by the user" do
@@ -247,15 +247,15 @@ describe Chef::Knife::AzurermServerCreate do
 
       context "when given by user" do
         before do
-          @vm_name_with_no_special_chars = 'testvm'
-          Chef::Config[:knife][:ssh_password] = 'ssh_password'
-          Chef::Config[:knife][:azure_storage_account] = 'azure_storage_account'
-          @storage_account_name_with_no_special_chars = 'azurestorageaccount'
-          Chef::Config[:knife][:azure_os_disk_name] = 'azure_os_disk_name'
-          @os_disk_name_with_no_special_chars = 'azureosdiskname'
-          Chef::Config[:knife][:azure_vnet_name] = 'azure_vnet_name'
-          Chef::Config[:knife][:azure_vnet_subnet_name] = 'azure_vnet_subnet_name'
-          Chef::Config[:knife][:azure_vm_size] = 'Medium'
+          @vm_name_with_no_special_chars = "testvm"
+          Chef::Config[:knife][:ssh_password] = "ssh_password"
+          Chef::Config[:knife][:azure_storage_account] = "azure_storage_account"
+          @storage_account_name_with_no_special_chars = "azurestorageaccount"
+          Chef::Config[:knife][:azure_os_disk_name] = "azure_os_disk_name"
+          @os_disk_name_with_no_special_chars = "azureosdiskname"
+          Chef::Config[:knife][:azure_vnet_name] = "azure_vnet_name"
+          Chef::Config[:knife][:azure_vnet_subnet_name] = "azure_vnet_subnet_name"
+          Chef::Config[:knife][:azure_vm_size] = "Medium"
           Chef::Config[:knife][:server_count] = 3
           Chef::Config[:knife][:ssh_public_key] = File.dirname(__FILE__) + "/assets/key_rsa.pub"
         end
@@ -272,40 +272,40 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "azure_vnet_name provided by user so vm_name does not get assigned to it" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_vnet_name]).to be == 'azure_vnet_name'
+          expect(@server_params[:azure_vnet_name]).to be == "azure_vnet_name"
         end
 
         it "azure_vnet_subnet_name provided by user so vm_name does not get assigned to it" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_vnet_subnet_name]).to be == 'azure_vnet_subnet_name'
+          expect(@server_params[:azure_vnet_subnet_name]).to be == "azure_vnet_subnet_name"
         end
 
-        context 'azure_vnet_name provided by user but azure_vnet_subnet_name not provided by user' do
+        context "azure_vnet_name provided by user but azure_vnet_subnet_name not provided by user" do
           before do
             Chef::Config[:knife].delete(:azure_vnet_subnet_name)
           end
 
           it "assigns vm_name to the azure_vnet_subnet_name" do
             @server_params = @arm_server_instance.create_server_def
-            expect(@server_params[:azure_vnet_subnet_name]).to be == 'test-vm'
+            expect(@server_params[:azure_vnet_subnet_name]).to be == "test-vm"
           end
         end
 
-        context 'azure_vnet_subnet_name provided by user but azure_vnet_name not provided by user' do
+        context "azure_vnet_subnet_name provided by user but azure_vnet_name not provided by user" do
           before do
             Chef::Config[:knife].delete(:azure_vnet_name)
           end
 
           it "raises error" do
             expect { @arm_server_instance.validate_params! }.to raise_error(
-              ArgumentError, 'When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified.'
+              ArgumentError, "When --azure-vnet-subnet-name is specified, the --azure-vnet-name must also be specified."
             )
           end
         end
 
-        context 'raise node_ssl_verify_mode error for wrong value' do
+        context "raise node_ssl_verify_mode error for wrong value" do
           before do
-            Chef::Config[:knife][:node_ssl_verify_mode] = 'MyValue'
+            Chef::Config[:knife][:node_ssl_verify_mode] = "MyValue"
           end
 
           it "raises error" do
@@ -316,18 +316,18 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         context "GatewaySubnet name provided by user as the name for azure_vnet_subnet_name option" do
-          it 'raises error' do
-            Chef::Config[:knife][:azure_vnet_name] = 'MyVnet'
-            Chef::Config[:knife][:azure_vnet_subnet_name] = 'GatewaySubnet'
+          it "raises error" do
+            Chef::Config[:knife][:azure_vnet_name] = "MyVnet"
+            Chef::Config[:knife][:azure_vnet_subnet_name] = "GatewaySubnet"
             expect { @arm_server_instance.validate_params! }.to raise_error(
-              ArgumentError, 'GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.'
+              ArgumentError, "GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways."
             )
           end
         end
 
         it "azure_vm_size provided by user so default value does not get assigned to it" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:azure_vm_size]).to be == 'Medium'
+          expect(@server_params[:azure_vm_size]).to be == "Medium"
         end
 
         it "should set the value of server_count as provided by the user" do
@@ -343,7 +343,7 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         it "raises error if wrong value is provided for daemon option by user" do
-          Chef::Config[:knife][:daemon] = 'foo'
+          Chef::Config[:knife][:daemon] = "foo"
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
           expect { @arm_server_instance.validate_params! }.to raise_error(
             ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
@@ -351,14 +351,14 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         it "raises error if daemon option is provided for other than windows node by user" do
-          Chef::Config[:knife][:daemon] = 'service'
+          Chef::Config[:knife][:daemon] = "service"
           expect { @arm_server_instance.validate_params! }.to raise_error(
             ArgumentError, "The daemon option is only support for Windows nodes."
           )
         end
 
         it "deos not raise any error if daemon option value is 'service'" do
-          Chef::Config[:knife][:daemon] = 'service'
+          Chef::Config[:knife][:daemon] = "service"
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
           expect { @arm_server_instance.validate_params! }.not_to raise_error(
             ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
@@ -366,7 +366,7 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         it "does not raise any error if daemon option value is 'none'" do
-          Chef::Config[:knife][:daemon] = 'none'
+          Chef::Config[:knife][:daemon] = "none"
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
           expect { @arm_server_instance.validate_params! }.not_to raise_error(
             ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
@@ -374,7 +374,7 @@ describe Chef::Knife::AzurermServerCreate do
         end
 
         it "does not raise any error if daemon option value is 'task'" do
-          Chef::Config[:knife][:daemon] = 'task'
+          Chef::Config[:knife][:daemon] = "task"
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
           expect { @arm_server_instance.validate_params! }.not_to raise_error(
             ArgumentError, "Invalid value for --daemon option. Use valid daemon values i.e 'none', 'service' and 'task'."
@@ -396,8 +396,8 @@ describe Chef::Knife::AzurermServerCreate do
 
   describe "server create" do
     before do
-      Chef::Config[:knife][:ssh_password] = 'ssh_password'
-      Chef::Config[:knife][:winrm_password] = 'winrm_password'
+      Chef::Config[:knife][:ssh_password] = "ssh_password"
+      Chef::Config[:knife][:winrm_password] = "winrm_password"
 
       @resource_client = double("ResourceManagementClient")
       @compute_client = double("ComputeManagementClient")
@@ -425,7 +425,7 @@ describe Chef::Knife::AzurermServerCreate do
             :set_default_image_reference!)
     end
 
-    describe 'security_group_exist' do
+    describe "security_group_exist" do
       module Azure
         module ARM
           class DummyClass < Azure::ResourceManagement::ARMInterface
@@ -437,30 +437,30 @@ describe Chef::Knife::AzurermServerCreate do
         @dummy_class = Azure::ARM::DummyClass.new
       end
 
-      context 'given security group exist under the given resource group' do
+      context "given security group exist under the given resource group" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @vnet_name = 'vnet-2'
-          @sec_grp_name = 'sec_grp_2'
+          @resource_group_name = "rgrp-2"
+          @vnet_name = "vnet-2"
+          @sec_grp_name = "sec_grp_2"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name, @sec_grp_name))
         end
 
-        it 'returns true' do
+        it "returns true" do
           response = @dummy_class.security_group_exist?(@resource_group_name, @sec_grp_name)
           expect(response).to be == true
         end
       end
 
-      context 'given security group does not exist under the given resource group' do
+      context "given security group does not exist under the given resource group" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @sec_grp_name = 'sec_grp_2'
+          @resource_group_name = "rgrp-2"
+          @sec_grp_name = "sec_grp_2"
           request = {}
           response = OpenStruct.new({
-            'body'=>'{"error": {"code": "ResourceNotFound"}}'
+            "body" => '{"error": {"code": "ResourceNotFound"}}'
           })
-          body = 'MsRestAzure::AzureOperationError'
+          body = "MsRestAzure::AzureOperationError"
           error = MsRestAzure::AzureOperationError.new(request, response, body)
           network_resource_client = double("NetworkResourceClient",
             :network_security_groups => double)
@@ -470,21 +470,21 @@ describe Chef::Knife::AzurermServerCreate do
             network_resource_client)
         end
 
-        it 'returns false' do
+        it "returns false" do
           response = @dummy_class.security_group_exist?(@resource_group_name, @sec_grp_name)
           expect(response).to be == false
         end
       end
 
-      context 'security group get api call raises some unknown exception' do
+      context "security group get api call raises some unknown exception" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @sec_grp_name = 'sec_grp_2'
+          @resource_group_name = "rgrp-2"
+          @sec_grp_name = "sec_grp_2"
           request = {}
           response = OpenStruct.new({
-            'body'=>'{"error": {"code": "SomeProblemOccurred"}}'
+            "body" => '{"error": {"code": "SomeProblemOccurred"}}'
           })
-          body = 'MsRestAzure::AzureOperationError'
+          body = "MsRestAzure::AzureOperationError"
           @error = MsRestAzure::AzureOperationError.new(request, response, body)
           network_resource_client = double("NetworkResourceClient",
             :network_security_groups => double)
@@ -494,9 +494,10 @@ describe Chef::Knife::AzurermServerCreate do
             network_resource_client)
         end
 
-        it 'raises error' do
-          expect { @dummy_class.security_group_exist?(@resource_group_name, @sec_grp_name)
-            }.to raise_error(@error)
+        it "raises error" do
+          expect do
+            @dummy_class.security_group_exist?(@resource_group_name, @sec_grp_name)
+          end.to raise_error(@error)
         end
       end
     end
@@ -528,15 +529,15 @@ describe Chef::Knife::AzurermServerCreate do
       context "for Linux" do
         before do
           {
-            :azure_image_reference_publisher => 'OpenLogic',
-            :azure_image_reference_offer => 'CentOS',
-            :azure_image_reference_sku => '6.5',
-            :azure_image_reference_version => 'latest',
-            :ssh_user => 'ssh_user',
-            :azure_chef_extension_version => '1210.12'
+            :azure_image_reference_publisher => "OpenLogic",
+            :azure_image_reference_offer => "CentOS",
+            :azure_image_reference_sku => "6.5",
+            :azure_image_reference_version => "latest",
+            :ssh_user => "ssh_user",
+            :azure_chef_extension_version => "1210.12"
           }.each do |key, value|
-              Chef::Config[:knife][key] = value
-            end
+            Chef::Config[:knife][key] = value
+          end
 
           expect(@arm_server_instance).to receive(
             :is_image_windows?).at_least(3).and_return(false)
@@ -586,14 +587,14 @@ describe Chef::Knife::AzurermServerCreate do
       context "for Windows" do
         before do
           {
-            :azure_image_reference_publisher => 'MicrosoftWindowsServer',
-            :azure_image_reference_offer => 'WindowsServer',
-            :azure_image_reference_sku => '2012-R2-Datacenter',
-            :azure_image_reference_version => 'latest',
-            :winrm_user => 'winrm_user'
+            :azure_image_reference_publisher => "MicrosoftWindowsServer",
+            :azure_image_reference_offer => "WindowsServer",
+            :azure_image_reference_sku => "2012-R2-Datacenter",
+            :azure_image_reference_version => "latest",
+            :winrm_user => "winrm_user"
           }.each do |key, value|
-              Chef::Config[:knife][key] = value
-            end
+            Chef::Config[:knife][key] = value
+          end
 
           expect(@arm_server_instance).to receive(
             :is_image_windows?).at_least(3).and_return(true)
@@ -618,7 +619,7 @@ describe Chef::Knife::AzurermServerCreate do
       context "for multiple VM creation" do
         before do
           Chef::Config[:knife][:server_count] = 3
-          Chef::Config[:knife][:azure_chef_extension_version] = '1210.12'
+          Chef::Config[:knife][:azure_chef_extension_version] = "1210.12"
 
           expect(@arm_server_instance).to receive(
             :is_image_windows?).at_least(3).and_return(false)
@@ -710,34 +711,34 @@ describe Chef::Knife::AzurermServerCreate do
 
     describe "vm_public_ip" do
       it "successfully returns vm public ip response" do
-        expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client('Windows'))
+        expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client("Windows"))
         response = @service.vm_public_ip(@params)
-        expect(response).to be == '1.2.3.4'
+        expect(response).to be == "1.2.3.4"
       end
     end
 
     describe "vm_default_port" do
       context "for Linux" do
         before do
-          @platform = 'Linux'
+          @platform = "Linux"
         end
 
         it "successfully returns vm default port response" do
           expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client(@platform))
           response = @service.vm_default_port(@params)
-          expect(response).to be == '22'
+          expect(response).to be == "22"
         end
       end
 
       context "for Windows" do
         before do
-          @platform = 'Windows'
+          @platform = "Windows"
         end
 
         it "successfully returns vm default port response" do
           expect(@service).to receive(:network_resource_client).and_return(stub_network_resource_client(@platform))
           response = @service.vm_default_port(@params)
-          expect(response).to be == '3389'
+          expect(response).to be == "3389"
         end
       end
     end
@@ -745,18 +746,18 @@ describe Chef::Knife::AzurermServerCreate do
     describe "create_vm_extension" do
       context "when user has supplied chef extension version value" do
         it "successfully creates virtual machine extension with the user supplied version value" do
-          expect(@service).to receive(:compute_management_client).and_return(stub_compute_management_client('yes'))
+          expect(@service).to receive(:compute_management_client).and_return(stub_compute_management_client("yes"))
           expect(@service).to_not receive(:get_latest_chef_extension_version)
           response = @service.create_vm_extension(@params)
-          expect(response.name).to be == 'test-vm-ext'
+          expect(response.name).to be == "test-vm-ext"
           expect(response.id).to_not be nil
-          expect(response.type).to be == 'Microsoft.Compute/virtualMachines/extensions'
+          expect(response.type).to be == "Microsoft.Compute/virtualMachines/extensions"
           expect(response.location).to_not be nil
           expect(response.properties).to_not be nil
-          expect(response.properties.publisher).to be == 'Ext_Publisher'
-          expect(response.properties.type).to be == 'Ext_Type'
-          expect(response.properties.type_handler_version).to be == '11.10.1'
-          expect(response.properties.provisioning_state).to be == 'Succeeded'
+          expect(response.properties.publisher).to be == "Ext_Publisher"
+          expect(response.properties.type).to be == "Ext_Type"
+          expect(response.properties.type_handler_version).to be == "11.10.1"
+          expect(response.properties.provisioning_state).to be == "Succeeded"
         end
       end
 
@@ -767,17 +768,17 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "successfully creates virtual machine extension with the latest version" do
           expect(@service).to receive(:get_latest_chef_extension_version)
-          expect(@service).to receive(:compute_management_client).and_return(stub_compute_management_client('no'))
+          expect(@service).to receive(:compute_management_client).and_return(stub_compute_management_client("no"))
           response = @service.create_vm_extension(@params)
-          expect(response.name).to be == 'test-vm-ext'
+          expect(response.name).to be == "test-vm-ext"
           expect(response.id).to_not be nil
-          expect(response.type).to be == 'Microsoft.Compute/virtualMachines/extensions'
+          expect(response.type).to be == "Microsoft.Compute/virtualMachines/extensions"
           expect(response.location).to_not be nil
           expect(response.properties).to_not be nil
-          expect(response.properties.publisher).to be == 'Ext_Publisher'
-          expect(response.properties.type).to be == 'Ext_Type'
-          expect(response.properties.type_handler_version).to be == '1210.12'
-          expect(response.properties.provisioning_state).to be == 'Succeeded'
+          expect(response.properties.publisher).to be == "Ext_Publisher"
+          expect(response.properties.type).to be == "Ext_Type"
+          expect(response.properties.type_handler_version).to be == "1210.12"
+          expect(response.properties.provisioning_state).to be == "Succeeded"
         end
       end
     end
@@ -785,9 +786,9 @@ describe Chef::Knife::AzurermServerCreate do
     describe "get_latest_chef_extension_version" do
       it "successfully returns latest Chef Extension version" do
         expect(@service).to receive(:compute_management_client).and_return(
-          stub_compute_management_client('NA'))
+          stub_compute_management_client("NA"))
         response = @service.get_latest_chef_extension_version(@params)
-        expect(response).to be == '1210.12'
+        expect(response).to be == "1210.12"
       end
     end
 
@@ -816,26 +817,26 @@ describe Chef::Knife::AzurermServerCreate do
             allow(@arm_server_instance).to receive(
               :is_image_windows?).and_return(false)
             @server_params = @arm_server_instance.create_server_def
-            expect(@server_params[:chef_extension]).to be == 'LinuxChefClient'
+            expect(@server_params[:chef_extension]).to be == "LinuxChefClient"
           end
 
           it "sets correct value for Windows platform" do
             allow(@arm_server_instance).to receive(
               :is_image_windows?).and_return(true)
             @server_params = @arm_server_instance.create_server_def
-            expect(@server_params[:chef_extension]).to be == 'ChefClient'
+            expect(@server_params[:chef_extension]).to be == "ChefClient"
           end
         end
 
         it "sets correct value for chef_extension_publisher parameter" do
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:chef_extension_publisher]).to be == 'Chef.Bootstrap.WindowsAzure'
+          expect(@server_params[:chef_extension_publisher]).to be == "Chef.Bootstrap.WindowsAzure"
         end
 
         it "sets user supplied value for chef_extension_version parameter" do
-          Chef::Config[:knife][:azure_chef_extension_version] = '1210.12'
+          Chef::Config[:knife][:azure_chef_extension_version] = "1210.12"
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:chef_extension_version]).to be == '1210.12'
+          expect(@server_params[:chef_extension_version]).to be == "1210.12"
         end
 
         it "sets nil value for chef_extension_version parameter when user has not supplied any value for it" do
@@ -847,17 +848,17 @@ describe Chef::Knife::AzurermServerCreate do
         it "sets correct config for chef_extension_public_param parameter" do
           allow(@arm_server_instance).to receive(
             :get_chef_extension_public_params).and_return(
-              'public_params')
+              "public_params")
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:chef_extension_public_param]).to be == 'public_params'
+          expect(@server_params[:chef_extension_public_param]).to be == "public_params"
         end
 
         it "sets correct config for chef_extension_private_param parameter" do
           allow(@arm_server_instance).to receive(
             :get_chef_extension_private_params).and_return(
-              'private_params')
+              "private_params")
           @server_params = @arm_server_instance.create_server_def
-          expect(@server_params[:chef_extension_private_param]).to be == 'private_params'
+          expect(@server_params[:chef_extension_private_param]).to be == "private_params"
         end
       end
 
@@ -867,7 +868,7 @@ describe Chef::Knife::AzurermServerCreate do
             allow(@arm_server_instance).to receive(
               :is_image_windows?).and_return(false)
             response = @arm_server_instance.get_chef_extension_name
-            expect(response).to be == 'LinuxChefClient'
+            expect(response).to be == "LinuxChefClient"
           end
         end
 
@@ -876,7 +877,7 @@ describe Chef::Knife::AzurermServerCreate do
             allow(@arm_server_instance).to receive(
               :is_image_windows?).and_return(true)
             response = @arm_server_instance.get_chef_extension_name
-            expect(response).to be == 'ChefClient'
+            expect(response).to be == "ChefClient"
           end
         end
       end
@@ -884,14 +885,14 @@ describe Chef::Knife::AzurermServerCreate do
       describe "get_chef_extension_publisher" do
         it "successfully returns chef extension publisher" do
           response = @arm_server_instance.get_chef_extension_publisher
-          expect(response).to be == 'Chef.Bootstrap.WindowsAzure'
+          expect(response).to be == "Chef.Bootstrap.WindowsAzure"
         end
       end
 
       context "get_chef_extension_public_params" do
         it "sets bootstrapVersion variable in public_config" do
-          @arm_server_instance.config[:bootstrap_version] = '12.4.2'
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator", :bootstrap_version=>"12.4.2"}}
+          @arm_server_instance.config[:bootstrap_version] = "12.4.2"
+          public_config = { :client_rb => "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist => "\"getting-started\"", extendedLogs: "false", :custom_json_attr => {}, :hints => %w{vm_name public_fqdn platform}, :bootstrap_options => { :chef_server_url => "https://localhost:443", :validation_client_name => "chef-validator", :bootstrap_version => "12.4.2" } }
 
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
@@ -899,109 +900,111 @@ describe Chef::Knife::AzurermServerCreate do
 
         it "should set extendedLogs flag to true" do
           @arm_server_instance.config[:extended_logs] = true
-          public_config = {client_rb: "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", runlist: "\"getting-started\"", extendedLogs: "true", custom_json_attr: {}, :hints=>["vm_name", "public_fqdn", "platform"], bootstrap_options: {chef_server_url: "https://localhost:443", validation_client_name: "chef-validator"}}
+          public_config = { client_rb: "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", runlist: "\"getting-started\"", extendedLogs: "true", custom_json_attr: {}, :hints => %w{vm_name public_fqdn platform}, bootstrap_options: { chef_server_url: "https://localhost:443", validation_client_name: "chef-validator" } }
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
         end
 
-        context 'service is an instance_of ARM' do
-          it 'invokes ohai_hints method' do
+        context "service is an instance_of ARM" do
+          it "invokes ohai_hints method" do
             expect(@arm_server_instance).to receive(:ohai_hints)
             @arm_server_instance.get_chef_extension_public_params
           end
         end
 
-        context 'service is not an instance_of ARM' do
+        context "service is not an instance_of ARM" do
           before do
             allow(@service).to receive(:instance_of?).and_return(false)
           end
 
-          it 'does not invoke ohai_hints method' do
+          it "does not invoke ohai_hints method" do
             expect(@arm_server_instance).to_not receive(:ohai_hints)
             @arm_server_instance.get_chef_extension_public_params
           end
         end
 
         it "sets chefServiceInterval variable in public_config" do
-          @arm_server_instance.config[:chef_daemon_interval] = '0'
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :chef_daemon_interval=>'0', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator"}}
+          @arm_server_instance.config[:chef_daemon_interval] = "0"
+          public_config = { :client_rb => "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist => "\"getting-started\"", extendedLogs: "false", :custom_json_attr => {}, :hints => %w{vm_name public_fqdn platform}, :chef_daemon_interval => "0", :bootstrap_options => { :chef_server_url => "https://localhost:443", :validation_client_name => "chef-validator" } }
 
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
         end
 
         it "sets daemon variable in public config" do
-          @arm_server_instance.config[:daemon] = 'service'
+          @arm_server_instance.config[:daemon] = "service"
           allow(@arm_server_instance).to receive(:is_image_windows?).and_return(true)
-          public_config = {:client_rb=>"chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist=>"\"getting-started\"", extendedLogs: "false", :custom_json_attr=>{}, :hints=>["vm_name", "public_fqdn", "platform"], :daemon=>'service', :bootstrap_options=>{:chef_server_url=>"https://localhost:443", :validation_client_name=>"chef-validator"}}   
+          public_config = { :client_rb => "chef_server_url \t \"https://localhost:443\"\nvalidation_client_name\t\"chef-validator\"", :runlist => "\"getting-started\"", extendedLogs: "false", :custom_json_attr => {}, :hints => %w{vm_name public_fqdn platform}, :daemon => "service", :bootstrap_options => { :chef_server_url => "https://localhost:443", :validation_client_name => "chef-validator" } }
           response = @arm_server_instance.get_chef_extension_public_params
           expect(response).to be == public_config
         end
       end
 
-      shared_context 'private config contents' do
+      shared_context "private config contents" do
         before do
-          allow(File).to receive(:read).and_return('my_validation_key')
+          allow(File).to receive(:read).and_return("my_validation_key")
         end
 
-        it 'calls get chef extension private params and sets private config properly' do
+        it "calls get chef extension private params and sets private config properly" do
           response = @arm_server_instance.get_chef_extension_private_params
           expect(response).to be == private_config
         end
       end
 
-      context 'when validation key is not present', :chef_gte_12_only do
-        context 'when encrypted_data_bag_secret option is passed' do
-          let(:private_config) { {:validation_key=>'my_validation_key',
-            :encrypted_data_bag_secret=>'my_encrypted_data_bag_secret'
-          } }
+      context "when validation key is not present", :chef_gte_12_only do
+        context "when encrypted_data_bag_secret option is passed" do
+          let(:private_config) do
+            { :validation_key => "my_validation_key",
+              :encrypted_data_bag_secret => "my_encrypted_data_bag_secret"
+          } end
 
           before do
-            @arm_server_instance.config[:encrypted_data_bag_secret] = 'my_encrypted_data_bag_secret'
+            @arm_server_instance.config[:encrypted_data_bag_secret] = "my_encrypted_data_bag_secret"
           end
 
-          include_context 'private config contents'
+          include_context "private config contents"
         end
 
-        context 'when encrypted_data_bag_secret_file option is passed' do
-          let(:private_config) { {:validation_key=>'my_validation_key',
-            :encrypted_data_bag_secret=>'PgIxStCmMDsuIw3ygRhmdMtStpc9EMiWisQXoP'
-          } }
+        context "when encrypted_data_bag_secret_file option is passed" do
+          let(:private_config) do
+            { :validation_key => "my_validation_key",
+              :encrypted_data_bag_secret => "PgIxStCmMDsuIw3ygRhmdMtStpc9EMiWisQXoP"
+          } end
 
           before do
             @arm_server_instance.config[:encrypted_data_bag_secret_file] = File.dirname(__FILE__) + "/assets/secret_file"
           end
 
-          include_context 'private config contents'
+          include_context "private config contents"
         end
       end
 
-      context 'when SSL certificate file option is passed but file does not exist physically' do
+      context "when SSL certificate file option is passed but file does not exist physically" do
         before do
           allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:run)
           allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:client_path)
           allow(File).to receive(:exist?).and_return(false)
-          allow(File).to receive(:read).and_return('foo')
-          @arm_server_instance.config[:cert_path] = '~/my_cert.crt'
+          allow(File).to receive(:read).and_return("foo")
+          @arm_server_instance.config[:cert_path] = "~/my_cert.crt"
         end
 
-        it 'raises an error and exits' do
-          expect(@arm_server_instance.ui).to receive(:error).with('Specified SSL certificate does not exist.')
+        it "raises an error and exits" do
+          expect(@arm_server_instance.ui).to receive(:error).with("Specified SSL certificate does not exist.")
           expect { @arm_server_instance.get_chef_extension_private_params }.to raise_error(SystemExit)
         end
       end
 
-      context 'when SSL certificate file option is passed and file exist physically' do
+      context "when SSL certificate file option is passed and file exist physically" do
         before do
           allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:run)
           allow_any_instance_of(Chef::Knife::Bootstrap::ClientBuilder).to receive(:client_path)
           allow(File).to receive(:exist?).and_return(true)
-          allow(File).to receive(:read).and_return('foo')
-          @arm_server_instance.config[:cert_path] = '~/my_cert.crt'
+          allow(File).to receive(:read).and_return("foo")
+          @arm_server_instance.config[:cert_path] = "~/my_cert.crt"
         end
 
         it "copies SSL certificate contents into chef_server_crt attribute of extension's private params" do
-          pri_config = { validation_key: 'foo', chef_server_crt: 'foo', encrypted_data_bag_secret: nil}
+          pri_config = { validation_key: "foo", chef_server_crt: "foo", encrypted_data_bag_secret: nil }
           response = @arm_server_instance.get_chef_extension_private_params
           expect(response).to be == pri_config
         end
@@ -1012,7 +1015,7 @@ describe Chef::Knife::AzurermServerCreate do
           allow(File).to receive(:exist?).and_return(false)
         end
 
-        it 'raises an exception if validation_key is not present in chef 11' do
+        it "raises an exception if validation_key is not present in chef 11" do
           expect(@arm_server_instance.ui).to receive(:error).twice
           expect { @arm_server_instance.run }.to raise_error(SystemExit)
         end
@@ -1047,37 +1050,39 @@ describe Chef::Knife::AzurermServerCreate do
     it "validate_arm_keys! raises error and exits if azure_image_os_type is not specified" do
       @arm_server_instance.config.delete(:azure_image_os_type)
       expect(@arm_server_instance.ui).to receive(:error)
-      expect{@arm_server_instance.validate_arm_keys!(
-        :azure_image_os_type)}.to raise_error(SystemExit)
+      expect do
+         @arm_server_instance.validate_arm_keys!(
+        :azure_image_os_type) end.to raise_error(SystemExit)
     end
 
     it "validate_arm_keys! raises error and exits if image reference parameters are not specified" do
       expect(@arm_server_instance.ui).to receive(:error).thrice
-      expect{@arm_server_instance.validate_arm_keys!(
+      expect do
+         @arm_server_instance.validate_arm_keys!(
         :azure_image_reference_publisher,
         :azure_image_reference_offer,
         :azure_image_reference_sku,
-        :azure_image_reference_version)}.to raise_error(SystemExit)
+        :azure_image_reference_version) end.to raise_error(SystemExit)
     end
 
     it "calls validation for azure_image_os_type if azure_image_os_type and other image reference parameters are not given" do
       @arm_server_instance.config.delete(:azure_image_os_type)
       @arm_server_instance.config.delete(:azure_image_reference_version)
       @arm_server_instance.default_config.delete(:azure_image_reference_version)
-      expect{ @arm_server_instance.send(:set_default_image_reference!) }.to raise_error(SystemExit)
+      expect { @arm_server_instance.send(:set_default_image_reference!) }.to raise_error(SystemExit)
     end
 
     it "raises error and exits if azure_image_os_type or other image reference parameters are not specified" do
       @arm_server_instance.config.delete(:azure_image_os_type)
       expect(@arm_server_instance.ui).to receive(:error)
-      expect{@arm_server_instance.send(:set_default_image_reference!)}.to raise_error(SystemExit)
+      expect { @arm_server_instance.send(:set_default_image_reference!) }.to raise_error(SystemExit)
     end
 
     it "raises error and exits if both azure_image_os_type and other image reference parameters like publisher or offer are specified" do
       @arm_server_instance.config[:azure_image_os_type] = "ubuntu"
       @arm_server_instance.config[:azure_image_reference_publisher] = "azure_image_reference_publisher"
       expect(@arm_server_instance.ui).to receive(:error)
-      expect{@arm_server_instance.send(:set_default_image_reference!)}.to raise_error(SystemExit)
+      expect { @arm_server_instance.send(:set_default_image_reference!) }.to raise_error(SystemExit)
     end
 
     it "sets default image reference parameters for azure_image_os_type=ubuntu" do
@@ -1086,7 +1091,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "Canonical"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "UbuntuServer"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "14.04.2-LTS"
-      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == 'latest'
+      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == "latest"
     end
 
     it "sets default image reference parameters for azure_image_os_type=centos" do
@@ -1096,7 +1101,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "OpenLogic"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "CentOS"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "7.1"
-      expect(@arm_server_instance.config[:azure_image_reference_version]).to be == '6.5'
+      expect(@arm_server_instance.config[:azure_image_reference_version]).to be == "6.5"
     end
 
     it "sets default image reference parameters for azure_image_os_type=rhel" do
@@ -1105,7 +1110,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "RedHat"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "RHEL"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "7.2"
-      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == 'latest'
+      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == "latest"
     end
 
     it "sets default image reference parameters for azure_image_os_type=debian" do
@@ -1114,7 +1119,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "credativ"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "Debian"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "7"
-      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == 'latest'
+      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == "latest"
     end
 
     it "sets default image reference parameters for azure_image_os_type=windows" do
@@ -1123,7 +1128,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "MicrosoftWindowsServer"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "WindowsServer"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "2012-R2-Datacenter"
-      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == 'latest'
+      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == "latest"
     end
 
     it "overrides sku value for os_type when both azure_image_os_type and azure_image_reference_sku are given" do
@@ -1133,7 +1138,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@arm_server_instance.config[:azure_image_reference_publisher]).to be == "MicrosoftWindowsServer"
       expect(@arm_server_instance.config[:azure_image_reference_offer]).to be == "WindowsServer"
       expect(@arm_server_instance.config[:azure_image_reference_sku]).to be == "2008-R2-SP1"
-      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == 'latest'
+      expect(@arm_server_instance.default_config[:azure_image_reference_version]).to be == "latest"
     end
 
     it "uses all 4 user supplied values for image reference parameters when os_type is not given" do
@@ -1169,7 +1174,7 @@ describe Chef::Knife::AzurermServerCreate do
       @arm_server_instance.config.delete(:azure_image_reference_sku)
       @arm_server_instance.config.delete(:azure_image_reference_version)
       expect(@arm_server_instance.ui).to receive(:error)
-      expect{@arm_server_instance.send(:set_default_image_reference!)}.to raise_error(SystemExit)
+      expect { @arm_server_instance.send(:set_default_image_reference!) }.to raise_error(SystemExit)
     end
   end
 
@@ -1192,7 +1197,7 @@ describe Chef::Knife::AzurermServerCreate do
       expect(@service).to receive(:create_deployment_parameters)
       allow(@resource_client).to receive_message_chain(
           :deployments, :create_or_update).and_raise(Exception)
-      expect{ @service.create_virtual_machine_using_template(@params) }.to raise_error(Exception)
+      expect { @service.create_virtual_machine_using_template(@params) }.to raise_error(Exception)
     end
 
     after do
@@ -1203,34 +1208,34 @@ describe Chef::Knife::AzurermServerCreate do
   describe "create_deployment_template" do
     before do
       bootstrap_options = { :chef_server_url => "url",
-        :validation_client_name => "client_name",
-        :bootstrap_proxy => "http://test.com",
-        :node_ssl_verify_mode => 'true',
-        :node_verify_api_cert  => 'hfyreiur374294nehfdishf',
-        :environment => "development" }
+                            :validation_client_name => "client_name",
+                            :bootstrap_proxy => "http://test.com",
+                            :node_ssl_verify_mode => "true",
+                            :node_verify_api_cert => "hfyreiur374294nehfdishf",
+                            :environment => "development" }
       @params[:chef_extension_public_param] = { :hints =>
-        ['vm_name', 'public_fqdn', 'platform'],
-        :bootstrap_options => bootstrap_options,
-        :extendedLogs => 'true'
+        %w{vm_name public_fqdn platform},
+                                                :bootstrap_options => bootstrap_options,
+                                                :extendedLogs => "true"
       }
       {
-        :azure_image_reference_publisher => 'OpenLogic',
-        :azure_image_reference_offer => 'CentOS',
-        :azure_image_reference_sku => '6.5',
-        :azure_image_reference_version => 'latest',
-        :ssh_user => 'ssh_user',
+        :azure_image_reference_publisher => "OpenLogic",
+        :azure_image_reference_offer => "CentOS",
+        :azure_image_reference_sku => "6.5",
+        :azure_image_reference_version => "latest",
+        :ssh_user => "ssh_user",
         :server_count => 3,
         :vm_size => "Standard_A1"
       }.each do |key, value|
-          @params[key] = value
-        end
+        @params[key] = value
+      end
 
       @hints_json = { "vm_name" => "[reference(resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))).osProfile.computerName]",
-        "public_fqdn" => "[reference(resourceId('Microsoft.Network/publicIPAddresses',concat(variables('publicIPAddressName'),copyIndex()))).dnsSettings.fqdn]",
-        "platform" => "[concat(reference(resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))).storageProfile.imageReference.offer, concat(' ', reference(resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))).storageProfile.imageReference.sku))]"
+                      "public_fqdn" => "[reference(resourceId('Microsoft.Network/publicIPAddresses',concat(variables('publicIPAddressName'),copyIndex()))).dnsSettings.fqdn]",
+                      "platform" => "[concat(reference(resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))).storageProfile.imageReference.offer, concat(' ', reference(resourceId('Microsoft.Compute/virtualMachines', concat(variables('vmName'),copyIndex()))).storageProfile.imageReference.sku))]"
       }
       @params[:chef_extension_private_param] = {
-        :encrypted_data_bag_secret => 'rihrfwe739085928592nehrweirwefjsndwe'
+        :encrypted_data_bag_secret => "rihrfwe739085928592nehrweirwefjsndwe"
       }
     end
 
@@ -1267,14 +1272,14 @@ describe Chef::Knife::AzurermServerCreate do
       expect(extension["properties"]["settings"]["bootstrap_options"]["bootstrap_proxy"]).to be == "[parameters('bootstrap_proxy')]"
       expect(extension["properties"]["settings"]["bootstrap_options"]["node_ssl_verify_mode"]).to be == "[parameters('node_ssl_verify_mode')]"
       expect(extension["properties"]["settings"]["bootstrap_options"]["node_verify_api_cert"]).to be == "[parameters('node_verify_api_cert')]"
-      expect(extension["properties"]["settings"]["extendedLogs"]).to be == 'true'
+      expect(extension["properties"]["settings"]["extendedLogs"]).to be == "true"
       expect(extension["properties"]["settings"]["bootstrap_options"]["environment"]).to be == "[parameters('environment')]"
 
       expect(extension["properties"]["protectedSettings"]["encrypted_data_bag_secret"]).to be == "[parameters('encrypted_data_bag_secret')]"
     end
 
     it "does not set extendedLogs parameter under extension config in the template" do
-      @params[:chef_extension_public_param][:extendedLogs] = 'false'
+      @params[:chef_extension_public_param][:extendedLogs] = "false"
       template = @service.create_deployment_template(@params)
 
       extension = ""
@@ -1282,7 +1287,7 @@ describe Chef::Knife::AzurermServerCreate do
         extension = resource if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
       end
 
-      expect(extension["properties"]["settings"].has_key? 'extendedLogs').to be == false
+      expect(extension["properties"]["settings"].has_key? "extendedLogs").to be == false
     end
 
     context "chef_daemon_interval option" do
@@ -1299,8 +1304,8 @@ describe Chef::Knife::AzurermServerCreate do
             extension = resource if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
           end
 
-          expect(extension["properties"]["settings"].has_key? 'chef_daemon_interval').to be == true
-          expect(extension["properties"]["settings"]['chef_daemon_interval']).to be == "19"
+          expect(extension["properties"]["settings"].has_key? "chef_daemon_interval").to be == true
+          expect(extension["properties"]["settings"]["chef_daemon_interval"]).to be == "19"
         end
       end
 
@@ -1317,7 +1322,7 @@ describe Chef::Knife::AzurermServerCreate do
             extension = resource if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
           end
 
-          expect(extension["properties"]["settings"].has_key? 'chef_daemon_interval').to be == false
+          expect(extension["properties"]["settings"].has_key? "chef_daemon_interval").to be == false
         end
       end
     end
@@ -1336,8 +1341,8 @@ describe Chef::Knife::AzurermServerCreate do
             extension = resource if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
           end
 
-          expect(extension["properties"]["settings"].has_key? 'daemon').to be == true
-          expect(extension["properties"]["settings"]['daemon']).to be == "service"
+          expect(extension["properties"]["settings"].has_key? "daemon").to be == true
+          expect(extension["properties"]["settings"]["daemon"]).to be == "service"
         end
       end
 
@@ -1354,12 +1359,10 @@ describe Chef::Knife::AzurermServerCreate do
             extension = resource if resource["type"] == "Microsoft.Compute/virtualMachines/extensions"
           end
 
-          expect(extension["properties"]["settings"].has_key? 'daemon').to be == false
+          expect(extension["properties"]["settings"].has_key? "daemon").to be == false
         end
       end
     end
-
-
 
     after do
       @params.delete(:server_count)
@@ -1368,31 +1371,31 @@ describe Chef::Knife::AzurermServerCreate do
 
   describe "create_deployment_parameters" do
     before do
-      bootstrap_options = {:chef_server_url => "url",
-        :validation_client_name => "client_name",
-        :bootstrap_proxy => "http://test.com",
-        :node_ssl_verify_mode => 'true',
-        :node_verify_api_cert  => 'hfyreiur374294nehfdishf',
-        :chef_node_name => 'test-vm',
-        :environment => "development"}
+      bootstrap_options = { :chef_server_url => "url",
+                            :validation_client_name => "client_name",
+                            :bootstrap_proxy => "http://test.com",
+                            :node_ssl_verify_mode => "true",
+                            :node_verify_api_cert => "hfyreiur374294nehfdishf",
+                            :chef_node_name => "test-vm",
+                            :environment => "development" }
       @params[:chef_extension_public_param] = { :bootstrap_options => bootstrap_options }
       @params[:chef_extension_private_param] = {
         :validation_key => "validation_key",
-        :encrypted_data_bag_secret => 'rihrfwe739085928592nehrweirwefjsndwe'
+        :encrypted_data_bag_secret => "rihrfwe739085928592nehrweirwefjsndwe"
       }
       {
-        :azure_image_reference_publisher => 'OpenLogic',
-        :azure_image_reference_offer => 'CentOS',
-        :azure_image_reference_sku => '6.5',
-        :azure_image_reference_version => 'latest',
-        :ssh_user => 'ssh_user',
+        :azure_image_reference_publisher => "OpenLogic",
+        :azure_image_reference_offer => "CentOS",
+        :azure_image_reference_sku => "6.5",
+        :azure_image_reference_version => "latest",
+        :ssh_user => "ssh_user",
         :admin_password => "admin_password",
         :server_count => 3,
         :client_rb => "contents_of_client_rb",
         :custom_json_attr => '"{name: test}"'
       }.each do |key, value|
-          @params[key] = value
-        end
+        @params[key] = value
+      end
     end
 
     it "sets the parameters which are passed in the template" do
@@ -1409,8 +1412,8 @@ describe Chef::Knife::AzurermServerCreate do
       expect(parameters["encrypted_data_bag_secret"]["value"]).to be == "rihrfwe739085928592nehrweirwefjsndwe"
       expect(parameters["bootstrap_proxy"]["value"]).to be == "http://test.com"
       expect(parameters["node_ssl_verify_mode"]["value"]).to be == "true"
-      expect(parameters["node_verify_api_cert"]["value"]).to be == 'hfyreiur374294nehfdishf'
-      expect(parameters["chef_node_name"]["value"]).to be == 'test-vm'
+      expect(parameters["node_verify_api_cert"]["value"]).to be == "hfyreiur374294nehfdishf"
+      expect(parameters["chef_node_name"]["value"]).to be == "test-vm"
       expect(parameters["environment"]["value"]).to be == "development"
     end
 
@@ -1438,209 +1441,209 @@ describe Chef::Knife::AzurermServerCreate do
     end
   end
 
-  describe 'supported_ohai_hints' do
-    it 'returns the list of supported values' do
+  describe "supported_ohai_hints" do
+    it "returns the list of supported values" do
       response = @arm_server_instance.supported_ohai_hints
       expect(response).to be == ohai_hints_values
     end
   end
 
-  describe 'format_ohai_hints' do
-    context 'no input given by user' do
-      it 'formats the default input for Ohai Hints where the expected result is same as the default value' do
-        response = @arm_server_instance.format_ohai_hints('default')
-        expect(response).to be == 'default'
+  describe "format_ohai_hints" do
+    context "no input given by user" do
+      it "formats the default input for Ohai Hints where the expected result is same as the default value" do
+        response = @arm_server_instance.format_ohai_hints("default")
+        expect(response).to be == "default"
       end
     end
 
-    context 'input given by user in correct format' do
-      it 'formats the user input for Ohai Hints where the expected result is same as the user\'s input' do
-        response = @arm_server_instance.format_ohai_hints('public_fqdn,vm_name')
-        expect(response).to be == 'public_fqdn,vm_name'
+    context "input given by user in correct format" do
+      it "formats the user input for Ohai Hints where the expected result is same as the user's input" do
+        response = @arm_server_instance.format_ohai_hints("public_fqdn,vm_name")
+        expect(response).to be == "public_fqdn,vm_name"
       end
     end
 
-    context 'input given by user with incorrect syntax' do
-      it 'formats the user input for Ohai Hints where the expected result is the value with correct syntax' do
-        response = @arm_server_instance.format_ohai_hints('public_fqdn,vm_name,')
-        expect(response).to be == 'public_fqdn,vm_name'
+    context "input given by user with incorrect syntax" do
+      it "formats the user input for Ohai Hints where the expected result is the value with correct syntax" do
+        response = @arm_server_instance.format_ohai_hints("public_fqdn,vm_name,")
+        expect(response).to be == "public_fqdn,vm_name"
       end
     end
 
-    context 'input given by user in incorrect syntax and incorrect format' do
-      it 'formats the user input for Ohai Hints where the expected result is the value in correct syntax and correct format' do
-        response = @arm_server_instance.format_ohai_hints('public_fqdn , vm_name, platform ,,')
-        expect(response).to be == 'public_fqdn,vm_name,platform'
+    context "input given by user in incorrect syntax and incorrect format" do
+      it "formats the user input for Ohai Hints where the expected result is the value in correct syntax and correct format" do
+        response = @arm_server_instance.format_ohai_hints("public_fqdn , vm_name, platform ,,")
+        expect(response).to be == "public_fqdn,vm_name,platform"
       end
     end
 
-    context 'input given by user in incorrect format' do
-      it 'formats the user input for Ohai Hints where the expected result is the value in correct format' do
-        response = @arm_server_instance.format_ohai_hints(' public_fqdn ,platform , vm_name ')
-        expect(response).to be == 'public_fqdn,platform,vm_name'
+    context "input given by user in incorrect format" do
+      it "formats the user input for Ohai Hints where the expected result is the value in correct format" do
+        response = @arm_server_instance.format_ohai_hints(" public_fqdn ,platform , vm_name ")
+        expect(response).to be == "public_fqdn,platform,vm_name"
       end
     end
   end
 
-  describe 'is_supported_ohai_hint?' do
-    context 'supported value given by user' do
-      it 'returns true' do
-        response = @arm_server_instance.is_supported_ohai_hint?('platform')
+  describe "is_supported_ohai_hint?" do
+    context "supported value given by user" do
+      it "returns true" do
+        response = @arm_server_instance.is_supported_ohai_hint?("platform")
         expect(response).to be true
       end
     end
 
-    context 'unsupported value given by user' do
-      it 'returns false' do
-        response = @arm_server_instance.is_supported_ohai_hint?('mac_address')
+    context "unsupported value given by user" do
+      it "returns false" do
+        response = @arm_server_instance.is_supported_ohai_hint?("mac_address")
         expect(response).to be false
       end
     end
   end
 
-  describe 'validate_ohai_hints' do
-    context 'correct input by user' do
+  describe "validate_ohai_hints" do
+    context "correct input by user" do
       before do
-        @arm_server_instance.config[:ohai_hints] = 'vm_name,platform'
+        @arm_server_instance.config[:ohai_hints] = "vm_name,platform"
       end
 
-      it 'does not raise error' do
+      it "does not raise error" do
         expect { @arm_server_instance.validate_ohai_hints }.to_not raise_error
       end
     end
 
-    context 'incorrect input by user' do
+    context "incorrect input by user" do
       before do
-        @arm_server_instance.default_config[:ohai_hints] = 'public_fqdn,vm_name,platform,mac_address'
+        @arm_server_instance.default_config[:ohai_hints] = "public_fqdn,vm_name,platform,mac_address"
       end
 
-      it 'do raise error' do
+      it "do raise error" do
         expect { @arm_server_instance.validate_ohai_hints }.to raise_error(
           ArgumentError)
       end
     end
   end
 
-  describe 'default_hint_options' do
-    it 'returns the list of default hint values' do
+  describe "default_hint_options" do
+    it "returns the list of default hint values" do
       response = @arm_server_instance.default_hint_options
       expect(response).to be == ohai_hints_values
     end
   end
 
-  describe 'ohai_hints in bootstrapper' do
-    context 'no input given by user' do
-      it 'returns default values for Ohai Hints' do
+  describe "ohai_hints in bootstrapper" do
+    context "no input given by user" do
+      it "returns default values for Ohai Hints" do
         response = @arm_server_instance.ohai_hints
         expect(response).to be == ohai_hints_values
       end
     end
 
-    context 'input given by user' do
+    context "input given by user" do
       before do
-        @arm_server_instance.config[:ohai_hints] = 'platform,vm_name'
+        @arm_server_instance.config[:ohai_hints] = "platform,vm_name"
       end
 
-      it 'returns the input given by user' do
+      it "returns the input given by user" do
         response = @arm_server_instance.ohai_hints
-        expect(response[0]).to be == 'platform'
-        expect(response[1]).to be == 'vm_name'
+        expect(response[0]).to be == "platform"
+        expect(response[1]).to be == "vm_name"
       end
     end
   end
 
-  describe 'ohai_hints in arm_deployment_template' do
+  describe "ohai_hints in arm_deployment_template" do
     before do
       @hint_names = ohai_hints_values
       @resource_ids = { "vmId" =>
         "resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))",
-        "pubId" => "resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))" }
+                        "pubId" => "resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))" }
     end
 
-    it 'returns the json for the given hint names to be set in the template for Ohai Hints configuration' do
+    it "returns the json for the given hint names to be set in the template for Ohai Hints configuration" do
       response = @service.ohai_hints(@hint_names, @resource_ids)
-      expect(response['vm_name']).to be == "[reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).osProfile.computerName]"
-      expect(response['public_fqdn']).to be == "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))).dnsSettings.fqdn]"
-      expect(response['platform']).to be == "[concat(reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).storageProfile.imageReference.offer, concat(' ', reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).storageProfile.imageReference.sku))]"
+      expect(response["vm_name"]).to be == "[reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).osProfile.computerName]"
+      expect(response["public_fqdn"]).to be == "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))).dnsSettings.fqdn]"
+      expect(response["platform"]).to be == "[concat(reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).storageProfile.imageReference.offer, concat(' ', reference(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))).storageProfile.imageReference.sku))]"
     end
   end
 
-  describe 'parse_substatus_code' do
-    it 'returns substatus\' name field' do
-      response = @service.parse_substatus_code('ComponentStatus/Chef Client run logs/succeeded', 1)
-      expect(response).to be == 'Chef Client run logs'
+  describe "parse_substatus_code" do
+    it "returns substatus' name field" do
+      response = @service.parse_substatus_code("ComponentStatus/Chef Client run logs/succeeded", 1)
+      expect(response).to be == "Chef Client run logs"
     end
 
-    it 'returns substatus\' status field' do
-      response = @service.parse_substatus_code('ComponentStatus/Chef Client run logs/failed/0', 2)
-      expect(response).to be == 'failed'
+    it "returns substatus' status field" do
+      response = @service.parse_substatus_code("ComponentStatus/Chef Client run logs/failed/0", 2)
+      expect(response).to be == "failed"
     end
   end
 
-  describe 'fetch_substatus' do
-    context 'no substatuses returned' do
+  describe "fetch_substatus" do
+    context "no substatuses returned" do
       before do
         allow(@service).to receive(:compute_management_client).and_return(
-          stub_compute_management_client('substatuses_not_found'))
+          stub_compute_management_client("substatuses_not_found"))
       end
 
-      it 'returns nil' do
+      it "returns nil" do
         response = @service.fetch_substatus(@params[:azure_resource_group_name],
           @params[:azure_vm_name],
           @params[:chef_extension]
         )
 
-        expect(response).to be == nil
+        expect(response).to be.nil?
       end
     end
 
-    context 'substatuses returned' do
-      context 'but it does not contain chef-client run logs substatus' do
+    context "substatuses returned" do
+      context "but it does not contain chef-client run logs substatus" do
         before do
           allow(@service).to receive(:compute_management_client).and_return(
-            stub_compute_management_client('substatuses_found_with_no_chef_client_run_logs'))
+            stub_compute_management_client("substatuses_found_with_no_chef_client_run_logs"))
         end
 
-        it 'returns nil' do
+        it "returns nil" do
           response = @service.fetch_substatus(@params[:azure_resource_group_name],
             @params[:azure_vm_name],
             @params[:chef_extension]
           )
 
-          expect(response).to be == nil
+          expect(response).to be.nil?
         end
       end
 
-      context 'and it do not contain chef-client run logs substatus' do
+      context "and it do not contain chef-client run logs substatus" do
         before do
           allow(@service).to receive(:compute_management_client).and_return(
-            stub_compute_management_client('substatuses_found_with_chef_client_run_logs'))
+            stub_compute_management_client("substatuses_found_with_chef_client_run_logs"))
         end
 
-        it 'returns substatus hash for chef-client run logs' do
+        it "returns substatus hash for chef-client run logs" do
           response = @service.fetch_substatus(@params[:azure_resource_group_name],
             @params[:azure_vm_name],
             @params[:chef_extension]
           )
 
-          expect(response).to_not be == nil
-          expect(response.code).to be == 'ComponentStatus/Chef Client run logs/succeeded'
-          expect(response.message).to be == 'chef_client_run_logs'
+          expect(response).to_not be.nil?
+          expect(response.code).to be == "ComponentStatus/Chef Client run logs/succeeded"
+          expect(response.message).to be == "chef_client_run_logs"
         end
       end
 
     end
   end
 
-  describe 'fetch_chef_client_logs' do
-    context 'chef-client run logs substatus not available yet' do
+  describe "fetch_chef_client_logs" do
+    context "chef-client run logs substatus not available yet" do
       before do
         allow(@service).to receive(:fetch_substatus).and_return(nil)
         @start_time = Time.now
       end
 
-      context 'wait time has not exceeded wait timeout limit' do
-        it 'sleeps for some time and re-invokes the fetch_chef_client_logs method recursively' do
+      context "wait time has not exceeded wait timeout limit" do
+        it "sleeps for some time and re-invokes the fetch_chef_client_logs method recursively" do
           @service.instance_eval do
             class << self
               alias_method :fetch_chef_client_logs_mocked, :fetch_chef_client_logs
@@ -1663,8 +1666,8 @@ describe Chef::Knife::AzurermServerCreate do
         end
       end
 
-      context 'wait time has exceeded wait timeout limit' do
-        it 'displays wait timeout exceeded message' do
+      context "wait time has exceeded wait timeout limit" do
+        it "displays wait timeout exceeded message" do
           expect(@service.ui).to receive(:error).with(
             "\nchef-client run logs could not be fetched since fetch process exceeded wait timeout of -1 minutes.\n")
           @service.fetch_chef_client_logs(@params[:azure_resource_group_name],
@@ -1677,20 +1680,20 @@ describe Chef::Knife::AzurermServerCreate do
       end
     end
 
-    context 'chef-client run logs substatus available now' do
+    context "chef-client run logs substatus available now" do
       before do
         substatus = OpenStruct.new(
-          :code => 'ComponentStatus/Chef Client run logs/succeeded',
-          :level => 'Info',
-          :display_status => 'Provisioning succeeded',
-          :message => 'chef_client_run_logs',
-          :time => 'chef_client_run_logs_write_time'
+          :code => "ComponentStatus/Chef Client run logs/succeeded",
+          :level => "Info",
+          :display_status => "Provisioning succeeded",
+          :message => "chef_client_run_logs",
+          :time => "chef_client_run_logs_write_time"
         )
         allow(@service).to receive(:fetch_substatus).and_return(substatus)
         @start_time = Time.now
       end
 
-      it 'displays chef-client run logs and exit status to the user' do
+      it "displays chef-client run logs and exit status to the user" do
         expect(@service).to receive(:puts).exactly(4).times
         expect(@service).to receive(:print).exactly(1).times
         @service.fetch_chef_client_logs(@params[:azure_resource_group_name],
@@ -1702,10 +1705,10 @@ describe Chef::Knife::AzurermServerCreate do
   end
 
   def ohai_hints_values
-    [
-      'vm_name',
-      'public_fqdn',
-      'platform'
-    ]
+    %w{
+      vm_name
+      public_fqdn
+      platform
+    }
   end
 end

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -1,6 +1,6 @@
   #
 # Author:: Aliasgar Batterywala (<aliasgar.batterywala@clogeny.com>)
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")

--- a/spec/unit/azurerm_server_create_spec.rb
+++ b/spec/unit/azurerm_server_create_spec.rb
@@ -1593,7 +1593,7 @@ describe Chef::Knife::AzurermServerCreate do
           @params[:chef_extension]
         )
 
-        expect(response).to be.nil?
+        expect(response).to be_nil
       end
     end
 
@@ -1610,7 +1610,7 @@ describe Chef::Knife::AzurermServerCreate do
             @params[:chef_extension]
           )
 
-          expect(response).to be.nil?
+          expect(response).to be_nil
         end
       end
 
@@ -1626,7 +1626,7 @@ describe Chef::Knife::AzurermServerCreate do
             @params[:chef_extension]
           )
 
-          expect(response).to_not be.nil?
+          expect(response).to_not be_nil
           expect(response.code).to be == "ComponentStatus/Chef Client run logs/succeeded"
           expect(response.message).to be == "chef_client_run_logs"
         end

--- a/spec/unit/azurerm_server_delete_spec.rb
+++ b/spec/unit/azurerm_server_delete_spec.rb
@@ -1,11 +1,11 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzurermServerDelete do
   include AzureSpecHelper
   include QueryAzureMock
 
-  describe 'delete server without deleting resource group' do
+  describe "delete server without deleting resource group" do
     before do
       @arm_server_instance = create_arm_instance(Chef::Knife::AzurermServerDelete)
       allow(@arm_server_instance.service.ui).to receive(:confirm).and_return (true)
@@ -13,38 +13,38 @@ describe Chef::Knife::AzurermServerDelete do
 
       @service = @arm_server_instance.service
 
-      Chef::Config[:knife][:azure_resource_group_name] = 'test-rg-group'
-      @arm_server_instance.name_args = ['VM001']
+      Chef::Config[:knife][:azure_resource_group_name] = "test-rg-group"
+      @arm_server_instance.name_args = ["VM001"]
 
-      @server_detail = double('server', :name => "VM001", :hardware_profile => double, :storage_profile => double(:os_disk => double))
+      @server_detail = double("server", :name => "VM001", :hardware_profile => double, :storage_profile => double(:os_disk => double))
       allow(@server_detail.hardware_profile).to receive(:vm_size).and_return("10")
       allow(@server_detail.storage_profile.os_disk).to receive(:os_type).and_return("Linux")
       allow_any_instance_of(Chef::Knife::AzurermBase).to receive(:get_azure_cli_version).and_return("1.0.0")
     end
 
     it "deletes server" do
-      server = double('server')
-      delete_server = double('delete')
+      server = double("server")
+      delete_server = double("delete")
       allow(delete_server).to receive(:nil?).and_return("false")
 
       expect(@arm_server_instance).to receive(:validate_arm_keys!).with(:azure_resource_group_name)
       allow(@arm_server_instance.service).to receive(:compute_management_client).and_return(@compute_client)
-      allow(@compute_client).to receive_message_chain(:virtual_machines, :get).with('test-rg-group', 'VM001').and_return(@server_detail)
+      allow(@compute_client).to receive_message_chain(:virtual_machines, :get).with("test-rg-group", "VM001").and_return(@server_detail)
 
-      expect(@service).to receive(:msg_pair).with(@service.ui, 'VM Name', 'VM001')
-      expect(@service).to receive(:msg_pair).with(@service.ui, 'VM Size', '10')
-      expect(@service).to receive(:msg_pair).with(@service.ui, 'VM OS', 'Linux')
-      allow(@compute_client).to receive_message_chain(:virtual_machines, :delete).with('test-rg-group', 'VM001').and_return(delete_server)
+      expect(@service).to receive(:msg_pair).with(@service.ui, "VM Name", "VM001")
+      expect(@service).to receive(:msg_pair).with(@service.ui, "VM Size", "10")
+      expect(@service).to receive(:msg_pair).with(@service.ui, "VM OS", "Linux")
+      allow(@compute_client).to receive_message_chain(:virtual_machines, :delete).with("test-rg-group", "VM001").and_return(delete_server)
       expect(@service.ui).to receive(:info).once
       expect(@service.ui).to receive(:warn).twice
       @arm_server_instance.run
     end
 
     it "does nothing if the server is not found" do
-      server = double('server', :name => 'VM002')
+      server = double("server", :name => "VM002")
       expect(@arm_server_instance).to receive(:validate_arm_keys!).with(:azure_resource_group_name)
       expect(@arm_server_instance.service).to receive(:compute_management_client).and_return(@compute_client)
-      expect(@compute_client).to receive_message_chain(:virtual_machines, :get).with('test-rg-group', 'VM001').and_return(server)
+      expect(@compute_client).to receive_message_chain(:virtual_machines, :get).with("test-rg-group", "VM001").and_return(server)
       expect(@service.ui).to receive(:warn).once
       @arm_server_instance.run
     end
@@ -73,20 +73,20 @@ describe Chef::Knife::AzurermServerDelete do
       @resource_client = double("ResourceManagementClient")
       @service = @arm_server_instance.service
 
-      Chef::Config[:knife][:azure_resource_group_name] = 'test-rg-group'
+      Chef::Config[:knife][:azure_resource_group_name] = "test-rg-group"
       Chef::Config[:knife][:delete_resource_group] = true
-      @arm_server_instance.name_args = ['VM001']
+      @arm_server_instance.name_args = ["VM001"]
     end
 
     it "destroys the corresponding resource group if --delete-resource-group option is given" do
-      server = double('server')
+      server = double("server")
       allow(server).to receive(:nil?).and_return("false")
       Chef::Config[:knife][:delete_resource_group] = true
       allow(@arm_server_instance.service.ui).to receive(:confirm).and_return (true)
 
       expect(@arm_server_instance).to receive(:validate_arm_keys!).with(:azure_resource_group_name)
       expect(@arm_server_instance.service).to receive(:resource_management_client).and_return(@resource_client)
-      expect(@resource_client).to receive_message_chain(:resource_groups, :delete).with('test-rg-group').and_return(server)
+      expect(@resource_client).to receive_message_chain(:resource_groups, :delete).with("test-rg-group").and_return(server)
       expect(@service.ui).to receive(:warn).thrice
       expect(@service.ui).to receive(:info).twice
 

--- a/spec/unit/azurerm_server_list_spec.rb
+++ b/spec/unit/azurerm_server_list_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzurermServerList do
   include AzureSpecHelper
@@ -12,22 +12,22 @@ describe Chef::Knife::AzurermServerList do
     @compute_client = double("ComputeManagementClient")
 
     @server1 = double("server1", :name => "MyVM1", :id => double, :location => "west-us")
-    allow(@server1.id).to receive(:split).and_return(['','subscriptions','subscription_id','resourcegroups','myresourcegroup1','Microsoft.compute','virtualmachines','MyVM1'])
-    allow(@server1.id.split[4]).to receive(:downcase).and_return('myresourcegroup1')
+    allow(@server1.id).to receive(:split).and_return(["", "subscriptions", "subscription_id", "resourcegroups", "myresourcegroup1", "Microsoft.compute", "virtualmachines", "MyVM1"])
+    allow(@server1.id.split[4]).to receive(:downcase).and_return("myresourcegroup1")
     allow(@server1).to receive(:provisioning_state).and_return("running")
     allow(@server1).to receive_message_chain(
       :storage_profile, :os_disk, :os_type).and_return("linux")
 
     @server2 = double("server2", :name => "MyVM2", :id => double, :location => "west-us")
-    allow(@server2.id).to receive(:split).and_return(['','subscriptions','subscription_id','resourcegroups','myresourcegroup2','Microsoft.compute','virtualmachines','MyVM2'])
-    allow(@server2.id.split[4]).to receive(:downcase).and_return('myresourcegroup2')
+    allow(@server2.id).to receive(:split).and_return(["", "subscriptions", "subscription_id", "resourcegroups", "myresourcegroup2", "Microsoft.compute", "virtualmachines", "MyVM2"])
+    allow(@server2.id.split[4]).to receive(:downcase).and_return("myresourcegroup2")
     allow(@server2).to receive(:provisioning_state).and_return("running")
     allow(@server2).to receive_message_chain(
       :storage_profile, :os_disk, :os_type).and_return("linux")
 
     @server3 = double("server3", :name => "MyVM3", :id => double, :location => "west-us")
-    allow(@server3.id).to receive(:split).and_return(['','subscriptions','subscription_id','resourcegroups','myresourcegroup1','Microsoft.compute','virtualmachines','MyVM3'])
-    allow(@server3.id.split[4]).to receive(:downcase).and_return('myresourcegroup1')
+    allow(@server3.id).to receive(:split).and_return(["", "subscriptions", "subscription_id", "resourcegroups", "myresourcegroup1", "Microsoft.compute", "virtualmachines", "MyVM3"])
+    allow(@server3.id.split[4]).to receive(:downcase).and_return("myresourcegroup1")
     allow(@server3).to receive(:provisioning_state).and_return("running")
     allow(@server3).to receive_message_chain(
       :storage_profile, :os_disk, :os_type).and_return("windows")
@@ -54,13 +54,13 @@ describe Chef::Knife::AzurermServerList do
     end
 
     it "should display VM Name, Location, Provisioning State and OS Type for all the VMs irrespective of the resource_group" do
-      output_row = [@server1.name,@server1.id.split[4],@server1.location,@server1.provisioning_state,@server1.storage_profile.os_disk.os_type,
-                    @server2.name,@server2.id.split[4],@server2.location,@server2.provisioning_state,@server2.storage_profile.os_disk.os_type,
-                    @server3.name,@server3.id.split[4],@server3.location,@server3.provisioning_state,@server3.storage_profile.os_disk.os_type
+      output_row = [@server1.name, @server1.id.split[4], @server1.location, @server1.provisioning_state, @server1.storage_profile.os_disk.os_type,
+                    @server2.name, @server2.id.split[4], @server2.location, @server2.provisioning_state, @server2.storage_profile.os_disk.os_type,
+                    @server3.name, @server3.id.split[4], @server3.location, @server3.provisioning_state, @server3.storage_profile.os_disk.os_type
                    ]
       expect(@compute_client).to receive_message_chain(
         :virtual_machines, :list_all).and_return(
-          [@server1,@server2,@server3])
+          [@server1, @server2, @server3])
       expect(@arm_server_instance.service).to receive(:display_list).with(
         @arm_server_instance.service.ui,
         ["VM Name", "Resource Group Name", "Location", "Provisioning State", "OS Type"],
@@ -72,7 +72,7 @@ describe Chef::Knife::AzurermServerList do
 
   context "resource_group_name is given" do
     before do
-      Chef::Config[:knife][:azure_resource_group_name] = 'myresourcegroup1'
+      Chef::Config[:knife][:azure_resource_group_name] = "myresourcegroup1"
     end
 
     it "should display only labels if there are no servers under the given resource_group" do
@@ -87,12 +87,12 @@ describe Chef::Knife::AzurermServerList do
     end
 
     it "should display VM Name, Location, Provisioning State and OS Type for all the VMs existing under the given resource_group" do
-      output_row = [@server1.name,@server1.id.split[4],@server1.location,@server1.provisioning_state,@server1.storage_profile.os_disk.os_type,
-                    @server3.name,@server3.id.split[4],@server3.location,@server3.provisioning_state,@server3.storage_profile.os_disk.os_type
+      output_row = [@server1.name, @server1.id.split[4], @server1.location, @server1.provisioning_state, @server1.storage_profile.os_disk.os_type,
+                    @server3.name, @server3.id.split[4], @server3.location, @server3.provisioning_state, @server3.storage_profile.os_disk.os_type
                    ]
       expect(@compute_client).to receive_message_chain(
         :virtual_machines, :list).and_return(
-          [@server1,@server3])
+          [@server1, @server3])
       expect(@arm_server_instance.service).to receive(:display_list).with(
         @arm_server_instance.service.ui,
         ["VM Name", "Resource Group Name", "Location", "Provisioning State", "OS Type"],

--- a/spec/unit/azurerm_server_show_spec.rb
+++ b/spec/unit/azurerm_server_show_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzurermServerShow do
   include AzureSpecHelper
@@ -8,7 +8,7 @@ describe Chef::Knife::AzurermServerShow do
   before do
     @arm_server_instance = create_arm_instance(Chef::Knife::AzurermServerShow)
     Chef::Config[:knife][:azure_resource_group_name] = "RESOURCE_GROUP"
-    @arm_server_instance.name_args = %w(vmname)
+    @arm_server_instance.name_args = %w{vmname}
     @compute_client = double("ComputeManagementClient")
     @network_client = double("NetworkManagementClient")
     allow(@arm_server_instance.service).to receive(:compute_management_client).and_return(@compute_client)
@@ -27,7 +27,7 @@ describe Chef::Knife::AzurermServerShow do
     @network_interface_data = double
     @public_ip_data =  double
     @public_ip_id_data = double(:id => double)
-    network_interface_id ="/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/networkInterfaces/myVMNic"
+    network_interface_id = "/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/networkInterfaces/myVMNic"
     network_interface_name = "myVMNIC"
     public_ip_id = "/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/publicIPAddresses/myPublicIP"
     public_ip_name = "mypublicip"
@@ -40,10 +40,10 @@ describe Chef::Knife::AzurermServerShow do
     allow(@server).to receive_message_chain(:storage_profile, :os_disk, :os_type).and_return("Linux")
     allow(@public_ip_data).to receive(:ip_address).and_return("23.3.4.1")
     allow(@public_ip_data).to receive_message_chain(:dns_settings, :fqdn).and_return("test.westus.cloudapp.azure.com")
-    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(['network_interfaces'])
+    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(["network_interfaces"])
     allow(@server.network_profile.network_interfaces[0]).to receive_message_chain(:id).and_return(network_interface_id)
     expect(network_interface_id).to receive(:split).with("/").and_return(network_interface_name)
-    allow(@network_interface_data).to receive(:ip_configurations).and_return(['ip_configurations'])
+    allow(@network_interface_data).to receive(:ip_configurations).and_return(["ip_configurations"])
     allow(@network_interface_data.ip_configurations[0]).to receive(:public_ipaddress).and_return(@public_ip_id_data)
     allow(@public_ip_id_data).to receive(:id).and_return(public_ip_id)
     expect(public_ip_id).to receive(:split).with("/").and_return(public_ip_name)
@@ -55,7 +55,7 @@ describe Chef::Knife::AzurermServerShow do
                 "Size", @server.hardware_profile.vm_size,
                 "Provisioning State", @server.provisioning_state,
                 "Location", @server.location,
-                "Publisher",  @server.storage_profile.image_reference.publisher,
+                "Publisher", @server.storage_profile.image_reference.publisher,
                 "Offer", @server.storage_profile.image_reference.offer,
                 "Sku", @server.storage_profile.image_reference.sku,
                 "Version", @server.storage_profile.image_reference.version,
@@ -81,10 +81,10 @@ describe Chef::Knife::AzurermServerShow do
     allow(@server).to receive_message_chain(:storage_profile, :image_reference, :sku).and_return("12.04.5-LTS")
     allow(@server).to receive_message_chain(:storage_profile, :image_reference, :version).and_return("latest")
     allow(@server).to receive_message_chain(:storage_profile, :os_disk, :os_type).and_return("Linux")
-    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(['network_interfaces'])
+    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(["network_interfaces"])
     allow(@server.network_profile.network_interfaces[0]).to receive_message_chain(:id).and_return(network_interface_id)
     expect(network_interface_id).to receive(:split).with("/").and_return(network_interface_name)
-    allow(@network_interface_data).to receive(:ip_configurations).and_return(['ip_configurations'])
+    allow(@network_interface_data).to receive(:ip_configurations).and_return(["ip_configurations"])
     allow(@network_interface_data.ip_configurations[0]).to receive(:public_ipaddress).and_return(public_ip_id_data)
     expect(@compute_client).to receive_message_chain(:virtual_machines, :get).and_return(@server)
     expect(@network_client).to receive_message_chain(:network_interfaces, :get).and_return(@network_interface_data)
@@ -93,7 +93,7 @@ describe Chef::Knife::AzurermServerShow do
                 "Size", @server.hardware_profile.vm_size,
                 "Provisioning State", @server.provisioning_state,
                 "Location", @server.location,
-                "Publisher",  @server.storage_profile.image_reference.publisher,
+                "Publisher", @server.storage_profile.image_reference.publisher,
                 "Offer", @server.storage_profile.image_reference.offer,
                 "Sku", @server.storage_profile.image_reference.sku,
                 "Version", @server.storage_profile.image_reference.version,
@@ -110,7 +110,7 @@ describe Chef::Knife::AzurermServerShow do
     @network_interface_data = double
     @public_ip_data =  double
     @public_ip_id_data = double(:id => double)
-    network_interface_id ="/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/networkInterfaces/myVMNic"
+    network_interface_id = "/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/networkInterfaces/myVMNic"
     network_interface_name = "myVMNIC"
     public_ip_id = "/subscriptions/xxx-xx-xxx-xxxxx/resourceGroups/xxxxxxx/providers/Microsoft.Network/publicIPAddresses/myPublicIP"
     public_ip_name = "mypublicip"
@@ -123,10 +123,10 @@ describe Chef::Knife::AzurermServerShow do
     allow(@server).to receive_message_chain(:storage_profile, :os_disk, :os_type).and_return("Linux")
     allow(@public_ip_data).to receive(:ip_address).and_return("23.3.4.1")
     allow(@public_ip_data).to receive(:dns_settings).and_return(nil)
-    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(['network_interfaces'])
+    allow(@server).to receive_message_chain(:network_profile, :network_interfaces).and_return(["network_interfaces"])
     allow(@server.network_profile.network_interfaces[0]).to receive_message_chain(:id).and_return(network_interface_id)
     expect(network_interface_id).to receive(:split).with("/").and_return(network_interface_name)
-    allow(@network_interface_data).to receive(:ip_configurations).and_return(['ip_configurations'])
+    allow(@network_interface_data).to receive(:ip_configurations).and_return(["ip_configurations"])
     allow(@network_interface_data.ip_configurations[0]).to receive(:public_ipaddress).and_return(@public_ip_id_data)
     allow(@public_ip_id_data).to receive(:id).and_return(public_ip_id)
     expect(public_ip_id).to receive(:split).with("/").and_return(public_ip_name)
@@ -138,7 +138,7 @@ describe Chef::Knife::AzurermServerShow do
                 "Size", @server.hardware_profile.vm_size,
                 "Provisioning State", @server.provisioning_state,
                 "Location", @server.location,
-                "Publisher",  @server.storage_profile.image_reference.publisher,
+                "Publisher", @server.storage_profile.image_reference.publisher,
                 "Offer", @server.storage_profile.image_reference.offer,
                 "Sku", @server.storage_profile.image_reference.sku,
                 "Version", @server.storage_profile.image_reference.version,

--- a/spec/unit/bootstrap_azure_spec.rb
+++ b/spec/unit/bootstrap_azure_spec.rb
@@ -3,8 +3,8 @@
 # Copyright:: Copyright (c) 2016 Opscode, Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::BootstrapAzure do
   include AzureSpecHelper
@@ -14,30 +14,30 @@ describe Chef::Knife::BootstrapAzure do
   before do
     @bootstrap_azure_instance = create_instance(Chef::Knife::BootstrapAzure)
     @service = @bootstrap_azure_instance.service
-    Chef::Config[:knife][:azure_dns_name] = 'test-dns-01'
-    @bootstrap_azure_instance.name_args = ['test-vm-01']
-    @server_role = Azure::Role.new('connection')
+    Chef::Config[:knife][:azure_dns_name] = "test-dns-01"
+    @bootstrap_azure_instance.name_args = ["test-vm-01"]
+    @server_role = Azure::Role.new("connection")
     allow(@bootstrap_azure_instance.ui).to receive(:info)
     allow(@bootstrap_azure_instance).to receive(:puts)
   end
 
-  describe 'parameters validation' do
+  describe "parameters validation" do
     it "raises error when azure_subscription_id is not specified" do
-        Chef::Config[:knife].delete(:azure_subscription_id)
-        expect(@bootstrap_azure_instance.ui).to receive(:error)
-        expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
-      end
+      Chef::Config[:knife].delete(:azure_subscription_id)
+      expect(@bootstrap_azure_instance.ui).to receive(:error)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
+    end
 
     it "raises error when azure_mgmt_cert is not specified" do
       Chef::Config[:knife].delete(:azure_mgmt_cert)
       expect(@bootstrap_azure_instance.ui).to receive(:error)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when azure_api_host_name is not specified" do
       Chef::Config[:knife].delete(:azure_api_host_name)
       expect(@bootstrap_azure_instance.ui).to receive(:error)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when server name is not specified" do
@@ -45,19 +45,19 @@ describe Chef::Knife::BootstrapAzure do
         :length).and_return(0)
       expect(@service).to_not receive(:add_extension)
       expect(@bootstrap_azure_instance.ui).to receive(
-        :error).with('Please specify the SERVER name which needs to be bootstrapped via the Chef Extension.')
+        :error).with("Please specify the SERVER name which needs to be bootstrapped via the Chef Extension.")
       expect(Chef::Log).to receive(:debug)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when more than one server name is specified" do
-      @bootstrap_azure_instance.name_args = ['test-vm-01', 'test-vm-02', 'test-vm-03']
+      @bootstrap_azure_instance.name_args = ["test-vm-01", "test-vm-02", "test-vm-03"]
       expect(@bootstrap_azure_instance.name_args.length).to be == 3
       expect(@service).to_not receive(:add_extension)
       expect(@bootstrap_azure_instance.ui).to receive(
-        :error).with('Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension.')
+        :error).with("Please specify only one SERVER name which needs to be bootstrapped via the Chef Extension.")
       expect(Chef::Log).to receive(:debug)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when server name specified does not exist under the given hosted service" do
@@ -66,9 +66,9 @@ describe Chef::Knife::BootstrapAzure do
       expect(@service).to receive(
         :find_server).and_return(Array.new)
       expect(@bootstrap_azure_instance.ui).to receive(
-        :error).with('Server test-vm-01 does not exist under the hosted service test-dns-01.')
+        :error).with("Server test-vm-01 does not exist under the hosted service test-dns-01.")
       expect(Chef::Log).to receive(:debug)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when hosted service specified does not exist" do
@@ -77,9 +77,9 @@ describe Chef::Knife::BootstrapAzure do
       expect(@service).to receive(
         :find_server).and_return(nil)
       expect(@bootstrap_azure_instance.ui).to receive(
-        :error).with('Hosted service test-dns-01 does not exist.')
+        :error).with("Hosted service test-dns-01 does not exist.")
       expect(Chef::Log).to receive(:debug)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when hosted service name is not given but invalid server name is given" do
@@ -89,20 +89,20 @@ describe Chef::Knife::BootstrapAzure do
       expect(@service).to receive(
         :find_server).and_return(nil)
       expect(@bootstrap_azure_instance.ui).to receive(
-        :error).with('Server test-vm-01 does not exist.')
+        :error).with("Server test-vm-01 does not exist.")
       expect(Chef::Log).to receive(:debug)
-      expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
     end
 
     context "server name specified do exist" do
       context "hosted service name is specified in Chef::Config[:knife] object" do
         before do
-          @server_role.hostedservicename = 'my_new_dns'
+          @server_role.hostedservicename = "my_new_dns"
           allow(@server_role).to receive_message_chain(
-            :os_type, :downcase).and_return('windows')
+            :os_type, :downcase).and_return("windows")
           allow(@server_role).to receive(
-            :deployname).and_return('')
-          allow(@server_role).to receive(:role_xml).and_return('')
+            :deployname).and_return("")
+          allow(@server_role).to receive(:role_xml).and_return("")
           allow(@bootstrap_azure_instance).to receive(
             :get_chef_extension_version)
           allow(@bootstrap_azure_instance).to receive(
@@ -116,21 +116,21 @@ describe Chef::Knife::BootstrapAzure do
           expect(@service).to receive(:add_extension)
           expect(@service).to receive(
             :find_server).and_return(@server_role)
-          expect {@bootstrap_azure_instance.run}.not_to raise_error
-          expect(Chef::Config[:knife][:azure_dns_name]).to be == 'test-dns-01'
-          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be == nil
+          expect { @bootstrap_azure_instance.run }.not_to raise_error
+          expect(Chef::Config[:knife][:azure_dns_name]).to be == "test-dns-01"
+          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be.nil?
         end
       end
 
       context "hosted service name is not specified in Chef::Config[:knife] object or anywhere else" do
         before do
           Chef::Config[:knife].delete(:azure_dns_name)
-          @server_role.hostedservicename = 'my_new_dns'
+          @server_role.hostedservicename = "my_new_dns"
           allow(@server_role).to receive_message_chain(
-            :os_type, :downcase).and_return('windows')
+            :os_type, :downcase).and_return("windows")
           allow(@server_role).to receive(
-            :deployname).and_return('')
-          allow(@server_role).to receive(:role_xml).and_return('')
+            :deployname).and_return("")
+          allow(@server_role).to receive(:role_xml).and_return("")
           allow(@bootstrap_azure_instance).to receive(
             :get_chef_extension_version)
           allow(@bootstrap_azure_instance).to receive(
@@ -144,17 +144,17 @@ describe Chef::Knife::BootstrapAzure do
           expect(@service).to receive(:add_extension)
           expect(@service).to receive(
             :find_server).and_return(@server_role)
-          expect {@bootstrap_azure_instance.run}.not_to raise_error
-          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be == 'my_new_dns'
-          expect(Chef::Config[:knife][:azure_dns_name]).to be == nil
+          expect { @bootstrap_azure_instance.run }.not_to raise_error
+          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be == "my_new_dns"
+          expect(Chef::Config[:knife][:azure_dns_name]).to be.nil?
         end
       end
     end
   end
 
-  describe 'extended_logs functionality' do
-    context 'when extended_logs is false' do
-      it 'deploys the Chef Extension on the server but then does not wait and fetch the chef-client run logs' do
+  describe "extended_logs functionality" do
+    context "when extended_logs is false" do
+      it "deploys the Chef Extension on the server but then does not wait and fetch the chef-client run logs" do
         expect(@bootstrap_azure_instance.name_args.length).to be == 1
         expect(@bootstrap_azure_instance).to receive(:set_ext_params)
         expect(@service).to receive(:add_extension)
@@ -165,12 +165,12 @@ describe Chef::Knife::BootstrapAzure do
       end
     end
 
-    context 'when extended_logs is true' do
+    context "when extended_logs is true" do
       before do
         Chef::Config[:knife][:extended_logs] = true
       end
 
-      it 'deploys the Chef Extension on the server and also waits and fetch the chef-client run logs' do
+      it "deploys the Chef Extension on the server and also waits and fetch the chef-client run logs" do
         expect(@bootstrap_azure_instance.name_args.length).to be == 1
         expect(@bootstrap_azure_instance).to receive(:set_ext_params)
         expect(@service).to receive(:add_extension)
@@ -180,8 +180,8 @@ describe Chef::Knife::BootstrapAzure do
         @bootstrap_azure_instance.run
       end
 
-      context 'when Chef Extension becomes available/ready within the prescribed timeout' do
-        it 'successfully deploys the Chef Extension on the server and also successfully fetches the chef-client run logs without raising any error' do
+      context "when Chef Extension becomes available/ready within the prescribed timeout" do
+        it "successfully deploys the Chef Extension on the server and also successfully fetches the chef-client run logs without raising any error" do
           expect(@bootstrap_azure_instance.name_args.length).to be == 1
           expect(@bootstrap_azure_instance).to receive(:set_ext_params)
           expect(@service).to receive(:add_extension)
@@ -192,8 +192,8 @@ describe Chef::Knife::BootstrapAzure do
         end
       end
 
-      context 'when Chef Extension does not become available/ready within the prescribed timeout' do
-        it 'successfully deploys the Chef Extension on the server but fails to fetch the chef-client run logs as extension is unavailable and so it raises error and exits' do
+      context "when Chef Extension does not become available/ready within the prescribed timeout" do
+        it "successfully deploys the Chef Extension on the server but fails to fetch the chef-client run logs as extension is unavailable and so it raises error and exits" do
           expect(@bootstrap_azure_instance.name_args.length).to be == 1
           expect(@bootstrap_azure_instance).to receive(:set_ext_params)
           expect(@service).to receive(:add_extension)
@@ -212,129 +212,129 @@ describe Chef::Knife::BootstrapAzure do
     end
   end
 
-  describe 'os_type and os_version support validation' do
-    context 'invalid os_type for the given server' do
+  describe "os_type and os_version support validation" do
+    context "invalid os_type for the given server" do
       before do
         allow(@server_role).to receive(
-          :os_type).and_return('Abc')
+          :os_type).and_return("Abc")
       end
 
-      it 'raises an error' do
+      it "raises an error" do
         expect(@service).to receive(
           :find_server).and_return(@server_role)
         expect(@bootstrap_azure_instance.ui).to receive(
-          :error).with('OS type Abc is not supported.')
+          :error).with("OS type Abc is not supported.")
         expect(Chef::Log).to receive(:debug)
-        expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+        expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
       end
     end
 
-    context 'invalid os_version for the given Linux server' do
+    context "invalid os_version for the given Linux server" do
       before do
         allow(@server_role).to receive(
-          :os_type).and_return('Linux')
+          :os_type).and_return("Linux")
         allow(@server_role).to receive(
-          :os_version).and_return('Suse')
+          :os_version).and_return("Suse")
       end
 
-      it 'raises an error' do
+      it "raises an error" do
         expect(@service).to receive(
           :find_server).and_return(@server_role)
         expect(@bootstrap_azure_instance.ui).to receive(
-          :error).with('OS version Suse for OS type Linux is not supported.')
+          :error).with("OS version Suse for OS type Linux is not supported.")
         expect(Chef::Log).to receive(:debug)
-        expect {@bootstrap_azure_instance.run}.to raise_error(SystemExit)
+        expect { @bootstrap_azure_instance.run }.to raise_error(SystemExit)
       end
     end
 
-    context 'valid os_type and valid os_version' do
+    context "valid os_type and valid os_version" do
       before do
         allow(@server_role).to receive(
-          :deployname).and_return('test-deploy-01')
+          :deployname).and_return("test-deploy-01")
         allow(@server_role).to receive(
-          :role_xml).and_return('vm-role-xml')
+          :role_xml).and_return("vm-role-xml")
         allow(@bootstrap_azure_instance).to receive(
-          :get_chef_extension_version).and_return('1210.*')
+          :get_chef_extension_version).and_return("1210.*")
         allow(@bootstrap_azure_instance).to receive(
           :get_chef_extension_public_params).and_return(
-            'chef_ext_public_params')
+            "chef_ext_public_params")
         allow(@bootstrap_azure_instance).to receive(
           :get_chef_extension_private_params).and_return(
-            'chef_ext_private_params')
+            "chef_ext_private_params")
       end
 
-      context 'for Linux' do
+      context "for Linux" do
         before do
           allow(@server_role).to receive(
-            :os_type).and_return('Linux')
+            :os_type).and_return("Linux")
           allow(@server_role).to receive(
-            :os_version).and_return('CentOS')
+            :os_version).and_return("CentOS")
         end
 
-        it 'sets the extension parameters for Linux platform' do
+        it "sets the extension parameters for Linux platform" do
           expect(@service).to receive(
             :find_server).and_return(@server_role)
           response = @bootstrap_azure_instance.set_ext_params
-          expect(response[:chef_extension]).to be == 'LinuxChefClient'
-          expect(response[:azure_dns_name]).to be == 'test-dns-01'
-          expect(response[:deploy_name]).to be == 'test-deploy-01'
-          expect(response[:role_xml]).to be == 'vm-role-xml'
-          expect(response[:azure_vm_name]).to be == 'test-vm-01'
-          expect(response[:chef_extension_publisher]).to be == 'Chef.Bootstrap.WindowsAzure'
-          expect(response[:chef_extension_version]).to be == '1210.*'
-          expect(response[:chef_extension_public_param]).to be == 'chef_ext_public_params'
-          expect(response[:chef_extension_private_param]).to be == 'chef_ext_private_params'
+          expect(response[:chef_extension]).to be == "LinuxChefClient"
+          expect(response[:azure_dns_name]).to be == "test-dns-01"
+          expect(response[:deploy_name]).to be == "test-deploy-01"
+          expect(response[:role_xml]).to be == "vm-role-xml"
+          expect(response[:azure_vm_name]).to be == "test-vm-01"
+          expect(response[:chef_extension_publisher]).to be == "Chef.Bootstrap.WindowsAzure"
+          expect(response[:chef_extension_version]).to be == "1210.*"
+          expect(response[:chef_extension_public_param]).to be == "chef_ext_public_params"
+          expect(response[:chef_extension_private_param]).to be == "chef_ext_private_params"
         end
       end
 
-      context 'for Windows' do
+      context "for Windows" do
         before do
           allow(@server_role).to receive(
-            :os_type).and_return('Windows')
+            :os_type).and_return("Windows")
         end
 
-        it 'sets the extension parameters for Windows platform' do
+        it "sets the extension parameters for Windows platform" do
           expect(@service).to receive(
             :find_server).and_return(@server_role)
           response = @bootstrap_azure_instance.set_ext_params
-          expect(response[:chef_extension]).to be == 'ChefClient'
-          expect(response[:azure_dns_name]).to be == 'test-dns-01'
-          expect(response[:deploy_name]).to be == 'test-deploy-01'
-          expect(response[:role_xml]).to be == 'vm-role-xml'
-          expect(response[:azure_vm_name]).to be == 'test-vm-01'
-          expect(response[:chef_extension_publisher]).to be == 'Chef.Bootstrap.WindowsAzure'
-          expect(response[:chef_extension_version]).to be == '1210.*'
-          expect(response[:chef_extension_public_param]).to be == 'chef_ext_public_params'
-          expect(response[:chef_extension_private_param]).to be == 'chef_ext_private_params'
+          expect(response[:chef_extension]).to be == "ChefClient"
+          expect(response[:azure_dns_name]).to be == "test-dns-01"
+          expect(response[:deploy_name]).to be == "test-deploy-01"
+          expect(response[:role_xml]).to be == "vm-role-xml"
+          expect(response[:azure_vm_name]).to be == "test-vm-01"
+          expect(response[:chef_extension_publisher]).to be == "Chef.Bootstrap.WindowsAzure"
+          expect(response[:chef_extension_version]).to be == "1210.*"
+          expect(response[:chef_extension_public_param]).to be == "chef_ext_public_params"
+          expect(response[:chef_extension_private_param]).to be == "chef_ext_private_params"
         end
       end
     end
   end
 
-  describe 'parse role list xml' do
-    it 'reads os_type and os_version from role list 1 xml' do
-      role_list_1_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/parse_role_list_xml/role_list_1.xml'))
-      role = Azure::Role.new('connection')
+  describe "parse role list xml" do
+    it "reads os_type and os_version from role list 1 xml" do
+      role_list_1_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/parse_role_list_xml/role_list_1.xml"))
+      role = Azure::Role.new("connection")
       role.parse_role_list_xml(role_list_1_xml)
       expect(role.role_xml).to be == role_list_1_xml
-      expect(role.os_type).to be == 'Linux'
-      expect(role.os_version).to be == '842c8b9c6cvxzcvxzcv048xvbvge2323qe4c3__OpenLogic-CentOS-67-20140205'
+      expect(role.os_type).to be == "Linux"
+      expect(role.os_version).to be == "842c8b9c6cvxzcvxzcv048xvbvge2323qe4c3__OpenLogic-CentOS-67-20140205"
     end
 
-    it 'reads os_type and os_version from role list 2 xml' do
-      role_list_2_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/parse_role_list_xml/role_list_2.xml'))
-      role = Azure::Role.new('connection')
+    it "reads os_type and os_version from role list 2 xml" do
+      role_list_2_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/parse_role_list_xml/role_list_2.xml"))
+      role = Azure::Role.new("connection")
       role.parse_role_list_xml(role_list_2_xml)
       expect(role.role_xml).to be == role_list_2_xml
-      expect(role.os_type).to be == 'Windows'
-      expect(role.os_version).to be == 'a6dfsdfwerfdfc0bc8f24rwefsd4ds01__Windows-Server-2012-R2-20141128-en.us-127GB.vhd'
+      expect(role.os_type).to be == "Windows"
+      expect(role.os_version).to be == "a6dfsdfwerfdfc0bc8f24rwefsd4ds01__Windows-Server-2012-R2-20141128-en.us-127GB.vhd"
     end
   end
 
-  describe 'add_extension' do
-    it 'calls role update and prints success message on successful completion' do
+  describe "add_extension" do
+    it "calls role update and prints success message on successful completion" do
       expect(@service.ui).to receive(:info).with(
-        'Started with Chef Extension deployment on the server test-vm-01...')
+        "Started with Chef Extension deployment on the server test-vm-01...")
       expect(@service).to receive_message_chain(
         :connection, :roles, :update)
       expect(@service.ui).to receive(:info).with(
@@ -342,7 +342,7 @@ describe Chef::Knife::BootstrapAzure do
       @service.add_extension(@bootstrap_azure_instance.name_args[0])
     end
 
-    it 'calls role update and raises error on unsuccessful completion' do
+    it "calls role update and raises error on unsuccessful completion" do
       expect(@service).to receive_message_chain(
         :connection, :roles, :update).and_raise
       expect(Chef::Log).to receive(:error)
@@ -351,125 +351,125 @@ describe Chef::Knife::BootstrapAzure do
     end
   end
 
-  describe 'roles_update' do
+  describe "roles_update" do
     before do
-      @roles = Azure::Roles.new('connection')
-      @role = double('Role')
+      @roles = Azure::Roles.new("connection")
+      @role = double("Role")
       allow(Azure::Role).to receive(:new).and_return(@role)
     end
 
-    it 'calls setup_extension and update methods of Role class' do
+    it "calls setup_extension and update methods of Role class" do
       expect(@role).to receive(
         :setup_extension).with({}).and_return(nil)
       expect(@role).to receive(:update).with(
-        @bootstrap_azure_instance.name_args[0],{},nil)
-      @roles.update(@bootstrap_azure_instance.name_args[0],{})
+        @bootstrap_azure_instance.name_args[0], {}, nil)
+      @roles.update(@bootstrap_azure_instance.name_args[0], {})
     end
   end
 
-  describe 'setup_extension' do
+  describe "setup_extension" do
     before do
-      @role = Azure::Role.new('connection')
-      updated_role_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/setup_extension/updated_role.xml'))
+      @role = Azure::Role.new("connection")
+      updated_role_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/setup_extension/updated_role.xml"))
       allow(@role).to receive(:update_role_xml_for_extension).and_return(updated_role_xml)
-      @update_role_xml_for_extension = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/setup_extension/update_role.xml'))
+      @update_role_xml_for_extension = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/setup_extension/update_role.xml"))
       allow(@role).to receive(:puts)
     end
 
-    it 'creates new xml for update role' do
+    it "creates new xml for update role" do
       response = @role.setup_extension({})
       expect(response).to eq(@update_role_xml_for_extension.to_xml)
     end
   end
 
-  describe 'update_role_xml_for_extension' do
+  describe "update_role_xml_for_extension" do
     before do
       @params = {
-        :chef_extension_publisher => 'Chef.Bootstrap.WindowsAzure',
-        :chef_extension_version => '1210.12',
-        :chef_extension_public_param => 'MyPublicParamsValue',
-        :chef_extension_private_param => 'MyPrivateParamsValue',
+        :chef_extension_publisher => "Chef.Bootstrap.WindowsAzure",
+        :chef_extension_version => "1210.12",
+        :chef_extension_public_param => "MyPublicParamsValue",
+        :chef_extension_private_param => "MyPrivateParamsValue",
         :azure_dns_name => Chef::Config[:knife][:azure_dns_name]
       }
-      @role = Azure::Role.new('connection')
+      @role = Azure::Role.new("connection")
     end
 
-    context 'ResourceExtensionReferences node is not present in role xml' do
+    context "ResourceExtensionReferences node is not present in role xml" do
       before do
-        @input_role_1_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_1.xml'))
-        @output_role_1_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_1.xml'))
-        @params[:chef_extension] = 'LinuxChefClient'
+        @input_role_1_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_1.xml"))
+        @output_role_1_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_1.xml"))
+        @params[:chef_extension] = "LinuxChefClient"
       end
 
-      it 'adds ResourceExtensionReferences node with ChefExtension config' do
-        response = @role.update_role_xml_for_extension(@input_role_1_xml.at_css('Role'), @params)
-        expect(response.to_xml).to eq(@output_role_1_xml.at_css('Role').to_xml)
-      end
-    end
-
-    context 'ResourceExtensionReferences node is present in xml but it is empty' do
-      before do
-        @input_role_2_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_2.xml'))
-        @output_role_2_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_2.xml'))
-        @params[:chef_extension] = 'ChefClient'
-      end
-
-      it 'updates ResourceExtensionReferences node with ChefExtension config' do
-        response = @role.update_role_xml_for_extension(@input_role_2_xml.at_css('Role'), @params)
-        expect(response.to_xml).to eq(@output_role_2_xml.at_css('Role').to_xml)
+      it "adds ResourceExtensionReferences node with ChefExtension config" do
+        response = @role.update_role_xml_for_extension(@input_role_1_xml.at_css("Role"), @params)
+        expect(response.to_xml).to eq(@output_role_1_xml.at_css("Role").to_xml)
       end
     end
 
-    context 'ResourceExtensionReferences node is present in role xml but ChefExtension is not installed on the server' do
+    context "ResourceExtensionReferences node is present in xml but it is empty" do
       before do
-        @input_role_3_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_3.xml'))
-        @output_role_3_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_3.xml'))
-        @params[:chef_extension] = 'ChefClient'
+        @input_role_2_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_2.xml"))
+        @output_role_2_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_2.xml"))
+        @params[:chef_extension] = "ChefClient"
       end
 
-      it 'adds ChefExtension config in ResourceExtensionReferences node' do
-        response = @role.update_role_xml_for_extension(@input_role_3_xml.at_css('Role'), @params)
-        expect(response.to_xml).to eq(@output_role_3_xml.at_css('Role').to_xml)
+      it "updates ResourceExtensionReferences node with ChefExtension config" do
+        response = @role.update_role_xml_for_extension(@input_role_2_xml.at_css("Role"), @params)
+        expect(response.to_xml).to eq(@output_role_2_xml.at_css("Role").to_xml)
       end
     end
 
-    context 'ResourceExtensionReferences node is present in role xml and ChefExtension is already installed on the server' do
+    context "ResourceExtensionReferences node is present in role xml but ChefExtension is not installed on the server" do
       before do
-        @input_role_4_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_4.xml'))
-        @params[:chef_extension] = 'LinuxChefClient'
-        @params[:azure_vm_name] = 'test-vm-01'
+        @input_role_3_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_3.xml"))
+        @output_role_3_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/output_role_3.xml"))
+        @params[:chef_extension] = "ChefClient"
       end
 
-      it 'raises an error with message as \'ChefExtension is already installed on the server\'' do
-        expect { @role.update_role_xml_for_extension(@input_role_4_xml.at_css('Role'), @params) }.to raise_error('Chef Extension is already installed on the server test-vm-01.')
+      it "adds ChefExtension config in ResourceExtensionReferences node" do
+        response = @role.update_role_xml_for_extension(@input_role_3_xml.at_css("Role"), @params)
+        expect(response.to_xml).to eq(@output_role_3_xml.at_css("Role").to_xml)
+      end
+    end
+
+    context "ResourceExtensionReferences node is present in role xml and ChefExtension is already installed on the server" do
+      before do
+        @input_role_4_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/update_role_xml_for_extension/input_role_4.xml"))
+        @params[:chef_extension] = "LinuxChefClient"
+        @params[:azure_vm_name] = "test-vm-01"
+      end
+
+      it "raises an error with message as 'ChefExtension is already installed on the server'" do
+        expect { @role.update_role_xml_for_extension(@input_role_4_xml.at_css("Role"), @params) }.to raise_error("Chef Extension is already installed on the server test-vm-01.")
       end
     end
   end
 
-  describe 'role_update' do
+  describe "role_update" do
     before do
-      @role = Azure::Role.new('connection')
-      @role.connection = double('Connection')
+      @role = Azure::Role.new("connection")
+      @role.connection = double("Connection")
       allow(@role).to receive(:puts)
     end
 
-    it 'does not raise error on update role success' do
+    it "does not raise error on update role success" do
       expect(@role.connection).to receive(:query_azure)
-      expect(@role).to receive(:error_from_response_xml).and_return(['', ''])
+      expect(@role).to receive(:error_from_response_xml).and_return(["", ""])
       expect(Chef::Log).to_not receive(:debug)
-      expect { @role.update(@bootstrap_azure_instance.name_args[0], {}, '') }.not_to raise_error
+      expect { @role.update(@bootstrap_azure_instance.name_args[0], {}, "") }.not_to raise_error
     end
 
-    it 'raises an error on update role failure' do
+    it "raises an error on update role failure" do
       expect(@role.connection).to receive(:query_azure)
       expect(@role).to receive(:error_from_response_xml).
-        and_return(['InvalidXmlRequest', 'The request body\'s XML was invalid or not correctly specified.'])
+        and_return(["InvalidXmlRequest", "The request body's XML was invalid or not correctly specified."])
       expect(Chef::Log).to receive(:debug)
-      expect { @role.update(@bootstrap_azure_instance.name_args[0], {}, '') }.to raise_error('Unable to update role:InvalidXmlRequest : The request body\'s XML was invalid or not correctly specified.')
+      expect { @role.update(@bootstrap_azure_instance.name_args[0], {}, "") }.to raise_error("Unable to update role:InvalidXmlRequest : The request body's XML was invalid or not correctly specified.")
     end
   end
 
-  describe 'get_chef_extension_version' do
+  describe "get_chef_extension_version" do
     before do
       allow(@service).to receive(:instance_of?).with(
         Azure::ResourceManagement::ARMInterface).and_return(false)
@@ -477,55 +477,55 @@ describe Chef::Knife::BootstrapAzure do
         Azure::ServiceManagement::ASMInterface).and_return(true)
     end
 
-    context 'when extension version is set in knife.rb' do
+    context "when extension version is set in knife.rb" do
       before do
-        Chef::Config[:knife][:azure_chef_extension_version] = '1012.10'
+        Chef::Config[:knife][:azure_chef_extension_version] = "1012.10"
       end
 
-      it 'will pick up the extension version from knife.rb' do
-        response = @bootstrap_azure_instance.get_chef_extension_version('MyChefClient')
-        expect(response).to be == '1012.10'
+      it "will pick up the extension version from knife.rb" do
+        response = @bootstrap_azure_instance.get_chef_extension_version("MyChefClient")
+        expect(response).to be == "1012.10"
       end
     end
 
-    context 'when extension version is not set in knife.rb' do
+    context "when extension version is not set in knife.rb" do
       before do
         Chef::Config[:knife].delete(:azure_chef_extension_version)
-        extensions_list_xml = Nokogiri::XML(readFile('bootstrap_azure_role_xmls/extensions_list.xml'))
+        extensions_list_xml = Nokogiri::XML(readFile("bootstrap_azure_role_xmls/extensions_list.xml"))
         allow(@service).to receive(
           :get_extension).and_return(extensions_list_xml)
       end
 
-      it 'will pick up the latest version of the extension' do
+      it "will pick up the latest version of the extension" do
         expect(@service).to_not receive(:get_latest_chef_extension_version)
-        response = @bootstrap_azure_instance.get_chef_extension_version('MyChefClient')
-        expect(response).to be == '1210.*'
+        response = @bootstrap_azure_instance.get_chef_extension_version("MyChefClient")
+        expect(response).to be == "1210.*"
       end
     end
   end
 
-  describe 'wait_until_extension_available' do
-    context 'extension_availaibility_wait_time has exceeded the extension_availaibility_wait_timeout' do
+  describe "wait_until_extension_available" do
+    context "extension_availaibility_wait_time has exceeded the extension_availaibility_wait_timeout" do
       before do
         @start_time = Time.now
       end
 
-      it 'raises error saying unable to fetch chef-client run logs' do
+      it "raises error saying unable to fetch chef-client run logs" do
         expect { @bootstrap_azure_instance.wait_until_extension_available(@start_time, -1) }.to raise_error(
           "\nUnable to fetch chef-client run logs as Chef Extension seems to be unavailable even after -1 minutes of its deployment.\n"
         )
       end
     end
 
-    context 'extension_availaibility_wait_time has not exceeded the extension_availaibility_wait_timeout' do
-      context 'deployment not available' do
+    context "extension_availaibility_wait_time has not exceeded the extension_availaibility_wait_timeout" do
+      context "deployment not available" do
         before do
           @start_time = Time.now
-          deployment = Nokogiri::XML('')
+          deployment = Nokogiri::XML("")
           allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
         end
 
-        it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+        it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
           mock_recursive_call
           expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
           expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -535,15 +535,15 @@ describe Chef::Knife::BootstrapAzure do
         end
       end
 
-      context 'deployment available' do
-        context 'given role not available' do
+      context "deployment available" do
+        context "given role not available" do
           before do
             @start_time = Time.now
-            deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+            deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
             allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
           end
 
-          it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+          it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
             mock_recursive_call
             expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
             expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -553,16 +553,16 @@ describe Chef::Knife::BootstrapAzure do
           end
         end
 
-        context 'given role available' do
-          context 'GuestAgent not ready' do
+        context "given role available" do
+          context "GuestAgent not ready" do
             before do
-              @bootstrap_azure_instance.name_args = [ 'vm05' ]
+              @bootstrap_azure_instance.name_args = [ "vm05" ]
               @start_time = Time.now
-              deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+              deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
               allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
             end
 
-            it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+            it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
               mock_recursive_call
               expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
               expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -572,16 +572,16 @@ describe Chef::Knife::BootstrapAzure do
             end
           end
 
-          context 'GuestAgent ready' do
-            context 'none of the extension status available' do
+          context "GuestAgent ready" do
+            context "none of the extension status available" do
               before do
-                @bootstrap_azure_instance.name_args = [ 'vm06' ]
+                @bootstrap_azure_instance.name_args = [ "vm06" ]
                 @start_time = Time.now
-                deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                 allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
               end
 
-              it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+              it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
                 mock_recursive_call
                 expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
                 expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -591,16 +591,16 @@ describe Chef::Knife::BootstrapAzure do
               end
             end
 
-            context 'extension status(es) available apart from extension status for Chef Extension' do
-              context 'example-1' do
+            context "extension status(es) available apart from extension status for Chef Extension" do
+              context "example-1" do
                 before do
-                  @bootstrap_azure_instance.name_args = [ 'vm01' ]
+                  @bootstrap_azure_instance.name_args = [ "vm01" ]
                   @start_time = Time.now
-                  deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                  deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                   allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
                 end
 
-                it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+                it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
                   mock_recursive_call
                   expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
                   expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -610,15 +610,15 @@ describe Chef::Knife::BootstrapAzure do
                 end
               end
 
-              context 'example-2' do
+              context "example-2" do
                 before do
-                  @bootstrap_azure_instance.name_args = [ 'vm07' ]
+                  @bootstrap_azure_instance.name_args = [ "vm07" ]
                   @start_time = Time.now
-                  deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                  deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                   allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
                 end
 
-                it 'goes to sleep and then re-invokes the wait_until_extension_available method recursively' do
+                it "goes to sleep and then re-invokes the wait_until_extension_available method recursively" do
                   mock_recursive_call
                   expect(@bootstrap_azure_instance).to receive(:print).exactly(1).times
                   expect(@bootstrap_azure_instance).to receive(:sleep).with(30)
@@ -629,16 +629,16 @@ describe Chef::Knife::BootstrapAzure do
               end
             end
 
-            context 'extension status(es) available including extension status for Chef Extension' do
-              context 'example-1' do
+            context "extension status(es) available including extension status for Chef Extension" do
+              context "example-1" do
                 before do
-                  @bootstrap_azure_instance.name_args = [ 'vm02' ]
+                  @bootstrap_azure_instance.name_args = [ "vm02" ]
                   @start_time = Time.now
-                  deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                  deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                   allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
                 end
 
-                it 'does not go to sleep and does not re-invoke the wait_until_extension_available method recursively' do
+                it "does not go to sleep and does not re-invoke the wait_until_extension_available method recursively" do
                   mock_recursive_call
                   expect(@bootstrap_azure_instance).to_not receive(:print)
                   expect(@bootstrap_azure_instance).to_not receive(:sleep).with(30)
@@ -648,15 +648,15 @@ describe Chef::Knife::BootstrapAzure do
                 end
               end
 
-              context 'example-2' do
+              context "example-2" do
                 before do
-                  @bootstrap_azure_instance.name_args = [ 'vm03' ]
+                  @bootstrap_azure_instance.name_args = [ "vm03" ]
                   @start_time = Time.now
-                  deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                  deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                   allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
                 end
 
-                it 'does not go to sleep and does not re-invoke the wait_until_extension_available method recursively' do
+                it "does not go to sleep and does not re-invoke the wait_until_extension_available method recursively" do
                   mock_recursive_call
                   expect(@bootstrap_azure_instance).to_not receive(:print)
                   expect(@bootstrap_azure_instance).to_not receive(:sleep).with(30)
@@ -666,15 +666,15 @@ describe Chef::Knife::BootstrapAzure do
                 end
               end
 
-              context 'example-3' do
+              context "example-3" do
                 before do
-                  @bootstrap_azure_instance.name_args = [ 'vm08' ]
+                  @bootstrap_azure_instance.name_args = [ "vm08" ]
                   @start_time = Time.now
-                  deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+                  deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
                   allow(@bootstrap_azure_instance).to receive(:fetch_deployment).and_return(deployment)
                 end
 
-                it 'does not go to sleep and does not re-invoke the wait_until_extension_available method recursively' do
+                it "does not go to sleep and does not re-invoke the wait_until_extension_available method recursively" do
                   mock_recursive_call
                   expect(@bootstrap_azure_instance).to_not receive(:print)
                   expect(@bootstrap_azure_instance).to_not receive(:sleep).with(30)
@@ -690,21 +690,21 @@ describe Chef::Knife::BootstrapAzure do
     end
   end
 
-  describe 'fetch_deployment' do
+  describe "fetch_deployment" do
     before do
       allow(@bootstrap_azure_instance.service).to receive(
-        :deployment_name).and_return('deploymentExtension')
-      deployment = Nokogiri::XML readFile('extension_deployment_xml.xml')
+        :deployment_name).and_return("deploymentExtension")
+      deployment = Nokogiri::XML readFile("extension_deployment_xml.xml")
       allow(@bootstrap_azure_instance.service).to receive(
         :deployment).and_return(deployment)
     end
 
-    it 'returns the deployment' do
+    it "returns the deployment" do
       response = @bootstrap_azure_instance.fetch_deployment
       expect(response).to_not be nil
-      expect(response.at_css('Deployment Name').text).to be == 'deploymentExtension'
-      expect(response.css('RoleInstanceList RoleInstance RoleName').class).to be == Nokogiri::XML::NodeSet
-      expect(response.css('RoleInstanceList RoleInstance RoleName').children.count).to be == 8
+      expect(response.at_css("Deployment Name").text).to be == "deploymentExtension"
+      expect(response.css("RoleInstanceList RoleInstance RoleName").class).to be == Nokogiri::XML::NodeSet
+      expect(response.css("RoleInstanceList RoleInstance RoleName").children.count).to be == 8
     end
   end
 
@@ -716,4 +716,3 @@ describe Chef::Knife::BootstrapAzure do
     end
   end
 end
-

--- a/spec/unit/bootstrap_azure_spec.rb
+++ b/spec/unit/bootstrap_azure_spec.rb
@@ -118,7 +118,7 @@ describe Chef::Knife::BootstrapAzure do
             :find_server).and_return(@server_role)
           expect { @bootstrap_azure_instance.run }.not_to raise_error
           expect(Chef::Config[:knife][:azure_dns_name]).to be == "test-dns-01"
-          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be.nil?
+          expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be_nil
         end
       end
 
@@ -146,7 +146,7 @@ describe Chef::Knife::BootstrapAzure do
             :find_server).and_return(@server_role)
           expect { @bootstrap_azure_instance.run }.not_to raise_error
           expect(@bootstrap_azure_instance.config[:azure_dns_name]).to be == "my_new_dns"
-          expect(Chef::Config[:knife][:azure_dns_name]).to be.nil?
+          expect(Chef::Config[:knife][:azure_dns_name]).to be_nil
         end
       end
     end

--- a/spec/unit/bootstrap_azure_spec.rb
+++ b/spec/unit/bootstrap_azure_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aliasgar Batterywala (<aliasgar.batterywala@clogeny.com>)
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")

--- a/spec/unit/bootstrap_azurerm_spec.rb
+++ b/spec/unit/bootstrap_azurerm_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@clogeny.com>)
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")

--- a/spec/unit/bootstrap_azurerm_spec.rb
+++ b/spec/unit/bootstrap_azurerm_spec.rb
@@ -3,8 +3,8 @@
 # Copyright:: Copyright (c) 2016 Opscode, Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::BootstrapAzurerm do
   include AzureSpecHelper
@@ -14,9 +14,9 @@ describe Chef::Knife::BootstrapAzurerm do
   before do
     @bootstrap_azurerm_instance = create_arm_instance(Chef::Knife::BootstrapAzurerm)
     @service = @bootstrap_azurerm_instance.service
-    @bootstrap_azurerm_instance.name_args = ['test-vm-01']
-    Chef::Config[:knife][:azure_resource_group_name] = 'test-rgp-01'
-    Chef::Config[:knife][:azure_service_location] = 'West US'
+    @bootstrap_azurerm_instance.name_args = ["test-vm-01"]
+    Chef::Config[:knife][:azure_resource_group_name] = "test-rgp-01"
+    Chef::Config[:knife][:azure_service_location] = "West US"
 
     @compute_client = double("ComputeManagementClient")
     allow(@bootstrap_azurerm_instance.service).to receive(
@@ -26,7 +26,7 @@ describe Chef::Knife::BootstrapAzurerm do
   context "parameters validation" do
     it "raises error when server name is not given in the args" do
       allow(@bootstrap_azurerm_instance.name_args).to receive(:length).and_return(0)
-      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with('Validating...')
+      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with("Validating...")
       expect(@bootstrap_azurerm_instance).to receive(:validate_arm_keys!)
       expect(@service).to_not receive(:create_vm_extension)
       expect(@bootstrap_azurerm_instance.ui).to receive(
@@ -37,22 +37,22 @@ describe Chef::Knife::BootstrapAzurerm do
 
     it "raises error when azure_resource_group_name is not specified" do
       Chef::Config[:knife].delete(:azure_resource_group_name)
-      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with('Validating...')
+      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with("Validating...")
       expect(@bootstrap_azurerm_instance.ui).to receive(:error)
-      expect {@bootstrap_azurerm_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azurerm_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when azure_service_location is not specified" do
       Chef::Config[:knife].delete(:azure_service_location)
-      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with('Validating...')
+      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with("Validating...")
       expect(@bootstrap_azurerm_instance.ui).to receive(:error)
-      expect {@bootstrap_azurerm_instance.run}.to raise_error(SystemExit)
+      expect { @bootstrap_azurerm_instance.run }.to raise_error(SystemExit)
     end
 
     it "raises error when more than one server name is specified" do
-      @bootstrap_azurerm_instance.name_args = ['test-vm-01', 'test-vm-02', 'test-vm-03']
+      @bootstrap_azurerm_instance.name_args = ["test-vm-01", "test-vm-02", "test-vm-03"]
       expect(@bootstrap_azurerm_instance.name_args.length).to be == 3
-      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with('Validating...')
+      expect(@bootstrap_azurerm_instance.ui).to receive(:log).with("Validating...")
       expect(@service).to_not receive(:create_vm_extension)
       expect(@bootstrap_azurerm_instance.ui).to receive(
         :error).twice
@@ -93,14 +93,14 @@ describe Chef::Knife::BootstrapAzurerm do
       allow(@bootstrap_azurerm_instance).to receive(:get_chef_extension_public_params).and_return("public_params")
       allow(@bootstrap_azurerm_instance).to receive(:get_chef_extension_private_params).and_return("private_params")
       response = @bootstrap_azurerm_instance.set_ext_params
-      expect(response[:chef_extension]).to be == 'ChefClient'
-      expect(response[:azure_resource_group_name]).to be == 'test-rgp-01'
-      expect(response[:azure_vm_name]).to be == 'test-vm-01'
-      expect(response[:azure_service_location]).to be == 'West US'
-      expect(response[:chef_extension_publisher]).to be == 'Chef.Bootstrap.WindowsAzure'
-      expect(response[:chef_extension_version]).to be == '1210.*'
-      expect(response[:chef_extension_public_param]).to be == 'public_params'
-      expect(response[:chef_extension_private_param]).to be == 'private_params'
+      expect(response[:chef_extension]).to be == "ChefClient"
+      expect(response[:azure_resource_group_name]).to be == "test-rgp-01"
+      expect(response[:azure_vm_name]).to be == "test-vm-01"
+      expect(response[:azure_service_location]).to be == "West US"
+      expect(response[:chef_extension_publisher]).to be == "Chef.Bootstrap.WindowsAzure"
+      expect(response[:chef_extension_version]).to be == "1210.*"
+      expect(response[:chef_extension_public_param]).to be == "public_params"
+      expect(response[:chef_extension_private_param]).to be == "private_params"
     end
 
     it "sets LinuxChefClient extension in the ext_params for linux" do
@@ -113,14 +113,14 @@ describe Chef::Knife::BootstrapAzurerm do
       allow(@bootstrap_azurerm_instance).to receive(:get_chef_extension_public_params).and_return("public_params")
       allow(@bootstrap_azurerm_instance).to receive(:get_chef_extension_private_params).and_return("private_params")
       response = @bootstrap_azurerm_instance.set_ext_params
-      expect(response[:chef_extension]).to be == 'LinuxChefClient'
-      expect(response[:azure_resource_group_name]).to be == 'test-rgp-01'
-      expect(response[:azure_vm_name]).to be == 'test-vm-01'
-      expect(response[:azure_service_location]).to be == 'West US'
-      expect(response[:chef_extension_publisher]).to be == 'Chef.Bootstrap.WindowsAzure'
-      expect(response[:chef_extension_version]).to be == '1210.*'
-      expect(response[:chef_extension_public_param]).to be == 'public_params'
-      expect(response[:chef_extension_private_param]).to be == 'private_params'
+      expect(response[:chef_extension]).to be == "LinuxChefClient"
+      expect(response[:azure_resource_group_name]).to be == "test-rgp-01"
+      expect(response[:azure_vm_name]).to be == "test-vm-01"
+      expect(response[:azure_service_location]).to be == "West US"
+      expect(response[:chef_extension_publisher]).to be == "Chef.Bootstrap.WindowsAzure"
+      expect(response[:chef_extension_version]).to be == "1210.*"
+      expect(response[:chef_extension_public_param]).to be == "public_params"
+      expect(response[:chef_extension_private_param]).to be == "private_params"
     end
 
     it "raises error if an offer of OS_type linux is not supported" do
@@ -140,7 +140,7 @@ describe Chef::Knife::BootstrapAzurerm do
     it "creates VM extension with no extended log option passed" do
       @server = double("server", :name => "foo", :id => 1)
       vm_extension = double("vm_extension", :name => "foo", :id => 1)
-      public_params = {:extendedLogs => "false"}
+      public_params = { :extendedLogs => "false" }
       allow(@service).to receive(:find_server).and_return(@server)
       allow(@service).to receive(:extension_already_installed?).and_return(false)
       allow(@server).to receive_message_chain(:storage_profile, :os_disk, :os_type).and_return("linux")
@@ -157,7 +157,7 @@ describe Chef::Knife::BootstrapAzurerm do
     it "creates VM extension with extended log option passed" do
       @server = double("server", :name => "foo", :id => 1)
       vm_extension = double("vm_extension", :name => "foo", :id => 1)
-      public_params = {:extendedLogs => "true"}
+      public_params = { :extendedLogs => "true" }
       allow(@service).to receive(:find_server).and_return(@server)
       allow(@service).to receive(:extension_already_installed?).and_return(false)
       allow(@server).to receive_message_chain(:storage_profile, :os_disk, :os_type).and_return("linux")
@@ -176,7 +176,7 @@ describe Chef::Knife::BootstrapAzurerm do
   context "find_server" do
     it "returns error if the server or resource group doesn't exist" do
       allow(@compute_client).to receive_message_chain(:virtual_machines, :get).and_return(nil)
-      response = @service.find_server('test-vm-01', 'test-rgp-01')
+      response = @service.find_server("test-vm-01", "test-rgp-01")
       expect(response).to be(nil)
     end
   end
@@ -204,56 +204,56 @@ describe Chef::Knife::BootstrapAzurerm do
     end
   end
 
-  describe 'get_chef_extension_version' do
+  describe "get_chef_extension_version" do
     before do
       allow(@service).to receive(:instance_of?).with(
         Azure::ResourceManagement::ARMInterface).and_return(true)
     end
 
-    context 'when extension version is set in knife.rb' do
+    context "when extension version is set in knife.rb" do
       before do
-        Chef::Config[:knife][:azure_chef_extension_version] = '1312.11'
+        Chef::Config[:knife][:azure_chef_extension_version] = "1312.11"
       end
 
-      it 'will pick up the extension version from knife.rb' do
-        response = @bootstrap_azurerm_instance.get_chef_extension_version('MyChefClient')
-        expect(response).to be == '1312.11'
+      it "will pick up the extension version from knife.rb" do
+        response = @bootstrap_azurerm_instance.get_chef_extension_version("MyChefClient")
+        expect(response).to be == "1312.11"
       end
     end
 
-    context 'when extension version is not set in knife.rb' do
+    context "when extension version is not set in knife.rb" do
       before do
         Chef::Config[:knife].delete(:azure_chef_extension_version)
         allow(@service).to receive(
-          :get_latest_chef_extension_version).and_return('1213.14')
+          :get_latest_chef_extension_version).and_return("1213.14")
       end
 
-      it 'will pick up the latest version of the extension' do
+      it "will pick up the latest version of the extension" do
         expect(@service).to_not receive(:get_extension)
-        response = @bootstrap_azurerm_instance.get_chef_extension_version('MyChefClient')
-        expect(response).to be == '1213.14'
+        response = @bootstrap_azurerm_instance.get_chef_extension_version("MyChefClient")
+        expect(response).to be == "1213.14"
       end
     end
   end
 
-  describe 'get_chef_extension_public_params' do
-    context 'service is an instance_of ARM' do
+  describe "get_chef_extension_public_params" do
+    context "service is an instance_of ARM" do
       before do
         allow(@service).to receive(:instance_of?).and_return(true)
       end
 
-      it 'does not set hints in extension\'s public config parameters' do
+      it "does not set hints in extension's public config parameters" do
         response = @bootstrap_azurerm_instance.get_chef_extension_public_params
         expect(response.has_key? :hints).to be == false
       end
     end
 
-    context 'service is not an instance_of ARM' do
+    context "service is not an instance_of ARM" do
       before do
         allow(@service).to receive(:instance_of?).and_return(false)
       end
 
-      it 'does not set hints in extension\'s public config parameters' do
+      it "does not set hints in extension's public config parameters" do
         response = @bootstrap_azurerm_instance.get_chef_extension_public_params
         expect(response.has_key? :hints).to be == false
       end

--- a/spec/unit/certificate_spec.rb
+++ b/spec/unit/certificate_spec.rb
@@ -1,16 +1,16 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
-describe 'certificates' do
+describe "certificates" do
   include AzureSpecHelper
   include QueryAzureMock
 
   before do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -18,13 +18,13 @@ describe 'certificates' do
     @connection = @server_instance.service.connection
   end
 
-  describe 'get_certificate' do
-    it "gets certificates for given dns name and fingerprint" do      
+  describe "get_certificate" do
+    it "gets certificates for given dns name and fingerprint" do
       certificate = @connection.certificates.get_certificate("unknown_yet", "7dbcac68f670a27cf5d9a4e6c4a8d097bff645e2")
       expect(certificate).not_to be_empty
     end
 
-    it "it returns empty array if certificate not found" do      
+    it "it returns empty array if certificate not found" do
       certificate = @connection.certificates.get_certificate("unknown_yet", "9dbcac68f670a27cf5d9a4e6c4a8d097bff645e2")
       expect(certificate).to be_empty
     end

--- a/spec/unit/deploys_list_spec.rb
+++ b/spec/unit/deploys_list_spec.rb
@@ -1,15 +1,15 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 describe "deploys" do
-include AzureSpecHelper
+  include AzureSpecHelper
   include QueryAzureMock
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -18,8 +18,8 @@ include AzureSpecHelper
     @connection = @server_instance.service.connection
   end
 
-  specify {expect(@connection.deploys.all.length).to be > 0}
-  it 'each deployment should have values' do
+  specify { expect(@connection.deploys.all.length).to be > 0 }
+  it "each deployment should have values" do
     @connection.deploys.all.each do |deploy|
       expect(deploy.name).to_not be nil
       expect(deploy.status).to_not be nil
@@ -27,7 +27,7 @@ include AzureSpecHelper
       expect(deploy.roles.length).to be > 0
     end
   end
-  it 'each role should have values' do
+  it "each role should have values" do
     @connection.deploys.all.each do |deploy|
     #describe_deploy deploy
       deploy.roles.each do |role|
@@ -44,24 +44,25 @@ include AzureSpecHelper
     end
   end
   def describe_deploy(deploy)
-      puts '============================='
-      puts 'deployed service: ' + deploy.hostedservicename + '  deployment: ' + deploy.name
+    puts "============================="
+    puts "deployed service: " + deploy.hostedservicename + "  deployment: " + deploy.name
   end
+
   def describe_role(role)
-        puts 'role: ' + role.name
-        puts 'status: ' + role.status
-        puts 'size: ' + role.size
-        puts 'ip address: ' + role.ipaddress
-        puts 'ssh port: ' + role.sshport
-        puts 'ssh ip address: ' + role.publicipaddress
-        role.tcpports.each do |port|
-          puts ' tcp: ' + port['Name'] + ' ' + port['Vip'] + ' ' +
-            port['PublicPort'] + ' ' + port['LocalPort']
-        end
-        role.udpports.each do |port|
-          puts ' udp: ' + port['Name'] + ' ' + port['Vip'] + ' ' +
-            port['PublicPort'] + ' ' + port['LocalPort']
-        end
-        puts '============================='
+    puts "role: " + role.name
+    puts "status: " + role.status
+    puts "size: " + role.size
+    puts "ip address: " + role.ipaddress
+    puts "ssh port: " + role.sshport
+    puts "ssh ip address: " + role.publicipaddress
+    role.tcpports.each do |port|
+      puts " tcp: " + port["Name"] + " " + port["Vip"] + " " +
+        port["PublicPort"] + " " + port["LocalPort"]
+    end
+    role.udpports.each do |port|
+      puts " udp: " + port["Name"] + " " + port["Vip"] + " " +
+        port["PublicPort"] + " " + port["LocalPort"]
+    end
+    puts "============================="
   end
 end

--- a/spec/unit/disks_spec.rb
+++ b/spec/unit/disks_spec.rb
@@ -1,15 +1,15 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 describe "disks" do
   include AzureSpecHelper
   include QueryAzureMock
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -18,7 +18,7 @@ describe "disks" do
     @connection = @server_instance.service.connection
   end
 
-  context 'mock with actually retrieved values' do
+  context "mock with actually retrieved values" do
     it "should find strings" do
       items = @connection.disks.all
       expect(items.length).to be > 1
@@ -28,7 +28,7 @@ describe "disks" do
     end
     it "should contain an attached disk" do
       items = @connection.disks.all
-      count = 0;
+      count = 0
       items.each do |item|
         if item.attached == true
           count += 1
@@ -38,7 +38,7 @@ describe "disks" do
     end
     it "should contain unattached disks" do
       items = @connection.disks.all
-      count = 0;
+      count = 0
       items.each do |item|
         if item.attached == false
           count += 1

--- a/spec/unit/hosts_spec.rb
+++ b/spec/unit/hosts_spec.rb
@@ -1,15 +1,15 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 describe "hosts" do
   include AzureSpecHelper
   include QueryAzureMock
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -18,8 +18,8 @@ describe "hosts" do
     @connection = @server_instance.service.connection
   end
 
-  context 'get all hosts' do
-    specify {expect(@connection.hosts.all.length).to be > 1}
+  context "get all hosts" do
+    specify { expect(@connection.hosts.all.length).to be > 1 }
     it "entry fields should not be nil" do
       items = @connection.hosts.all
       items.each do |host|
@@ -33,42 +33,41 @@ describe "hosts" do
         expect(host.status).to_not be nil
       end
     end
-    specify {expect(@connection.hosts.exists?("notExpectedName")).to be == false}
-    specify {expect(@connection.hosts.exists?("service001")).to be == true}
+    specify { expect(@connection.hosts.exists?("notExpectedName")).to be == false }
+    specify { expect(@connection.hosts.exists?("service001")).to be == true }
   end
 
-  context 'create a new host with service location' do
-    it 'using explicit parameters it should pass in expected body' do
-      params = {:azure_dns_name=>'service003', :azure_service_location=>'West US', 'hosted_azure_service_location'=>'Windows Azure Preview'}
+  context "create a new host with service location" do
+    it "using explicit parameters it should pass in expected body" do
+      params = { :azure_dns_name => "service003", :azure_service_location => "West US", "hosted_azure_service_location" => "Windows Azure Preview" }
       host = @connection.hosts.create(params)
-      expect(@postname).to be == 'hostedservices'
-      expect(@postverb).to be == 'post'
-      expect(@postbody).to eq(readFile('create_host_location.xml'))
+      expect(@postname).to be == "hostedservices"
+      expect(@postverb).to be == "post"
+      expect(@postbody).to eq(readFile("create_host_location.xml"))
     end
-    it 'using default parameters it should pass in expected body' do
-      params = {:azure_dns_name=>'service003', :azure_service_location=>'West US'}
+    it "using default parameters it should pass in expected body" do
+      params = { :azure_dns_name => "service003", :azure_service_location => "West US" }
       host = @connection.hosts.create(params)
-      expect(@postname).to be == 'hostedservices'
-      expect(@postverb).to be == 'post'
-      expect(@postbody).to eq(readFile('create_host_location.xml'))
-    end
-  end
-  context 'create a new host with affinity group' do
-    it 'using explicit parameters it should pass in expected body' do
-      params = {:azure_dns_name=>'service003', :azure_affinity_group=>'test-affinity' }
-      host = @connection.hosts.create(params)
-      expect(@postname).to be == 'hostedservices'
-      expect(@postverb).to be == 'post'
-      expect(@postbody).to eq(readFile('create_host_affinity.xml'))
+      expect(@postname).to be == "hostedservices"
+      expect(@postverb).to be == "post"
+      expect(@postbody).to eq(readFile("create_host_location.xml"))
     end
   end
-  context 'delete a host' do
-    it 'should pass in correct name, verb, and body' do
-      @connection.hosts.delete('service001');
-      expect(@deletename).to be == 'hostedservices/service001'
-      expect(@deleteverb).to be == 'delete'
+  context "create a new host with affinity group" do
+    it "using explicit parameters it should pass in expected body" do
+      params = { :azure_dns_name => "service003", :azure_affinity_group => "test-affinity" }
+      host = @connection.hosts.create(params)
+      expect(@postname).to be == "hostedservices"
+      expect(@postverb).to be == "post"
+      expect(@postbody).to eq(readFile("create_host_affinity.xml"))
+    end
+  end
+  context "delete a host" do
+    it "should pass in correct name, verb, and body" do
+      @connection.hosts.delete("service001")
+      expect(@deletename).to be == "hostedservices/service001"
+      expect(@deleteverb).to be == "delete"
       expect(@deletebody).to be nil
     end
   end
 end
-

--- a/spec/unit/images_spec.rb
+++ b/spec/unit/images_spec.rb
@@ -1,15 +1,15 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 describe "images" do
   include AzureSpecHelper
   include QueryAzureMock
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -18,7 +18,7 @@ describe "images" do
     @connection = @server_instance.service.connection
   end
 
-  context 'mock with actually retrieved values' do
+  context "mock with actually retrieved values" do
     it "should find strings" do
       items = @connection.images.all
       expect(items.length).to be > 1
@@ -35,7 +35,7 @@ describe "images" do
       items = @connection.images.all
       foundLinux = false
       items.each do |item|
-        if item.os == 'Linux'
+        if item.os == "Linux"
           foundLinux = true
         end
       end

--- a/spec/unit/query_azure_mock.rb
+++ b/spec/unit/query_azure_mock.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 module QueryAzureMock
   include AzureUtility
@@ -8,33 +8,33 @@ module QueryAzureMock
 
   def create_instance(object)
     @server_instance = object.new
-      {
-        azure_subscription_id: 'azure_subscription_id',
-        azure_mgmt_cert: @cert_file,
-        azure_api_host_name: 'preview.core.windows-int.net',
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      azure_subscription_id: "azure_subscription_id",
+      azure_mgmt_cert: @cert_file,
+      azure_api_host_name: "preview.core.windows-int.net",
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
 
     @server_instance
   end
 
   def create_arm_instance(object)
     @server_instance = object.new
-      {
-        azure_subscription_id: 'azure_subscription_id',
-        azure_tenant_id: 'azure_tenant_id',
-        azure_client_id: 'azure_client_id',
-        azure_client_secret: 'azure_client_secret',
-        azure_resource_group_name: 'test-rgrp',
-        azure_vm_name: 'test-vm',
-        azure_service_location: 'West Europe',
-        ssh_user: 'test-user',
-        validation_key: '/tmp/validation_key',
-        winrm_password: 'admin_password'
-      }.each do |key, value|
-          Chef::Config[:knife][key] = value
-        end
+    {
+      azure_subscription_id: "azure_subscription_id",
+      azure_tenant_id: "azure_tenant_id",
+      azure_client_id: "azure_client_id",
+      azure_client_secret: "azure_client_secret",
+      azure_resource_group_name: "test-rgrp",
+      azure_vm_name: "test-vm",
+      azure_service_location: "West Europe",
+      ssh_user: "test-user",
+      validation_key: "/tmp/validation_key",
+      winrm_password: "admin_password"
+    }.each do |key, value|
+      Chef::Config[:knife][key] = value
+    end
 
     stub_resource_groups
     @server_instance
@@ -42,9 +42,9 @@ module QueryAzureMock
 
   def stub_resource_group_create_response
     resource_group = OpenStruct.new
-    resource_group.name = 'test-rgrp'
-    resource_group.id = 'myrgrp'
-    resource_group.location = 'West Europe'
+    resource_group.name = "test-rgrp"
+    resource_group.id = "myrgrp"
+    resource_group.location = "West Europe"
     resource_group
   end
 
@@ -54,7 +54,7 @@ module QueryAzureMock
     allow(resource_management_client.resource_groups).to receive(
       :create_or_update).and_return(stub_resource_group_create_response)
     allow(resource_management_client.deployments).to receive_message_chain(
-      :create_or_update => 'create_or_update',
+      :create_or_update => "create_or_update",
       :value! => nil,
       :body => nil
       ).and_return(stub_deployments_response)
@@ -63,8 +63,8 @@ module QueryAzureMock
 
   def stub_deployments_response
     deployments = OpenStruct.new
-    deployments.name = 'test-deployment'
-    deployments.id = 'xxx-xxxx-xxxx'
+    deployments.name = "test-deployment"
+    deployments.id = "xxx-xxxx-xxxx"
     deployments
   end
 
@@ -74,13 +74,13 @@ module QueryAzureMock
       :virtual_machine_extensions => double,
       :virtual_machine_extension_images => double)
     allow(compute_management_client.virtual_machine_extensions).to receive_message_chain(
-      :create_or_update => 'create_or_update'
+      :create_or_update => "create_or_update"
     ).and_return(stub_vm_extension_create_response(user_supplied_value))
     allow(compute_management_client.virtual_machine_extension_images).to receive_message_chain(
       :list_versions,
       :last,
       :name
-    ).and_return('1210.12.10.100')
+    ).and_return("1210.12.10.100")
 
     allow(compute_management_client.virtual_machine_extensions).to receive_message_chain(
       :get,
@@ -91,48 +91,48 @@ module QueryAzureMock
   end
 
   def stub_substatuses(user_supplied_value)
-    if user_supplied_value == 'substatuses_found_with_no_chef_client_run_logs'
+    if user_supplied_value == "substatuses_found_with_no_chef_client_run_logs"
       [
        OpenStruct.new(
-        :code => 'code1',
-        :level => 'Info',
-        :display_status => 'my_code1',
-        :message => 'my_message1',
-        :time => 'my_time1'
+        :code => "code1",
+        :level => "Info",
+        :display_status => "my_code1",
+        :message => "my_message1",
+        :time => "my_time1"
        ),
        OpenStruct.new(
-        :code => 'code2',
-        :level => 'Warning',
-        :display_status => 'my_code2',
-        :message => 'my_message2',
-        :time => 'my_time2'
+        :code => "code2",
+        :level => "Warning",
+        :display_status => "my_code2",
+        :message => "my_message2",
+        :time => "my_time2"
        )
       ]
-    elsif user_supplied_value == 'substatuses_found_with_chef_client_run_logs'
+    elsif user_supplied_value == "substatuses_found_with_chef_client_run_logs"
       [
        OpenStruct.new(
-        :code => 'code1',
-        :level => 'Info',
-        :display_status => 'my_code1',
-        :message => 'my_message1',
-        :time => 'my_time1'
+        :code => "code1",
+        :level => "Info",
+        :display_status => "my_code1",
+        :message => "my_message1",
+        :time => "my_time1"
        ),
        OpenStruct.new(
-        :code => 'ComponentStatus/Chef Client run logs/succeeded',
-        :level => 'Info',
-        :display_status => 'Provisioning succeeded',
-        :message => 'chef_client_run_logs',
-        :time => 'chef_client_run_logs_write_time'
+        :code => "ComponentStatus/Chef Client run logs/succeeded",
+        :level => "Info",
+        :display_status => "Provisioning succeeded",
+        :message => "chef_client_run_logs",
+        :time => "chef_client_run_logs_write_time"
        ),
        OpenStruct.new(
-        :code => 'code2',
-        :level => 'Warning',
-        :display_status => 'my_code2',
-        :message => 'my_message2',
-        :time => 'my_time2'
+        :code => "code2",
+        :level => "Warning",
+        :display_status => "my_code2",
+        :message => "my_message2",
+        :time => "my_time2"
        )
       ]
-    elsif user_supplied_value == 'substatuses_not_found'
+    elsif user_supplied_value == "substatuses_not_found"
       nil
     end
   end
@@ -146,7 +146,7 @@ module QueryAzureMock
       :network_interfaces => double,
       :security_rules => double)
     allow(network_resource_client.public_ipaddresses).to receive_message_chain(
-      :get => 'get',
+      :get => "get",
       :value! => nil,
       :body => nil,
       :properties => nil,
@@ -158,7 +158,7 @@ module QueryAzureMock
       :value!,
       :body,
       :properties,
-      :security_rules).and_return(['default_security_rule'])
+      :security_rules).and_return(["default_security_rule"])
     if resource_group_name.nil? && vnet_name.nil?
       allow(network_resource_client.virtual_networks).to receive(
         :get).and_return(nil)
@@ -166,21 +166,21 @@ module QueryAzureMock
       allow(network_resource_client.virtual_networks).to receive(
         :get).and_return(stub_vnet_get_response(resource_group_name, vnet_name))
     end
-    if platform == 'Windows'
+    if platform == "Windows"
       allow(network_resource_client.network_security_groups.get.value!.body.properties.security_rules[0]).to receive_message_chain(
         :properties,
-        :destination_port_range).and_return('3389')
+        :destination_port_range).and_return("3389")
     else
       allow(network_resource_client.network_security_groups.get.value!.body.properties.security_rules[0]).to receive_message_chain(
         :properties,
-        :destination_port_range).and_return('22')
+        :destination_port_range).and_return("22")
     end
     allow(network_resource_client.network_security_groups).to receive_message_chain(
-      :create_or_update => 'create_or_update',
+      :create_or_update => "create_or_update",
       :value! => nil,
       :body => nil).and_return(stub_network_security_group_create_response)
     allow(network_resource_client.security_rules).to receive_message_chain(
-      :create_or_update => 'create_or_update',
+      :create_or_update => "create_or_update",
       :value! => nil,
       :body => nil).and_return(stub_default_security_rule_add_response(platform))
     if resource_group_name.nil? && vnet_name.nil?
@@ -202,7 +202,7 @@ module QueryAzureMock
     @resource_groups.each_with_index do |resource_group, rindex|
       if resource_group.has_key? resource_group_name
         rgrp_index = rindex
-        resource_group[resource_group_name]['vnets'].each_with_index do |vnet, vindex|
+        resource_group[resource_group_name]["vnets"].each_with_index do |vnet, vindex|
           if vnet.has_key? vnet_name
             vnet_index = vindex
             break
@@ -212,108 +212,108 @@ module QueryAzureMock
       end
     end
 
-    return rgrp_index, vnet_index
+    [rgrp_index, vnet_index]
   end
 
   def stub_subnets_list_response(resource_group_name, vnet_name)
     rgrp_index, vnet_index = locate_resource_group_and_vnet(resource_group_name, vnet_name)
 
-    @resource_groups[rgrp_index][resource_group_name]['vnets'][vnet_index][vnet_name]['subnets']
+    @resource_groups[rgrp_index][resource_group_name]["vnets"][vnet_index][vnet_name]["subnets"]
   end
 
   def stub_vnet_get_response(resource_group_name, vnet_name)
     rgrp_index, vnet_index = locate_resource_group_and_vnet(resource_group_name, vnet_name)
 
-    @resource_groups[rgrp_index][resource_group_name]['vnets'][vnet_index][vnet_name]
+    @resource_groups[rgrp_index][resource_group_name]["vnets"][vnet_index][vnet_name]
   end
 
   def stub_deployments_create_response
     deploy = double("deploy1", :resource_type => "Microsoft.Compute/virtualMachines", :resource_name => "MyVM",
-      :id => "/subscriptions/e00d2b3f-3b94-4dfc-ae8e-ca34c8ba1a99/resourceGroups/vjgroup/providers/Microsoft.Compute/virtualMachines/MyVM0")
+                               :id => "/subscriptions/e00d2b3f-3b94-4dfc-ae8e-ca34c8ba1a99/resourceGroups/vjgroup/providers/Microsoft.Compute/virtualMachines/MyVM0")
     deployment = double("Deployment",
-      :name => 'test-deployment',
-      :id => 'id',
+      :name => "test-deployment",
+      :id => "id",
       :properties => double)
     allow(deployment.properties).to receive_message_chain(
       :dependencies).and_return([deploy])
     allow(deployment.properties).to receive(
-      :provisioning_state).and_return('Succeeded')
+      :provisioning_state).and_return("Succeeded")
     deployment
   end
 
   def stub_vm_details
     vm_details = OpenStruct.new
-    vm_details.id = 'test-vm-id'
-    vm_details.name = 'test-vm'
-    vm_details.locationname = 'test-vm-loc'
-    vm_details.ostype = 'test-vm-os'
-    vm_details.publicipaddress = '1.2.3.4'
-    vm_details.rdpport = '3389'
-    vm_details.sshport = '22'
-    vm_details.provisioningstate = 'Succeeded'
+    vm_details.id = "test-vm-id"
+    vm_details.name = "test-vm"
+    vm_details.locationname = "test-vm-loc"
+    vm_details.ostype = "test-vm-os"
+    vm_details.publicipaddress = "1.2.3.4"
+    vm_details.rdpport = "3389"
+    vm_details.sshport = "22"
+    vm_details.provisioningstate = "Succeeded"
     vm_details
   end
 
   def stub_vm_extension_create_response(user_supplied_value)
     vm_extension = double("VMExtension",
-      :name => 'test-vm-ext',
-      :id => 'myvmextid',
-      :type => 'Microsoft.Compute/virtualMachines/extensions',
+      :name => "test-vm-ext",
+      :id => "myvmextid",
+      :type => "Microsoft.Compute/virtualMachines/extensions",
       :properties => double,
-      :location => 'West Europe')
+      :location => "West Europe")
     allow(vm_extension.properties).to receive(
-      :publisher).and_return('Ext_Publisher')
+      :publisher).and_return("Ext_Publisher")
     allow(vm_extension.properties).to receive(
-      :type).and_return('Ext_Type')
-    if user_supplied_value == 'yes'
+      :type).and_return("Ext_Type")
+    if user_supplied_value == "yes"
       allow(vm_extension.properties).to receive(
-        :type_handler_version).and_return('11.10.1')
-    elsif user_supplied_value == 'no'
+        :type_handler_version).and_return("11.10.1")
+    elsif user_supplied_value == "no"
       allow(vm_extension.properties).to receive(
-        :type_handler_version).and_return('1210.12')
+        :type_handler_version).and_return("1210.12")
     else
       allow(vm_extension.properties).to receive(
-        :type_handler_version).and_return('')
+        :type_handler_version).and_return("")
     end
     allow(vm_extension.properties).to receive(
-      :provisioning_state).and_return('Succeeded')
+      :provisioning_state).and_return("Succeeded")
     vm_extension
   end
 
   def stub_storage_profile_response
     storage_profile = OpenStruct.new
-    storage_profile.image_reference = 'image_reference'
-    storage_profile.os_disk = 'osdisk'
+    storage_profile.image_reference = "image_reference"
+    storage_profile.os_disk = "osdisk"
     storage_profile
   end
 
   def stub_vm_public_ip_get_response
-    '1.2.3.4'
+    "1.2.3.4"
   end
 
   def stub_network_security_group_create_response
     network_security_group = OpenStruct.new
-    network_security_group.name = 'network_security_group_name'
-    network_security_group.id = 'network_security_group_id'
-    network_security_group.location = 'network_security_group_location'
+    network_security_group.name = "network_security_group_name"
+    network_security_group.id = "network_security_group_id"
+    network_security_group.location = "network_security_group_location"
     network_security_group.properties = OpenStruct.new
-    network_security_group.properties.default_security_rules = ['nsg_default_security_rules']
+    network_security_group.properties.default_security_rules = ["nsg_default_security_rules"]
     network_security_group
   end
 
   def stub_default_security_rule_add_response(platform)
     security_rule = OpenStruct.new
-    security_rule.name = 'security_rule_name'
-    security_rule.id = 'security_rule_id'
-    security_rule.location = 'security_rule_location'
-    security_rule.properties = 'security_rule_properties'
+    security_rule.name = "security_rule_name"
+    security_rule.id = "security_rule_id"
+    security_rule.location = "security_rule_location"
+    security_rule.properties = "security_rule_properties"
     security_rule.properties = OpenStruct.new
-    if platform == 'Windows'
+    if platform == "Windows"
       security_rule.properties.description = "Windows port."
-      security_rule.properties.destination_port_range = '3389'
+      security_rule.properties.destination_port_range = "3389"
     else
       security_rule.properties.description = "Linux port."
-      security_rule.properties.destination_port_range = '22'
+      security_rule.properties.destination_port_range = "22"
     end
     security_rule.properties.protocol = "Tcp"
     security_rule.properties.source_port_range = "*"
@@ -329,7 +329,7 @@ module QueryAzureMock
     dataXML = Nokogiri::XML readFile(in_file)
     itemsXML = dataXML.css(tag)
     not_found = true
-    retval = ''
+    retval = ""
     itemsXML.each do |itemXML|
       if xml_content(itemXML, lookup_pty) == lookup_name
         not_found = false
@@ -337,239 +337,238 @@ module QueryAzureMock
         break
       end
     end
-    retval = Nokogiri::XML readFile('error_404.xml') if not_found
+    retval = Nokogiri::XML readFile("error_404.xml") if not_found
     retval
   end
 
   def stub_query_azure(connection)
-    @getname = ''
-    @getverb = ''
-    @getbody = ''
+    @getname = ""
+    @getverb = ""
+    @getbody = ""
 
-    @postname = ''
-    @postverb = ''
-    @postbody = ''
+    @postname = ""
+    @postverb = ""
+    @postbody = ""
 
-    @deletename = ''
-    @deleteverb = ''
-    @deletebody = ''
-    @deleteparams= ''
+    @deletename = ""
+    @deleteverb = ""
+    @deletebody = ""
+    @deleteparams = ""
     @deletecount = 0
 
-    @receivedXML = Nokogiri::XML ''
+    @receivedXML = Nokogiri::XML ""
     allow(connection).to receive(:query_azure) do |name, verb, body, params, wait, services|
-      Chef::Log.info 'calling web service:' + name
-      if verb == 'get' || verb == nil
-        retval = ''
-        if name == 'affinitygroups' && services == false
-          retval = Nokogiri::XML readFile('list_affinitygroups.xml')
-        elsif name == 'networking/virtualnetwork'
-          retval = Nokogiri::XML readFile('list_vnets.xml')
-        elsif name == 'networking/media'
-          retval = Nokogiri::XML readFile('get_network.xml')
-        elsif name == 'images'
-          retval = Nokogiri::XML readFile('list_images.xml')
-        elsif name == 'disks'
-          retval = Nokogiri::XML readFile('list_disks.xml')
-        elsif name == 'disks/deployment001-role002-0-201241722728'
-          retval = Nokogiri::XML readFile('list_disks_for_role002.xml')
-        elsif name == 'hostedservices'
-          retval = Nokogiri::XML readFile('list_hosts.xml')
+      Chef::Log.info "calling web service:" + name
+      if verb == "get" || verb.nil?
+        retval = ""
+        if name == "affinitygroups" && services == false
+          retval = Nokogiri::XML readFile("list_affinitygroups.xml")
+        elsif name == "networking/virtualnetwork"
+          retval = Nokogiri::XML readFile("list_vnets.xml")
+        elsif name == "networking/media"
+          retval = Nokogiri::XML readFile("get_network.xml")
+        elsif name == "images"
+          retval = Nokogiri::XML readFile("list_images.xml")
+        elsif name == "disks"
+          retval = Nokogiri::XML readFile("list_disks.xml")
+        elsif name == "disks/deployment001-role002-0-201241722728"
+          retval = Nokogiri::XML readFile("list_disks_for_role002.xml")
+        elsif name == "hostedservices"
+          retval = Nokogiri::XML readFile("list_hosts.xml")
         elsif name =~ /hostedservices\/([-\w]*)$/ && params == "embed-detail=true"
-          retval = Nokogiri::XML readFile('list_deployments_for_service001.xml')
+          retval = Nokogiri::XML readFile("list_deployments_for_service001.xml")
         elsif name =~ /hostedservices\/([-\w]*)$/
           service_name = /hostedservices\/([-\w]*)/.match(name)[1]
-          retval = lookup_resource_in_test_xml(service_name, 'ServiceName', 'HostedServices HostedService', 'list_hosts.xml')
-        elsif name == 'hostedservices/service001/deploymentslots/Production'
-          retval = Nokogiri::XML readFile('list_deployments_for_service001.xml')
-        elsif name == 'hostedservices/service001/deployments/deployment001/roles/role001'
-          retval = Nokogiri::XML readFile('list_deployments_for_service001.xml')
+          retval = lookup_resource_in_test_xml(service_name, "ServiceName", "HostedServices HostedService", "list_hosts.xml")
+        elsif name == "hostedservices/service001/deploymentslots/Production"
+          retval = Nokogiri::XML readFile("list_deployments_for_service001.xml")
+        elsif name == "hostedservices/service001/deployments/deployment001/roles/role001"
+          retval = Nokogiri::XML readFile("list_deployments_for_service001.xml")
         elsif name =~ /hostedservices\/[-\w]*\/deployments\/[-\w]*\/roles\/[-\w]*/
-          retval = Nokogiri::XML readFile('list_deployments_for_service005.xml')
-        elsif name == 'hostedservices/service002/deploymentslots/Production'
-          retval = Nokogiri::XML readFile('list_deployments_for_service002.xml')
-        elsif name == 'hostedservices/service002/deployments/testrequest'
-          retval = Nokogiri::XML readFile('list_deployments_for_service002.xml')
-        elsif name == 'hostedservices/service003/deploymentslots/Production'
-          retval = Nokogiri::XML readFile('list_deployments_for_service003.xml')
-        elsif name == 'hostedservices/vmname/deploymentslots/Production'
-          retval = Nokogiri::XML readFile('list_deployments_for_vmname.xml')
-        elsif name == 'hostedservices/service004/deploymentslots/Production'
-          retval = Nokogiri::XML readFile('list_deployments_for_service004.xml')
-        elsif name == 'storageservices'
-          retval = Nokogiri::XML readFile('list_storageaccounts.xml')
+          retval = Nokogiri::XML readFile("list_deployments_for_service005.xml")
+        elsif name == "hostedservices/service002/deploymentslots/Production"
+          retval = Nokogiri::XML readFile("list_deployments_for_service002.xml")
+        elsif name == "hostedservices/service002/deployments/testrequest"
+          retval = Nokogiri::XML readFile("list_deployments_for_service002.xml")
+        elsif name == "hostedservices/service003/deploymentslots/Production"
+          retval = Nokogiri::XML readFile("list_deployments_for_service003.xml")
+        elsif name == "hostedservices/vmname/deploymentslots/Production"
+          retval = Nokogiri::XML readFile("list_deployments_for_vmname.xml")
+        elsif name == "hostedservices/service004/deploymentslots/Production"
+          retval = Nokogiri::XML readFile("list_deployments_for_service004.xml")
+        elsif name == "storageservices"
+          retval = Nokogiri::XML readFile("list_storageaccounts.xml")
         elsif name =~ /storageservices\/[-\w]*$/
           service_name = /storageservices\/([-\w]*)/.match(name)[1]
-          retval = lookup_resource_in_test_xml(service_name, 'ServiceName', 'StorageServices StorageService', 'list_storageaccounts.xml')
-        elsif name == 'hostedservices/unknown_yet/certificates/sha1-9dbcac68f670a27cf5d9a4e6c4a8d097bff645e2'
-          retval = Nokogiri::XML readFile('get_service_certificate_error.xml')
+          retval = lookup_resource_in_test_xml(service_name, "ServiceName", "StorageServices StorageService", "list_storageaccounts.xml")
+        elsif name == "hostedservices/unknown_yet/certificates/sha1-9dbcac68f670a27cf5d9a4e6c4a8d097bff645e2"
+          retval = Nokogiri::XML readFile("get_service_certificate_error.xml")
         elsif /\b([a-f0-9]{40})\b/.match(name)
-          retval = Nokogiri::XML readFile('get_service_certificate.xml')
+          retval = Nokogiri::XML readFile("get_service_certificate.xml")
         else
-          Chef::Log.warn 'unknown get value:' + name
+          Chef::Log.warn "unknown get value:" + name
         end
         @getname = name
         @getverb = verb
         @getbody = body
-      elsif verb == 'post'
-        if name == 'affinitygroups' && services == false
-          retval = Nokogiri::XML readFile('post_success.xml')
+      elsif verb == "post"
+        if name == "affinitygroups" && services == false
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
-        elsif name == 'hostedservices'
-          retval = Nokogiri::XML readFile('post_success.xml')
+        elsif name == "hostedservices"
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
-        elsif name == 'hostedservices/unknown_yet/deployments'
-          retval = Nokogiri::XML readFile('post_success.xml')
+        elsif name == "hostedservices/unknown_yet/deployments"
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
-        elsif name == 'hostedservices/service001/deployments/deployment001/roles'
-          retval = Nokogiri::XML readFile('post_success.xml')
+        elsif name == "hostedservices/service001/deployments/deployment001/roles"
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
-        elsif name == 'hostedservices/service004/deployments/deployment004/roles'
-          retval = Nokogiri::XML readFile('post_success.xml')
+        elsif name == "hostedservices/service004/deployments/deployment004/roles"
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
         elsif name =~ /hostedservices\/vm01.*\/deployments/
-          retval = Nokogiri::XML readFile('post_success.xml')
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
         elsif name =~ /hostedservices\/vmname\/deployments/
           # Case when vm name and service name are same.
-          retval = Nokogiri::XML readFile('post_success.xml')
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
         else
-          Chef::Log.warn 'unknown post value:' + name
+          Chef::Log.warn "unknown post value:" + name
         end
         @postname = name
         @postverb = verb
         @postbody = body
-      elsif verb == 'delete'
+      elsif verb == "delete"
         @deletename = name
         @deleteverb = verb
         @deletebody = body
         @deleteparams = params
         @deletecount += 1
-      elsif verb == 'put'
-        if name == 'networking/media'
-          retval = Nokogiri::XML readFile('post_success.xml')
+      elsif verb == "put"
+        if name == "networking/media"
+          retval = Nokogiri::XML readFile("post_success.xml")
           @receivedXML = body
         end
         @postname = name
         @postverb = verb
         @postbody = body
       else
-        Chef::Log.warn 'unknown verb:' + verb
+        Chef::Log.warn "unknown verb:" + verb
       end
       retval
     end
-
   end
 
   def stub_resource_groups
-    @resource_groups = [{'rgrp-1' => {
-      'vnets' => [{'vnet-1' => OpenStruct.new({
-        'location' => 'westus',
-        'address_space' => OpenStruct.new({
-          'address_prefixes' => [ '10.1.0.0/16' ]
+    @resource_groups = [{ "rgrp-1" => {
+      "vnets" => [{ "vnet-1" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+          "address_prefixes" => [ "10.1.0.0/16" ]
         }),
-        'subnets' => [OpenStruct.new({'name'=> 'sbn1',
-          
-            'address_prefix'=> '10.1.0.0/24'
+        "subnets" => [OpenStruct.new({ "name" => "sbn1",
+
+                                       "address_prefix" => "10.1.0.0/24"
         }),
-        OpenStruct.new({'name'=> 'sbn2',
-            'address_prefix'=> '10.1.48.0/20'
+        OpenStruct.new({ "name" => "sbn2",
+                         "address_prefix" => "10.1.48.0/20"
         })]
-      })}]
-    }},
-    {'rgrp-2' => {
-      'vnets' => [{'vnet-2' => OpenStruct.new({
-        'location' => 'westus',
-        'address_space' => OpenStruct.new({
-          'address_prefixes' => [ '10.2.0.0/16', '192.168.172.0/24', '16.2.0.0/24' ]
+      }) }]
+    } },
+    { "rgrp-2" => {
+      "vnets" => [{ "vnet-2" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+          "address_prefixes" => [ "10.2.0.0/16", "192.168.172.0/24", "16.2.0.0/24" ]
         }),
-        'subnets' => [OpenStruct.new({'name'=> 'sbn3',
-            'address_prefix'=> '10.2.0.0/20'
+        "subnets" => [OpenStruct.new({ "name" => "sbn3",
+                                       "address_prefix" => "10.2.0.0/20"
         }),
-        OpenStruct.new({'name'=> 'sbn4',
-            'address_prefix'=> '192.168.172.0/25'
+        OpenStruct.new({ "name" => "sbn4",
+                         "address_prefix" => "192.168.172.0/25"
         }),
-        OpenStruct.new({'name'=> 'sbn5',
-            'address_prefix'=> '10.2.16.0/28'
+        OpenStruct.new({ "name" => "sbn5",
+                         "address_prefix" => "10.2.16.0/28"
         })]
-      })},
-      {'vnet-3' => OpenStruct.new({
-        'location' => 'westus',
-        'address_space' => OpenStruct.new({
-          'address_prefixes' => [ '25.3.16.0/20', '141.154.163.0/26']
+      }) },
+      { "vnet-3" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+          "address_prefixes" => [ "25.3.16.0/20", "141.154.163.0/26"]
         }),
-        'subnets' => [OpenStruct.new({'name'=> 'sbn6',
-            'address_prefix'=> '25.3.29.0/25'
+        "subnets" => [OpenStruct.new({ "name" => "sbn6",
+                                       "address_prefix" => "25.3.29.0/25"
         }),
-        OpenStruct.new({'name'=> 'sbn7',
-            'address_prefix'=> '25.3.29.128/25'
+        OpenStruct.new({ "name" => "sbn7",
+                         "address_prefix" => "25.3.29.128/25"
           })]
-      })}]
-    }},
-    {'rgrp-3' => {
-      'vnets' => [{'vnet-4' => OpenStruct.new({
-        'location' => 'westus',
-          'address_space' => OpenStruct.new({
-            'address_prefixes' => [ '10.15.0.0/20', '40.23.19.0/29' ]
+      }) }]
+    } },
+    { "rgrp-3" => {
+      "vnets" => [{ "vnet-4" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+            "address_prefixes" => [ "10.15.0.0/20", "40.23.19.0/29" ]
           }),
-          'subnets' => [OpenStruct.new({'name'=> 'sbn8',
-              'address_prefix'=> '40.23.19.0/29'
+        "subnets" => [OpenStruct.new({ "name" => "sbn8",
+                                       "address_prefix" => "40.23.19.0/29"
           })]
-      })},
-      {'vnet-5' => OpenStruct.new({
-        'location' => 'westus',
-          'address_space' => OpenStruct.new({
-            'address_prefixes' => [ '69.182.8.0/21', '12.3.19.0/24' ]
+      }) },
+      { "vnet-5" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+            "address_prefixes" => [ "69.182.8.0/21", "12.3.19.0/24" ]
           }),
-          'subnets' => [OpenStruct.new({'name'=> 'sbn9',
-              'address_prefix'=> '69.182.9.0/24'
+        "subnets" => [OpenStruct.new({ "name" => "sbn9",
+                                       "address_prefix" => "69.182.9.0/24"
           }),
-          OpenStruct.new({'name'=> 'sbn10',
-              'address_prefix'=> '69.182.11.0/24'
+          OpenStruct.new({ "name" => "sbn10",
+                           "address_prefix" => "69.182.11.0/24"
           }),
-          OpenStruct.new({'name'=> 'sbn11',
-              'address_prefix'=> '12.3.19.0/25'
+          OpenStruct.new({ "name" => "sbn11",
+                           "address_prefix" => "12.3.19.0/25"
           }),
-          OpenStruct.new({'name'=> 'sbn12',
-              'address_prefix'=> '69.182.14.0/24'
+          OpenStruct.new({ "name" => "sbn12",
+                           "address_prefix" => "69.182.14.0/24"
           }),
-          OpenStruct.new({'name'=> 'sbn13',
-              'address_prefix'=> '12.3.19.128/25'
+          OpenStruct.new({ "name" => "sbn13",
+                           "address_prefix" => "12.3.19.128/25"
           })]
-      })}]
-    }},
-    {'rgrp-4' => {
-      'vnets' => [{'vnet-6' => OpenStruct.new({
-        'location' => 'westus',
-          'address_space' => OpenStruct.new({
-            'address_prefixes' => [ '130.88.9.0/24', '112.90.2.0/24' ]
+      }) }]
+    } },
+    { "rgrp-4" => {
+      "vnets" => [{ "vnet-6" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+            "address_prefixes" => [ "130.88.9.0/24", "112.90.2.0/24" ]
           }),
-          'subnets' => [OpenStruct.new({'name'=> 'sbn14',
-              'address_prefix'=> '112.90.2.128/25'
+        "subnets" => [OpenStruct.new({ "name" => "sbn14",
+                                       "address_prefix" => "112.90.2.128/25"
           }),
-          OpenStruct.new({'name'=> 'sbn15',
-              'address_prefix'=> '130.88.9.0/24'
+          OpenStruct.new({ "name" => "sbn15",
+                           "address_prefix" => "130.88.9.0/24"
           }),
-          OpenStruct.new({'name'=> 'sbn16',
-              'address_prefix'=> '112.90.2.0/25'
+          OpenStruct.new({ "name" => "sbn16",
+                           "address_prefix" => "112.90.2.0/25"
           })]
-      })},
-      {'vnet-7' => OpenStruct.new({
-        'location' => 'westus',
-          'address_space' => OpenStruct.new({
-            'address_prefixes' => [ '10.3.0.0/16', '160.10.2.0/24' ]
+      }) },
+      { "vnet-7" => OpenStruct.new({
+        "location" => "westus",
+        "address_space" => OpenStruct.new({
+            "address_prefixes" => [ "10.3.0.0/16", "160.10.2.0/24" ]
           }),
-          'subnets' => [OpenStruct.new({'name'=> 'sbn15',
-              'address_prefix'=> '160.10.2.192/26'
+        "subnets" => [OpenStruct.new({ "name" => "sbn15",
+                                       "address_prefix" => "160.10.2.192/26"
           }),
-          OpenStruct.new({'name'=> 'GatewaySubnet',
-              'address_prefix'=> '10.3.1.0/24'
+          OpenStruct.new({ "name" => "GatewaySubnet",
+                           "address_prefix" => "10.3.1.0/24"
           }),
-          OpenStruct.new({'name'=> 'sbn16',
-              'address_prefix'=> '160.10.2.0/25'
+          OpenStruct.new({ "name" => "sbn16",
+                           "address_prefix" => "160.10.2.0/25"
           })]
-      })}]
-    }}]
+      }) }]
+    } }]
   end
 end

--- a/spec/unit/roles_create_spec.rb
+++ b/spec/unit/roles_create_spec.rb
@@ -1,5 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 module Azure
   class Certificate
@@ -22,9 +22,9 @@ describe "roles" do
   before do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -33,184 +33,184 @@ describe "roles" do
     @connection = @server_instance.service.connection
   end
 
-  context 'delete a role' do
-    context 'when the role is not the only one in a deployment' do
-      it 'should pass in correct name, verb, and body' do
-        @connection.roles.delete({ name:'vm002', preserve_azure_os_disk: true })
-        expect(@deletename).to be == 'hostedservices/service001/deployments/deployment001/roles/vm002'
-        expect(@deleteverb).to be == 'delete'
+  context "delete a role" do
+    context "when the role is not the only one in a deployment" do
+      it "should pass in correct name, verb, and body" do
+        @connection.roles.delete({ name: "vm002", preserve_azure_os_disk: true })
+        expect(@deletename).to be == "hostedservices/service001/deployments/deployment001/roles/vm002"
+        expect(@deleteverb).to be == "delete"
         expect(@deletebody).to be nil
       end
     end
   end
 
-  context 'delete a role' do
-    context 'when the role is the only one in a deployment' do
-      it 'should pass in correct name, verb, and body' do
-        @connection.roles.delete({ name:'vm01', preserve_azure_os_disk: true })
-        expect(@deletename).to be == 'hostedservices/service002/deployments/testrequest'
-        expect(@deleteverb).to be == 'delete'
+  context "delete a role" do
+    context "when the role is the only one in a deployment" do
+      it "should pass in correct name, verb, and body" do
+        @connection.roles.delete({ name: "vm01", preserve_azure_os_disk: true })
+        expect(@deletename).to be == "hostedservices/service002/deployments/testrequest"
+        expect(@deleteverb).to be == "delete"
         expect(@deletebody).to be nil
       end
     end
   end
 
-  context 'create a new role' do
-    it 'should pass in expected body' do
+  context "create a new role" do
+    it "should pass in expected body" do
       params = {
-        :azure_dns_name=>'service001',
-        :azure_api_host_name => 'management.core.windows.net',
-        :azure_vm_name=>'vm01',
-        :ssh_user=>'jetstream',
-        :ssh_password=>'jetstream1!',
-        :media_location_prefix=>'auxpreview104',
-        :azure_os_disk_name=>'disk004Test',
-        :azure_source_image=>'SUSE__OpenSUSE64121-03192012-en-us-15GB',
-        :azure_vm_size=>'ExtraSmall',
-        :tcp_endpoints => '80:80, 3389:3389, 993:993, 44: 45',
-        :udp_endpoints=>'65:65,75',
-        :azure_storage_account=>'storageaccount001',
-        :bootstrap_proto=>'ssh',
-        :os_type=>'Linux',
-        :port=>'22'
+        :azure_dns_name => "service001",
+        :azure_api_host_name => "management.core.windows.net",
+        :azure_vm_name => "vm01",
+        :ssh_user => "jetstream",
+        :ssh_password => "jetstream1!",
+        :media_location_prefix => "auxpreview104",
+        :azure_os_disk_name => "disk004Test",
+        :azure_source_image => "SUSE__OpenSUSE64121-03192012-en-us-15GB",
+        :azure_vm_size => "ExtraSmall",
+        :tcp_endpoints => "80:80, 3389:3389, 993:993, 44: 45",
+        :udp_endpoints => "65:65,75",
+        :azure_storage_account => "storageaccount001",
+        :bootstrap_proto => "ssh",
+        :os_type => "Linux",
+        :port => "22"
 
       }
 
       deploy = @connection.deploys.create(params)
-      expect(readFile('create_role.xml')).to eq(@receivedXML)
+      expect(readFile("create_role.xml")).to eq(@receivedXML)
     end
   end
 
-  describe 'assign tcp endpoint name' do
+  describe "assign tcp endpoint name" do
     before do
       @params = {
-        azure_dns_name: 'service001',
-        azure_api_host_name: 'management.core.windows.net',
-        azure_vm_name: 'vm01',
-        ssh_user: 'jetstream',
-        ssh_password: 'jetstream1!',
-        media_location_prefix: 'auxpreview104',
-        azure_source_image: 'SUSE__OpenSUSE64121-03192012-en-us-15GB',
-        azure_vm_size: 'ExtraSmall',
-        azure_storage_account: 'storageaccount001',
-        bootstrap_proto: 'ssh'
+        azure_dns_name: "service001",
+        azure_api_host_name: "management.core.windows.net",
+        azure_vm_name: "vm01",
+        ssh_user: "jetstream",
+        ssh_password: "jetstream1!",
+        media_location_prefix: "auxpreview104",
+        azure_source_image: "SUSE__OpenSUSE64121-03192012-en-us-15GB",
+        azure_vm_size: "ExtraSmall",
+        azure_storage_account: "storageaccount001",
+        bootstrap_proto: "ssh"
       }
     end
 
-    context 'tcp_endpoint 80:80' do
-      it 'assigns tcp endpoint name HTTP' do
-        @params[:tcp_endpoints] = '80:80'
+    context "tcp_endpoint 80:80" do
+      it "assigns tcp endpoint name HTTP" do
+        @params[:tcp_endpoints] = "80:80"
         @connection.deploys.create(@params)
         doc = Nokogiri::XML::Document.parse(@receivedXML)
         doc.remove_namespaces!
-        endpoints = doc.xpath('//InputEndpoints/InputEndpoint')
+        endpoints = doc.xpath("//InputEndpoints/InputEndpoint")
         endpoints[1].children.each do |node|
-          expect(node.children.text).to eq('HTTP') if node.name == 'Name'
+          expect(node.children.text).to eq("HTTP") if node.name == "Name"
         end
       end
     end
 
-    context 'tcp_endpoint 44:45' do
-      it 'generates tcp endpoint name as TCPEndpoint_chef_<port_number>' do
-        @params[:tcp_endpoints] = '44:45'
+    context "tcp_endpoint 44:45" do
+      it "generates tcp endpoint name as TCPEndpoint_chef_<port_number>" do
+        @params[:tcp_endpoints] = "44:45"
         @connection.deploys.create(@params)
         doc = Nokogiri::XML::Document.parse(@receivedXML)
         doc.remove_namespaces!
-        endpoints = doc.xpath('//InputEndpoints/InputEndpoint')
+        endpoints = doc.xpath("//InputEndpoints/InputEndpoint")
         endpoints[1].children.each do |node|
-          expect(node.children.text).to eq('TCPEndpoint_chef_44') if node.name == 'Name'
+          expect(node.children.text).to eq("TCPEndpoint_chef_44") if node.name == "Name"
         end
       end
     end
   end
 
-  context 'create a new deployment' do
-    it 'should pass in expected body' do
+  context "create a new deployment" do
+    it "should pass in expected body" do
       params = {
-        :azure_dns_name=>'unknown_yet',
-        :azure_api_host_name => 'management.core.windows.net',
-        :azure_vm_name=>'vm01',
-        :ssh_user=>'jetstream',
-        :ssh_password=>'jetstream1!',
-        :media_location_prefix=>'auxpreview104',
-        :azure_os_disk_name=>'disk004Test',
-        :azure_source_image=>'SUSE__OpenSUSE64121-03192012-en-us-15GB',
-        :azure_vm_size=>'ExtraSmall',
-        :azure_storage_account=>'storageaccount001',
-        :bootstrap_proto=>'ssh',
-        :os_type=>'Linux',
-        :port=>'22'
+        :azure_dns_name => "unknown_yet",
+        :azure_api_host_name => "management.core.windows.net",
+        :azure_vm_name => "vm01",
+        :ssh_user => "jetstream",
+        :ssh_password => "jetstream1!",
+        :media_location_prefix => "auxpreview104",
+        :azure_os_disk_name => "disk004Test",
+        :azure_source_image => "SUSE__OpenSUSE64121-03192012-en-us-15GB",
+        :azure_vm_size => "ExtraSmall",
+        :azure_storage_account => "storageaccount001",
+        :bootstrap_proto => "ssh",
+        :os_type => "Linux",
+        :port => "22"
       }
 
       deploy = @connection.deploys.create(params)
-      expect(readFile('create_deployment.xml')).to eq(@receivedXML)
+      expect(readFile("create_deployment.xml")).to eq(@receivedXML)
     end
-    it 'create request with virtual network' do
+    it "create request with virtual network" do
       params = {
-        :azure_dns_name=>'unknown_yet',
-        :azure_api_host_name => 'management.core.windows.net',
-        :azure_vm_name=>'vm01',
-        :ssh_user=>'jetstream',
-        :ssh_password=>'jetstream1!',
-        :media_location_prefix=>'auxpreview104',
-        :azure_os_disk_name=>'disk004Test',
-        :azure_source_image=>'SUSE__OpenSUSE64121-03192012-en-us-15GB',
-        :azure_vm_size=>'ExtraSmall',
-        :azure_storage_account=>'storageaccount001',
-        :bootstrap_proto=>'ssh',
-        :os_type=>'Linux',
-        :port=>'22',
-        :azure_network_name=>'test-network',
-        :azure_subnet_name=>'test-subnet'
+        :azure_dns_name => "unknown_yet",
+        :azure_api_host_name => "management.core.windows.net",
+        :azure_vm_name => "vm01",
+        :ssh_user => "jetstream",
+        :ssh_password => "jetstream1!",
+        :media_location_prefix => "auxpreview104",
+        :azure_os_disk_name => "disk004Test",
+        :azure_source_image => "SUSE__OpenSUSE64121-03192012-en-us-15GB",
+        :azure_vm_size => "ExtraSmall",
+        :azure_storage_account => "storageaccount001",
+        :bootstrap_proto => "ssh",
+        :os_type => "Linux",
+        :port => "22",
+        :azure_network_name => "test-network",
+        :azure_subnet_name => "test-subnet"
       }
 
       deploy = @connection.deploys.create(params)
-      expect(readFile('create_deployment_virtual_network.xml')).to eq(@receivedXML)
+      expect(readFile("create_deployment_virtual_network.xml")).to eq(@receivedXML)
     end
 
-    it 'with ssh key' do
+    it "with ssh key" do
       params = {
-        :azure_dns_name=>'unknown_yet',
-        :azure_api_host_name => 'management.core.windows.net',
-        :azure_vm_name=>'vm01',
-        :ssh_user=>'jetstream',
-        :identity_file=> File.dirname(__FILE__) + '/assets/key_rsa',
-        :media_location_prefix=>'auxpreview104',
-        :azure_os_disk_name=>'disk004Test',
-        :azure_source_image=>'SUSE__OpenSUSE64121-03192012-en-us-15GB',
-        :azure_vm_size=>'ExtraSmall',
-        :azure_storage_account=>'storageaccount001',
-        :bootstrap_proto=>'ssh',
-        :os_type=>'Linux',
-        :port=>'22'
+        :azure_dns_name => "unknown_yet",
+        :azure_api_host_name => "management.core.windows.net",
+        :azure_vm_name => "vm01",
+        :ssh_user => "jetstream",
+        :identity_file => File.dirname(__FILE__) + "/assets/key_rsa",
+        :media_location_prefix => "auxpreview104",
+        :azure_os_disk_name => "disk004Test",
+        :azure_source_image => "SUSE__OpenSUSE64121-03192012-en-us-15GB",
+        :azure_vm_size => "ExtraSmall",
+        :azure_storage_account => "storageaccount001",
+        :bootstrap_proto => "ssh",
+        :os_type => "Linux",
+        :port => "22"
       }
 
       deploy = @connection.deploys.create(params)
-      expect(readFile('create_deployment_key.xml')).to eq(@receivedXML)
+      expect(readFile("create_deployment_key.xml")).to eq(@receivedXML)
     end
 
-    describe 'WinRM bootstrapping' do
-      it 'customizes the WinRM config' do
+    describe "WinRM bootstrapping" do
+      it "customizes the WinRM config" do
         params = {
-          :azure_dns_name=>'unknown_yet',
-          :azure_vm_name=>'vm01',
-          :azure_api_host_name => 'management.core.windows.net',
-          :winrm_user=>'build',
-          :admin_password=> 'foobar',
-          :ssl_cert_fingerprint=> '7FCCD713CC390E3488290BF7A106AD267B5AC2A5',
-          :azure_os_disk_name=>'disk_ce92083f-0041-4825-84b3-6ae8b3525b29',
-          :azure_source_image=>'a699494373c04fc0bc8f2bb1389d6106__Win2K8R2SP1-Datacenter-201502.01-en.us-127GB.vhd',
-          :azure_vm_size=>'Medium',
-          :azure_storage_account=>'chefci',
-          :os_type=>'Windows',
-          :bootstrap_proto=>'winrm',
-          :winrm_transport=>'ssl',
-          :winrm_max_timeout=>1800000,
-          :winrm_max_memoryPerShell=>600
+          :azure_dns_name => "unknown_yet",
+          :azure_vm_name => "vm01",
+          :azure_api_host_name => "management.core.windows.net",
+          :winrm_user => "build",
+          :admin_password => "foobar",
+          :ssl_cert_fingerprint => "7FCCD713CC390E3488290BF7A106AD267B5AC2A5",
+          :azure_os_disk_name => "disk_ce92083f-0041-4825-84b3-6ae8b3525b29",
+          :azure_source_image => "a699494373c04fc0bc8f2bb1389d6106__Win2K8R2SP1-Datacenter-201502.01-en.us-127GB.vhd",
+          :azure_vm_size => "Medium",
+          :azure_storage_account => "chefci",
+          :os_type => "Windows",
+          :bootstrap_proto => "winrm",
+          :winrm_transport => "ssl",
+          :winrm_max_timeout => 1800000,
+          :winrm_max_memoryPerShell => 600
         }
 
         deploy = @connection.deploys.create(params)
-        expect(readFile('create_deployment_winrm.xml')).to eq(@receivedXML)
+        expect(readFile("create_deployment_winrm.xml")).to eq(@receivedXML)
       end
     end
   end

--- a/spec/unit/roles_list_spec.rb
+++ b/spec/unit/roles_list_spec.rb
@@ -1,14 +1,14 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 describe "roles" do
   include AzureSpecHelper
   include QueryAzureMock
   before do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -17,21 +17,21 @@ describe "roles" do
     @connection = @server_instance.service.connection
   end
 
-  it 'show all roles' do
+  it "show all roles" do
     roles = @connection.roles.all
     roles.each do |role|
       expect(role.name).to_not be nil
     end
     expect(roles.length).to be == 7
   end
-  specify {expect(@connection.roles.exists?('vm01')).to be true}
-  specify {expect(@connection.roles.exists?('vm002')).to be true}
-  specify {expect(@connection.roles.exists?('role001')).to be true}
-  specify {expect(@connection.roles.exists?('role002')).to be true}
-  specify {expect(@connection.roles.exists?('role002qqqqq')).to be false}
+  specify { expect(@connection.roles.exists?("vm01")).to be true }
+  specify { expect(@connection.roles.exists?("vm002")).to be true }
+  specify { expect(@connection.roles.exists?("role001")).to be true }
+  specify { expect(@connection.roles.exists?("role002")).to be true }
+  specify { expect(@connection.roles.exists?("role002qqqqq")).to be false }
 
-  it 'each role should have values' do
-    role = @connection.roles.find('vm01')
+  it "each role should have values" do
+    role = @connection.roles.find("vm01")
     expect(role.name).to_not be nil
     expect(role.status).to_not be nil
     expect(role.size).to_not be nil

--- a/spec/unit/storageaccount_spec.rb
+++ b/spec/unit/storageaccount_spec.rb
@@ -1,16 +1,16 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
 describe "storageaccounts" do
   include AzureSpecHelper
   include QueryAzureMock
 
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -19,8 +19,8 @@ describe "storageaccounts" do
     @connection = @server_instance.service.connection
   end
 
-  context 'get all storage accounts' do
-    specify {expect(@connection.storageaccounts.all.length).to be > 0}
+  context "get all storage accounts" do
+    specify { expect(@connection.storageaccounts.all.length).to be > 0 }
     it "entry fields should not be null" do
       items = @connection.storageaccounts.all
       items.each do |storageaccount|
@@ -29,40 +29,40 @@ describe "storageaccounts" do
     end
   end
 
-  context 'check storage account existence' do
-    it 'storage account should exist' do
+  context "check storage account existence" do
+    it "storage account should exist" do
       expect(@connection.storageaccounts.exists?("storage-service-name")).to be true
     end
-    it 'storage account should not exist' do
+    it "storage account should not exist" do
       expect(@connection.storageaccounts.exists?("invalid-storage-service-name")).to be false
     end
   end
 
-  context 'create a new storage account' do
-    it 'using explicity parameters it should pass in expected body' do
+  context "create a new storage account" do
+    it "using explicity parameters it should pass in expected body" do
       params = {
-        :azure_dns_name => 'service003',
-        :azure_storage_account => 'ka001testeurope',
-        :storage_location => 'North Europe'
+        :azure_dns_name => "service003",
+        :azure_storage_account => "ka001testeurope",
+        :storage_location => "North Europe"
       }
       storageaccount = @connection.storageaccounts.create(params)
-      expect(@postname).to be == 'storageservices'
-      expect(@postverb).to be == 'post'
-      expect(@postbody).to eq(readFile('create_storageservice_for_service003.xml'))
+      expect(@postname).to be == "storageservices"
+      expect(@postverb).to be == "post"
+      expect(@postbody).to eq(readFile("create_storageservice_for_service003.xml"))
     end
   end
 
-  context 'create a new storage account with affinity group' do
-    it 'using explicity parameters it should pass in expected body' do
+  context "create a new storage account with affinity group" do
+    it "using explicity parameters it should pass in expected body" do
       params = {
-        :azure_dns_name => 'service004',
-        :azure_storage_account => 'ka001testeurope',
-        :azure_affinity_group => 'test-affinity-group'
+        :azure_dns_name => "service004",
+        :azure_storage_account => "ka001testeurope",
+        :azure_affinity_group => "test-affinity-group"
       }
       storageaccount = @connection.storageaccounts.create(params)
-      expect(@postname).to be == 'storageservices'
-      expect(@postverb).to be == 'post'
-      expect(@postbody).to eq(readFile('create_storageservice_for_service004.xml'))
+      expect(@postname).to be == "storageservices"
+      expect(@postverb).to be == "post"
+      expect(@postbody).to eq(readFile("create_storageservice_for_service004.xml"))
     end
   end
 

--- a/spec/unit/vnet_config_spec.rb
+++ b/spec/unit/vnet_config_spec.rb
@@ -3,8 +3,8 @@
 # Copyright:: Copyright (c) 2016 Opscode, Inc.
 #
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Azure::ARM::VnetConfig do
   include QueryAzureMock
@@ -36,68 +36,68 @@ describe Azure::ARM::VnetConfig do
     used_networks_pool
   end
 
-  describe 'subnets_list_for_specific_address_space' do
-    context 'subnets exist in the given address_prefix of the virtual network' do
-      context 'example-1' do
+  describe "subnets_list_for_specific_address_space" do
+    context "subnets exist in the given address_prefix of the virtual network" do
+      context "example-1" do
         before do
-          resource_group_name = 'rgrp-2'
-          vnet_name = 'vnet-2'
+          resource_group_name = "rgrp-2"
+          vnet_name = "vnet-2"
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
           @subnets_address_prefix = [ subnet(resource_group_name, vnet_name, 0),
             subnet(resource_group_name, vnet_name, 2)
           ]
         end
 
-        it 'returns the list of subnets which belongs to the given address_prefix of the virtual network' do
-          response = @dummy_class.subnets_list_for_specific_address_space('10.2.0.0/16', @subnets)
+        it "returns the list of subnets which belongs to the given address_prefix of the virtual network" do
+          response = @dummy_class.subnets_list_for_specific_address_space("10.2.0.0/16", @subnets)
           expect(response.class).to be == Array
           expect(response).to be == @subnets_address_prefix
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          resource_group_name = 'rgrp-1'
-          vnet_name = 'vnet-1'
+          resource_group_name = "rgrp-1"
+          vnet_name = "vnet-1"
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
           @subnets_address_prefix = [ subnet(resource_group_name, vnet_name, 0),
             subnet(resource_group_name, vnet_name, 1)
           ]
         end
 
-        it 'returns the list of subnets which belongs to the given address_prefix of the virtual network' do
-          response = @dummy_class.subnets_list_for_specific_address_space('10.1.0.0/16', @subnets)
+        it "returns the list of subnets which belongs to the given address_prefix of the virtual network" do
+          response = @dummy_class.subnets_list_for_specific_address_space("10.1.0.0/16", @subnets)
           expect(response.class).to be == Array
           expect(response).to be == @subnets_address_prefix
         end
       end
     end
 
-    context 'no subnets exist in the given address_prefix of the virtual network - example1' do
-      context 'example-1' do
+    context "no subnets exist in the given address_prefix of the virtual network - example1" do
+      context "example-1" do
         before do
-          resource_group_name = 'rgrp-3'
-          vnet_name = 'vnet-4'
+          resource_group_name = "rgrp-3"
+          vnet_name = "vnet-4"
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
           @subnets_address_prefix = []
         end
 
-        it 'returns the empty list of subnets' do
-          response = @dummy_class.subnets_list_for_specific_address_space('10.15.0.0/20', @subnets)
+        it "returns the empty list of subnets" do
+          response = @dummy_class.subnets_list_for_specific_address_space("10.15.0.0/20", @subnets)
           expect(response.class).to be == Array
           expect(response).to be == @subnets_address_prefix
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          resource_group_name = 'rgrp-2'
-          vnet_name = 'vnet-3'
+          resource_group_name = "rgrp-2"
+          vnet_name = "vnet-3"
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
         end
 
-        it 'returns the empty list of subnets' do
-          response = @dummy_class.subnets_list_for_specific_address_space('141.154.163.0/26', @subnets)
+        it "returns the empty list of subnets" do
+          response = @dummy_class.subnets_list_for_specific_address_space("141.154.163.0/26", @subnets)
           expect(response.class).to be == Array
           expect(response.empty?).to be == true
         end
@@ -105,32 +105,32 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'get_vnet' do
-    context 'given vnet exist under the given resource group' do
+  describe "get_vnet" do
+    context "given vnet exist under the given resource group" do
       before do
-        @resource_group_name = 'rgrp-2'
-        @vnet_name = 'vnet-2'
+        @resource_group_name = "rgrp-2"
+        @vnet_name = "vnet-2"
         allow(@dummy_class).to receive(:network_resource_client).and_return(
           stub_network_resource_client(nil, @resource_group_name, @vnet_name))
       end
 
-      it 'returns vnet object' do
+      it "returns vnet object" do
         response = @dummy_class.get_vnet(@resource_group_name, @vnet_name)
-        expect(response.address_space.address_prefixes).to be == [ '10.2.0.0/16', '192.168.172.0/24', '16.2.0.0/24' ]
+        expect(response.address_space.address_prefixes).to be == [ "10.2.0.0/16", "192.168.172.0/24", "16.2.0.0/24" ]
         expect(response.subnets.class).to be == Array
         expect(response.subnets.length).to be == 3
       end
     end
 
-    context 'given vnet does not exist under the given resource group' do
+    context "given vnet does not exist under the given resource group" do
       before do
-        @resource_group_name = 'rgrp-2'
-        @vnet_name = 'vnet-22'
+        @resource_group_name = "rgrp-2"
+        @vnet_name = "vnet-22"
         request = {}
         response = OpenStruct.new({
-          'body'=>'{"error": {"code": "ResourceNotFound"}}'
+          "body" => '{"error": {"code": "ResourceNotFound"}}'
         })
-        body = 'MsRestAzure::AzureOperationError'
+        body = "MsRestAzure::AzureOperationError"
         error = MsRestAzure::AzureOperationError.new(request, response, body)
         network_resource_client = double("NetworkResourceClient",
           :virtual_networks => double)
@@ -140,21 +140,21 @@ describe Azure::ARM::VnetConfig do
           network_resource_client)
       end
 
-      it 'returns false' do
+      it "returns false" do
         response = @dummy_class.get_vnet(@resource_group_name, @vnet_name)
         expect(response).to be == false
       end
     end
 
-    context 'vnet get api call raises some unknown exception' do
+    context "vnet get api call raises some unknown exception" do
       before do
-        @resource_group_name = 'rgrp-2'
-        @vnet_name = 'vnet-22'
+        @resource_group_name = "rgrp-2"
+        @vnet_name = "vnet-22"
         request = {}
         response = OpenStruct.new({
-          'body'=>'{"error": {"code": "SomeProblemOccurred"}}'
+          "body" => '{"error": {"code": "SomeProblemOccurred"}}'
         })
-        body = 'MsRestAzure::AzureOperationError'
+        body = "MsRestAzure::AzureOperationError"
         @error = MsRestAzure::AzureOperationError.new(request, response, body)
         network_resource_client = double("NetworkResourceClient",
           :virtual_networks => double)
@@ -164,41 +164,42 @@ describe Azure::ARM::VnetConfig do
           network_resource_client)
       end
 
-      it 'raises error' do
-        expect { @dummy_class.get_vnet(@resource_group_name, @vnet_name)
-          }.to raise_error(@error)
+      it "raises error" do
+        expect do
+          @dummy_class.get_vnet(@resource_group_name, @vnet_name)
+        end.to raise_error(@error)
       end
     end
   end
 
-  describe 'subnets_list' do
-    context 'when address_prefix is not passed' do
-      context 'example-1' do
+  describe "subnets_list" do
+    context "when address_prefix is not passed" do
+      context "example-1" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @vnet_name = 'vnet-2'
+          @resource_group_name = "rgrp-2"
+          @vnet_name = "vnet-2"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
           @subnets_vnet_name = [ subnet(@resource_group_name, @vnet_name) ].flatten!
         end
 
-        it 'returns a list of all the subnets present under the given virtual network' do
+        it "returns a list of all the subnets present under the given virtual network" do
           response = @dummy_class.subnets_list(@resource_group_name, @vnet_name)
           expect(response.class).to be == Array
           expect(response).to be == @subnets_vnet_name
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @vnet_name = 'vnet-3'
+          @resource_group_name = "rgrp-2"
+          @vnet_name = "vnet-3"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
           @subnets_vnet_name = [ subnet(@resource_group_name, @vnet_name) ].flatten!
         end
 
-        it 'returns a list of all the subnets present under the given virtual network' do
+        it "returns a list of all the subnets present under the given virtual network" do
           response = @dummy_class.subnets_list(@resource_group_name, @vnet_name)
           expect(response.class).to be == Array
           expect(response).to be == @subnets_vnet_name
@@ -206,27 +207,27 @@ describe Azure::ARM::VnetConfig do
       end
     end
 
-    context 'when address_prefix is passed' do
-      context 'example-1' do
+    context "when address_prefix is passed" do
+      context "example-1" do
         before do
-          @resource_group_name = 'rgrp-2'
-          @vnet_name = 'vnet-2'
+          @resource_group_name = "rgrp-2"
+          @vnet_name = "vnet-2"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
           @subnets_address_prefix = [ subnet(@resource_group_name, @vnet_name, 1) ]
         end
 
-        it 'returns a list of all the subnets present under the given virtual network' do
-          response = @dummy_class.subnets_list(@resource_group_name, @vnet_name, '192.168.172.0/24')
+        it "returns a list of all the subnets present under the given virtual network" do
+          response = @dummy_class.subnets_list(@resource_group_name, @vnet_name, "192.168.172.0/24")
           expect(response.class).to be == Array
           expect(response).to be == @subnets_address_prefix
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          @resource_group_name = 'rgrp-3'
-          @vnet_name = 'vnet-5'
+          @resource_group_name = "rgrp-3"
+          @vnet_name = "vnet-5"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
           @subnets_address_prefix = [ subnet(@resource_group_name, @vnet_name, 0),
@@ -235,8 +236,8 @@ describe Azure::ARM::VnetConfig do
           ]
         end
 
-        it 'returns a list of all the subnets present under the given virtual network' do
-          response = @dummy_class.subnets_list(@resource_group_name, @vnet_name, '69.182.8.0/21')
+        it "returns a list of all the subnets present under the given virtual network" do
+          response = @dummy_class.subnets_list(@resource_group_name, @vnet_name, "69.182.8.0/21")
           expect(response.class).to be == Array
           expect(response).to be == @subnets_address_prefix
         end
@@ -244,48 +245,48 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'subnet' do
+  describe "subnet" do
     before do
       @subnet = {
-        'name'=> 'my_sbn',
-        'properties'=> {
-          'addressPrefix'=> '10.20.30.40/20'
+        "name" => "my_sbn",
+        "properties" => {
+          "addressPrefix" => "10.20.30.40/20"
         }
       }
     end
 
-    it 'returns the hash for subnet' do
-      response = @dummy_class.subnet('my_sbn', '10.20.30.40/20')
+    it "returns the hash for subnet" do
+      response = @dummy_class.subnet("my_sbn", "10.20.30.40/20")
       expect(response.class).to be == Hash
       expect(response).to be == @subnet
     end
   end
 
-  describe 'vnet_address_spaces' do
-    context 'example-1' do
+  describe "vnet_address_spaces" do
+    context "example-1" do
       before do
-        resource_group_name = 'rgrp-1'
-        vnet_name = 'vnet-1'
-        @vnet = @resource_groups[0][resource_group_name]['vnets'][0][vnet_name]
-        @address_prefixes = [ '10.1.0.0/16' ]
+        resource_group_name = "rgrp-1"
+        vnet_name = "vnet-1"
+        @vnet = @resource_groups[0][resource_group_name]["vnets"][0][vnet_name]
+        @address_prefixes = [ "10.1.0.0/16" ]
       end
 
-      it 'returns address_prefixes for the given virtual network existing under the given resource group' do
+      it "returns address_prefixes for the given virtual network existing under the given resource group" do
         response = @dummy_class.vnet_address_spaces(@vnet)
         expect(response.class).to be == Array
         expect(response).to be == @address_prefixes
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        resource_group_name = 'rgrp-2'
-        vnet_name = 'vnet-2'
-        @vnet = @resource_groups[1][resource_group_name]['vnets'][0][vnet_name]
-        @address_prefixes = [ '10.2.0.0/16', '192.168.172.0/24', '16.2.0.0/24' ]
+        resource_group_name = "rgrp-2"
+        vnet_name = "vnet-2"
+        @vnet = @resource_groups[1][resource_group_name]["vnets"][0][vnet_name]
+        @address_prefixes = [ "10.2.0.0/16", "192.168.172.0/24", "16.2.0.0/24" ]
       end
 
-      it 'returns address_prefixes for the given virtual network existing under the given resource group' do
+      it "returns address_prefixes for the given virtual network existing under the given resource group" do
         response = @dummy_class.vnet_address_spaces(@vnet)
         expect(response.class).to be == Array
         expect(response).to be == @address_prefixes
@@ -293,132 +294,132 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'subnet_address_prefix' do
-    context 'example-1' do
+  describe "subnet_address_prefix" do
+    context "example-1" do
       before do
-        resource_group_name = 'rgrp-2'
-        vnet_name = 'vnet-2'
+        resource_group_name = "rgrp-2"
+        vnet_name = "vnet-2"
         @subnet = subnet(resource_group_name, vnet_name, 1)
       end
 
-      it 'returns the address_prefix of the subnet present under the given resource_group and vnet_name at the 1st index' do
+      it "returns the address_prefix of the subnet present under the given resource_group and vnet_name at the 1st index" do
         response = @dummy_class.subnet_address_prefix(@subnet)
         expect(response.class).to be == String
-        expect(response).to be == '192.168.172.0/25'
+        expect(response).to be == "192.168.172.0/25"
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        resource_group_name = 'rgrp-3'
-        vnet_name = 'vnet-5'
+        resource_group_name = "rgrp-3"
+        vnet_name = "vnet-5"
         @subnet = subnet(resource_group_name, vnet_name, 4)
       end
 
-      it 'returns the address_prefix of the subnet present under the given resource_group and vnet_name at the 4th index' do
+      it "returns the address_prefix of the subnet present under the given resource_group and vnet_name at the 4th index" do
         response = @dummy_class.subnet_address_prefix(@subnet)
         expect(response.class).to be == String
-        expect(response).to be == '12.3.19.128/25'
+        expect(response).to be == "12.3.19.128/25"
       end
     end
   end
 
-  describe 'sort_available_networks' do
-    context 'example-1' do
+  describe "sort_available_networks" do
+    context "example-1" do
       before do
-        @available_networks = [ IPAddress('10.16.48.0/20'),
-          IPAddress('10.16.32.0/24'),
-          IPAddress('12.23.19.0/24'),
-          IPAddress('221.17.234.0/29'),
-          IPAddress('133.78.152.0/25'),
-          IPAddress('11.13.48.0/20')
+        @available_networks = [ IPAddress("10.16.48.0/20"),
+          IPAddress("10.16.32.0/24"),
+          IPAddress("12.23.19.0/24"),
+          IPAddress("221.17.234.0/29"),
+          IPAddress("133.78.152.0/25"),
+          IPAddress("11.13.48.0/20")
         ]
       end
 
-      it 'sorts the given pool of available_networks in ascending order of the network\'s address' do
+      it "sorts the given pool of available_networks in ascending order of the network's address" do
         response = @dummy_class.sort_available_networks(@available_networks)
-        expect("#{response[0].network.address}/#{response[0].prefix}").to be == '10.16.32.0/24'
-        expect("#{response[1].network.address}/#{response[1].prefix}").to be == '10.16.48.0/20'
-        expect("#{response[2].network.address}/#{response[2].prefix}").to be == '11.13.48.0/20'
-        expect("#{response[3].network.address}/#{response[3].prefix}").to be == '12.23.19.0/24'
-        expect("#{response[4].network.address}/#{response[4].prefix}").to be == '133.78.152.0/25'
-        expect("#{response[5].network.address}/#{response[5].prefix}").to be == '221.17.234.0/29'
+        expect("#{response[0].network.address}/#{response[0].prefix}").to be == "10.16.32.0/24"
+        expect("#{response[1].network.address}/#{response[1].prefix}").to be == "10.16.48.0/20"
+        expect("#{response[2].network.address}/#{response[2].prefix}").to be == "11.13.48.0/20"
+        expect("#{response[3].network.address}/#{response[3].prefix}").to be == "12.23.19.0/24"
+        expect("#{response[4].network.address}/#{response[4].prefix}").to be == "133.78.152.0/25"
+        expect("#{response[5].network.address}/#{response[5].prefix}").to be == "221.17.234.0/29"
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        @available_networks = [ IPAddress('159.10.0.0/16'),
-          IPAddress('28.65.42.0/24'),
-          IPAddress('165.98.0.0/20'),
-          IPAddress('192.168.172.0/24'),
-          IPAddress('31.66.12.128/25'),
-          IPAddress('10.9.0.0/16')
+        @available_networks = [ IPAddress("159.10.0.0/16"),
+          IPAddress("28.65.42.0/24"),
+          IPAddress("165.98.0.0/20"),
+          IPAddress("192.168.172.0/24"),
+          IPAddress("31.66.12.128/25"),
+          IPAddress("10.9.0.0/16")
         ]
       end
 
-      it 'sorts the given pool of available_networks in ascending order of the network\'s address' do
+      it "sorts the given pool of available_networks in ascending order of the network's address" do
         response = @dummy_class.sort_available_networks(@available_networks)
-        expect("#{response[0].network.address}/#{response[0].prefix}").to be == '10.9.0.0/16'
-        expect("#{response[1].network.address}/#{response[1].prefix}").to be == '28.65.42.0/24'
-        expect("#{response[2].network.address}/#{response[2].prefix}").to be == '31.66.12.128/25'
-        expect("#{response[3].network.address}/#{response[3].prefix}").to be == '159.10.0.0/16'
-        expect("#{response[4].network.address}/#{response[4].prefix}").to be == '165.98.0.0/20'
-        expect("#{response[5].network.address}/#{response[5].prefix}").to be == '192.168.172.0/24'
+        expect("#{response[0].network.address}/#{response[0].prefix}").to be == "10.9.0.0/16"
+        expect("#{response[1].network.address}/#{response[1].prefix}").to be == "28.65.42.0/24"
+        expect("#{response[2].network.address}/#{response[2].prefix}").to be == "31.66.12.128/25"
+        expect("#{response[3].network.address}/#{response[3].prefix}").to be == "159.10.0.0/16"
+        expect("#{response[4].network.address}/#{response[4].prefix}").to be == "165.98.0.0/20"
+        expect("#{response[5].network.address}/#{response[5].prefix}").to be == "192.168.172.0/24"
       end
     end
   end
 
-  describe 'sort_subnets_by_cidr_prefix' do
-    context 'example-1' do
+  describe "sort_subnets_by_cidr_prefix" do
+    context "example-1" do
       before do
-        resource_group_name = 'rgrp-2'
-        vnet_name = 'vnet-2'
+        resource_group_name = "rgrp-2"
+        vnet_name = "vnet-2"
         @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
 
-        resource_group_name = 'rgrp-1'
-        vnet_name = 'vnet-1'
+        resource_group_name = "rgrp-1"
+        vnet_name = "vnet-1"
         @subnets.push(stub_subnets_list_response(
           resource_group_name, vnet_name)).flatten!
       end
 
-      it 'returns the sorted list of subnets in ascending order of their cidr prefix' do
+      it "returns the sorted list of subnets in ascending order of their cidr prefix" do
         response = @dummy_class.sort_subnets_by_cidr_prefix(@subnets)
-        expect(response[0].address_prefix).to be == '10.2.0.0/20'
-        expect(response[1].address_prefix).to be == '10.1.48.0/20'
-        expect(response[2].address_prefix).to be == '10.1.0.0/24'
-        expect(response[3].address_prefix).to be == '192.168.172.0/25'
-        expect(response[4].address_prefix).to be == '10.2.16.0/28'
+        expect(response[0].address_prefix).to be == "10.2.0.0/20"
+        expect(response[1].address_prefix).to be == "10.1.48.0/20"
+        expect(response[2].address_prefix).to be == "10.1.0.0/24"
+        expect(response[3].address_prefix).to be == "192.168.172.0/25"
+        expect(response[4].address_prefix).to be == "10.2.16.0/28"
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        resource_group_name = 'rgrp-3'
-        vnet_name = 'vnet-5'
+        resource_group_name = "rgrp-3"
+        vnet_name = "vnet-5"
         @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
       end
 
-      it 'returns the sorted list of subnets in ascending order of their cidr prefix' do
+      it "returns the sorted list of subnets in ascending order of their cidr prefix" do
         response = @dummy_class.sort_subnets_by_cidr_prefix(@subnets)
-        expect(response[0].address_prefix).to be == '69.182.9.0/24'
-        expect(response[1].address_prefix).to be == '69.182.11.0/24'
-        expect(response[2].address_prefix).to be == '69.182.14.0/24'
-        expect(response[3].address_prefix).to be == '12.3.19.0/25'
-        expect(response[4].address_prefix).to be == '12.3.19.128/25'
+        expect(response[0].address_prefix).to be == "69.182.9.0/24"
+        expect(response[1].address_prefix).to be == "69.182.11.0/24"
+        expect(response[2].address_prefix).to be == "69.182.14.0/24"
+        expect(response[3].address_prefix).to be == "12.3.19.0/25"
+        expect(response[4].address_prefix).to be == "12.3.19.128/25"
       end
     end
   end
 
-  describe 'sort_used_networks_by_hosts_size' do
-    context 'example-1' do
+  describe "sort_used_networks_by_hosts_size" do
+    context "example-1" do
       before do
-        resource_group_name = 'rgrp-2'
-        vnet_name = 'vnet-2'
+        resource_group_name = "rgrp-2"
+        vnet_name = "vnet-2"
         subnets = stub_subnets_list_response(resource_group_name, vnet_name)
 
-        resource_group_name = 'rgrp-1'
-        vnet_name = 'vnet-1'
+        resource_group_name = "rgrp-1"
+        vnet_name = "vnet-1"
         subnets.push(stub_subnets_list_response(
           resource_group_name, vnet_name)
         ).flatten!
@@ -426,24 +427,24 @@ describe Azure::ARM::VnetConfig do
         @used_networks_pool = used_networks(subnets)
       end
 
-      it 'returns the list of used_networks sorted in descending order of their hosts size' do
+      it "returns the list of used_networks sorted in descending order of their hosts size" do
         response = @dummy_class.sort_used_networks_by_hosts_size(@used_networks_pool)
-        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == '10.2.0.0/20'
-        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == '10.1.48.0/20'
-        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == '10.1.0.0/24'
-        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == '192.168.172.0/25'
-        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == '10.2.16.0/28'
+        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == "10.2.0.0/20"
+        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == "10.1.48.0/20"
+        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == "10.1.0.0/24"
+        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == "192.168.172.0/25"
+        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == "10.2.16.0/28"
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        resource_group_name = 'rgrp-3'
-        vnet_name = 'vnet-4'
+        resource_group_name = "rgrp-3"
+        vnet_name = "vnet-4"
         subnets = stub_subnets_list_response(resource_group_name, vnet_name)
 
-        resource_group_name = 'rgrp-3'
-        vnet_name = 'vnet-5'
+        resource_group_name = "rgrp-3"
+        vnet_name = "vnet-5"
         subnets.push(stub_subnets_list_response(
           resource_group_name, vnet_name)
         ).flatten!
@@ -451,60 +452,60 @@ describe Azure::ARM::VnetConfig do
         @used_networks_pool = used_networks(subnets)
       end
 
-      it 'returns the list of used_networks sorted in descending order of their hosts size', :if => (RUBY_VERSION.to_f <= 2.1) do
+      it "returns the list of used_networks sorted in descending order of their hosts size", :if => (RUBY_VERSION.to_f <= 2.1) do
         response = @dummy_class.sort_used_networks_by_hosts_size(@used_networks_pool)
-        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == '69.182.14.0/24'
-        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == '69.182.9.0/24'
-        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == '69.182.11.0/24'
-        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == '12.3.19.128/25'
-        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == '12.3.19.0/25'
-        expect(response[5].network.address.concat("/" + response[5].prefix.to_s)).to be == '40.23.19.0/29'
+        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == "69.182.14.0/24"
+        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == "69.182.9.0/24"
+        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == "69.182.11.0/24"
+        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == "12.3.19.128/25"
+        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == "12.3.19.0/25"
+        expect(response[5].network.address.concat("/" + response[5].prefix.to_s)).to be == "40.23.19.0/29"
       end
 
-      it 'returns the list of used_networks sorted in descending order of their hosts size', :if => (RUBY_VERSION.to_f >= 2.2) do
+      it "returns the list of used_networks sorted in descending order of their hosts size", :if => (RUBY_VERSION.to_f >= 2.2) do
         response = @dummy_class.sort_used_networks_by_hosts_size(@used_networks_pool)
-        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == '69.182.9.0/24'
-        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == '69.182.11.0/24'
-        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == '69.182.14.0/24'
-        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == '12.3.19.0/25'
-        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == '12.3.19.128/25'
-        expect(response[5].network.address.concat("/" + response[5].prefix.to_s)).to be == '40.23.19.0/29'
+        expect(response[0].network.address.concat("/" + response[0].prefix.to_s)).to be == "69.182.9.0/24"
+        expect(response[1].network.address.concat("/" + response[1].prefix.to_s)).to be == "69.182.11.0/24"
+        expect(response[2].network.address.concat("/" + response[2].prefix.to_s)).to be == "69.182.14.0/24"
+        expect(response[3].network.address.concat("/" + response[3].prefix.to_s)).to be == "12.3.19.0/25"
+        expect(response[4].network.address.concat("/" + response[4].prefix.to_s)).to be == "12.3.19.128/25"
+        expect(response[5].network.address.concat("/" + response[5].prefix.to_s)).to be == "40.23.19.0/29"
       end
     end
   end
 
-  describe 'subnet_cidr_prefix' do
-    context 'example-1' do
+  describe "subnet_cidr_prefix" do
+    context "example-1" do
       before do
-        resource_group_name = 'rgrp-3'
-        vnet_name = 'vnet-4'
+        resource_group_name = "rgrp-3"
+        vnet_name = "vnet-4"
         @subnet = subnet(resource_group_name, vnet_name, 0)
       end
 
-      it 'returns the cidr prefix of the given subnet' do
+      it "returns the cidr prefix of the given subnet" do
         response = @dummy_class.subnet_cidr_prefix(@subnet)
-        expect(response.class).to be == Fixnum
+        expect(response.class).to be == Integer
         expect(response).to be == 29
       end
     end
 
-    context 'example-2' do
+    context "example-2" do
       before do
-        resource_group_name = 'rgrp-2'
-        vnet_name = 'vnet-3'
+        resource_group_name = "rgrp-2"
+        vnet_name = "vnet-3"
         @subnet = subnet(resource_group_name, vnet_name, 1)
       end
 
-      it 'returns the cidr prefix of the given subnet' do
+      it "returns the cidr prefix of the given subnet" do
         response = @dummy_class.subnet_cidr_prefix(@subnet)
-        expect(response.class).to be == Fixnum
+        expect(response.class).to be == Integer
         expect(response).to be == 25
       end
     end
   end
 
-  describe 'sort_pools' do
-    it 'invokes sort methods for available_networks_pool and used_networks_pool' do
+  describe "sort_pools" do
+    it "invokes sort methods for available_networks_pool and used_networks_pool" do
       expect(@dummy_class).to receive(:sort_available_networks).and_return([])
       expect(@dummy_class).to receive(:sort_used_networks_by_hosts_size).and_return([])
       response1, response2 = @dummy_class.sort_pools([], [])
@@ -513,65 +514,65 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'divide_network' do
-    context 'very large network is passed' do
-      context 'example-1' do
-        it 'divides the network into medium sized subnets' do
-          response = @dummy_class.divide_network('10.2.0.0/16')
-          expect(response).to be == '10.2.0.0/20'
+  describe "divide_network" do
+    context "very large network is passed" do
+      context "example-1" do
+        it "divides the network into medium sized subnets" do
+          response = @dummy_class.divide_network("10.2.0.0/16")
+          expect(response).to be == "10.2.0.0/20"
         end
       end
 
-      context 'example-2' do
-        it 'divides the network into medium sized subnets' do
-          response = @dummy_class.divide_network('10.2.0.0/19')
-          expect(response).to be == '10.2.0.0/20'
-        end
-      end
-    end
-
-    context 'medium sized network is passed' do
-      context 'example-1' do
-        it 'divides the network into smaller subnets' do
-          response = @dummy_class.divide_network('10.2.0.0/22')
-          expect(response).to be == '10.2.0.0/24'
-        end
-      end
-
-      context 'example-2' do
-        it 'divides the network into smaller subnets' do
-          response = @dummy_class.divide_network('10.2.0.0/20')
-          expect(response).to be == '10.2.0.0/24'
+      context "example-2" do
+        it "divides the network into medium sized subnets" do
+          response = @dummy_class.divide_network("10.2.0.0/19")
+          expect(response).to be == "10.2.0.0/20"
         end
       end
     end
 
-    context 'very small network is passed' do
-      context 'example-1' do
-        it 'does not divide the network and keeps it the same' do
-          response = @dummy_class.divide_network('10.2.0.0/28')
-          expect(response).to be == '10.2.0.0/28'
+    context "medium sized network is passed" do
+      context "example-1" do
+        it "divides the network into smaller subnets" do
+          response = @dummy_class.divide_network("10.2.0.0/22")
+          expect(response).to be == "10.2.0.0/24"
         end
       end
 
-      context 'example-2' do
-        it 'does not divide the network and keeps it the same' do
-          response = @dummy_class.divide_network('10.2.0.0/25')
-          expect(response).to be == '10.2.0.0/25'
+      context "example-2" do
+        it "divides the network into smaller subnets" do
+          response = @dummy_class.divide_network("10.2.0.0/20")
+          expect(response).to be == "10.2.0.0/24"
+        end
+      end
+    end
+
+    context "very small network is passed" do
+      context "example-1" do
+        it "does not divide the network and keeps it the same" do
+          response = @dummy_class.divide_network("10.2.0.0/28")
+          expect(response).to be == "10.2.0.0/28"
+        end
+      end
+
+      context "example-2" do
+        it "does not divide the network and keeps it the same" do
+          response = @dummy_class.divide_network("10.2.0.0/25")
+          expect(response).to be == "10.2.0.0/25"
         end
       end
     end
   end
 
-  describe 'in_use_network?' do
-    context 'subnet_network belongs to available_network' do
-      context 'example-1' do
+  describe "in_use_network?" do
+    context "subnet_network belongs to available_network" do
+      context "example-1" do
         before do
-          @subnet_network = IPAddress('79.224.43.229/24')
-          @available_network = IPAddress('79.224.43.0/24')
+          @subnet_network = IPAddress("79.224.43.229/24")
+          @available_network = IPAddress("79.224.43.0/24")
         end
 
-        it 'returns true' do
+        it "returns true" do
           response = @dummy_class.in_use_network?(
             @subnet_network, @available_network
           )
@@ -579,43 +580,13 @@ describe Azure::ARM::VnetConfig do
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          @subnet_network = IPAddress('152.23.13.65/24')
-          @available_network = IPAddress('152.23.0.0/20')
+          @subnet_network = IPAddress("152.23.13.65/24")
+          @available_network = IPAddress("152.23.0.0/20")
         end
 
-        it 'returns true' do
-          response = @dummy_class.in_use_network?(
-            @subnet_network, @available_network
-          )
-          expect(response).to be == true
-        end
-      end
-    end
-
-    context 'available_network belongs to subnet_network' do
-      context 'example-1' do
-        before do
-          @subnet_network = IPAddress('79.224.43.0/24')
-          @available_network = IPAddress('79.224.43.229/24')
-        end
-
-        it 'returns true' do
-          response = @dummy_class.in_use_network?(
-            @subnet_network, @available_network
-          )
-          expect(response).to be == true
-        end
-      end
-
-      context 'example-2' do
-        before do
-          @subnet_network = IPAddress('152.23.0.0/20')
-          @available_network = IPAddress('152.23.13.65/24')
-        end
-
-        it 'returns true' do
+        it "returns true" do
           response = @dummy_class.in_use_network?(
             @subnet_network, @available_network
           )
@@ -624,62 +595,92 @@ describe Azure::ARM::VnetConfig do
       end
     end
 
-    context 'none of the network belongs to the other one' do
-      context 'example-1' do
+    context "available_network belongs to subnet_network" do
+      context "example-1" do
         before do
-          @subnet_network = IPAddress('139.12.78.0/25')
-          @available_network = IPAddress('139.12.78.231')
+          @subnet_network = IPAddress("79.224.43.0/24")
+          @available_network = IPAddress("79.224.43.229/24")
         end
 
-        it 'returns false' do
+        it "returns true" do
           response = @dummy_class.in_use_network?(
-            @subnet_network,@available_network
+            @subnet_network, @available_network
           )
-          expect(response).to be == false
+          expect(response).to be == true
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          @subnet_network = IPAddress('208.140.12.0/24')
-          @available_network = IPAddress('208.140.10.0/24')
+          @subnet_network = IPAddress("152.23.0.0/20")
+          @available_network = IPAddress("152.23.13.65/24")
         end
 
-        it 'returns false' do
+        it "returns true" do
+          response = @dummy_class.in_use_network?(
+            @subnet_network, @available_network
+          )
+          expect(response).to be == true
+        end
+      end
+    end
+
+    context "none of the network belongs to the other one" do
+      context "example-1" do
+        before do
+          @subnet_network = IPAddress("139.12.78.0/25")
+          @available_network = IPAddress("139.12.78.231")
+        end
+
+        it "returns false" do
           response = @dummy_class.in_use_network?(
             @subnet_network, @available_network
           )
           expect(response).to be == false
         end
       end
+
+      context "example-2" do
+        before do
+          @subnet_network = IPAddress("208.140.12.0/24")
+          @available_network = IPAddress("208.140.10.0/24")
+        end
+
+        it "returns false" do
+          response = @dummy_class.in_use_network?(
+            @subnet_network, @available_network
+          )
+          expect(response).to be == false
+        end
+      end
     end
   end
 
-  describe 'new_subnet_address_prefix' do
-    context 'no subnets exist under the given vnet address space' do
-      it 'invokes the divide_network method' do
+  describe "new_subnet_address_prefix" do
+    context "no subnets exist under the given vnet address space" do
+      it "invokes the divide_network method" do
         expect(@dummy_class).to receive(:divide_network)
-        @dummy_class.new_subnet_address_prefix('', [])
+        @dummy_class.new_subnet_address_prefix("", [])
       end
 
-      it 'invokes divide_network method and return the new subnet prefix value' do
-        response = @dummy_class.new_subnet_address_prefix('11.23.0.0/16', [])
-        expect(response).to be == '11.23.0.0/20'
+      it "invokes divide_network method and return the new subnet prefix value" do
+        response = @dummy_class.new_subnet_address_prefix("11.23.0.0/16", [])
+        expect(response).to be == "11.23.0.0/20"
       end
 
-      it 'invokes divide_network method and return the same vnet prefix value for the new subnet prefix' do
-        response = @dummy_class.new_subnet_address_prefix('192.168.172.128/25', [])
-        expect(response).to be == '192.168.172.128/25'
+      it "invokes divide_network method and return the same vnet prefix value for the new subnet prefix" do
+        response = @dummy_class.new_subnet_address_prefix("192.168.172.128/25", [])
+        expect(response).to be == "192.168.172.128/25"
       end
     end
 
-    context 'subnets exist under the given vnet address space' do
-      context 'space available in the vnet address space for the addition of new subnet' do
-        context 'example-1' do
+    context "subnets exist under the given vnet address space" do
+      context "space available in the vnet address space for the addition of new subnet" do
+        context "example-1" do
           before do
-            resource_group_name = 'rgrp-1'
-            vnet_name = 'vnet-1'
-            @vnet_address_prefix = '10.1.0.0/16'
+            resource_group_name = "rgrp-1"
+            vnet_name = "vnet-1"
+            @vnet_address_prefix = "10.1.0.0/16"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, resource_group_name, vnet_name)
             )
@@ -688,19 +689,19 @@ describe Azure::ARM::VnetConfig do
             )
           end
 
-          it 'returns the address prefix for the new subnet' do
+          it "returns the address prefix for the new subnet" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == '10.1.1.0/24'
+            expect(response).to be == "10.1.1.0/24"
           end
         end
 
-        context 'example-2' do
+        context "example-2" do
           before do
-            resource_group_name = 'rgrp-2'
-            vnet_name = 'vnet-2'
-            @vnet_address_prefix = '192.168.172.0/24'
+            resource_group_name = "rgrp-2"
+            vnet_name = "vnet-2"
+            @vnet_address_prefix = "192.168.172.0/24"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, resource_group_name, vnet_name)
             )
@@ -709,19 +710,19 @@ describe Azure::ARM::VnetConfig do
             )
           end
 
-          it 'returns the address prefix for the new subnet' do
+          it "returns the address prefix for the new subnet" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == '192.168.172.128/25'
+            expect(response).to be == "192.168.172.128/25"
           end
         end
 
-        context 'example-3' do
+        context "example-3" do
           before do
-            resource_group_name = 'rgrp-3'
-            vnet_name = 'vnet-5'
-            @vnet_address_prefix = '69.182.8.0/21'
+            resource_group_name = "rgrp-3"
+            vnet_name = "vnet-5"
+            @vnet_address_prefix = "69.182.8.0/21"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, resource_group_name, vnet_name)
             )
@@ -730,21 +731,21 @@ describe Azure::ARM::VnetConfig do
             )
           end
 
-          it 'returns the address prefix for the new subnet' do
+          it "returns the address prefix for the new subnet" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == '69.182.8.0/24'
+            expect(response).to be == "69.182.8.0/24"
           end
         end
       end
 
-      context 'space not available in the vnet address space for the addition of new subnet' do
-        context 'example-1' do
+      context "space not available in the vnet address space for the addition of new subnet" do
+        context "example-1" do
           before do
-            resource_group_name = 'rgrp-3'
-            vnet_name = 'vnet-4'
-            @vnet_address_prefix = '40.23.19.0/29'
+            resource_group_name = "rgrp-3"
+            vnet_name = "vnet-4"
+            @vnet_address_prefix = "40.23.19.0/29"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, resource_group_name, vnet_name)
             )
@@ -753,19 +754,19 @@ describe Azure::ARM::VnetConfig do
             )
           end
 
-          it 'returns nil' do
+          it "returns nil" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == nil
+            expect(response).to be.nil?
           end
         end
 
-        context 'example-2' do
+        context "example-2" do
           before do
-            resource_group_name = 'rgrp-3'
-            vnet_name = 'vnet-5'
-            @vnet_address_prefix = '12.3.19.0/24'
+            resource_group_name = "rgrp-3"
+            vnet_name = "vnet-5"
+            @vnet_address_prefix = "12.3.19.0/24"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, resource_group_name, vnet_name)
             )
@@ -774,168 +775,170 @@ describe Azure::ARM::VnetConfig do
             )
           end
 
-          it 'returns nil' do
+          it "returns nil" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == nil
+            expect(response).to be.nil?
           end
         end
 
-        context 'example-3' do
+        context "example-3" do
           before do
-            @vnet_address_prefix = '62.12.3.128/25'
-            @subnets = [OpenStruct.new({'name'=> 'sbn17',
-                'address_prefix'=> '62.12.3.128/25'
+            @vnet_address_prefix = "62.12.3.128/25"
+            @subnets = [OpenStruct.new({ "name" => "sbn17",
+                                         "address_prefix" => "62.12.3.128/25"
             })]
           end
 
-          it 'returns nil' do
+          it "returns nil" do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be == nil
+            expect(response).to be.nil?
           end
         end
       end
     end
   end
 
-  describe 'add_subnet' do
-    context 'space does not exist in any of the address_prefixes of the virtual network' do
-      context 'example-1' do
+  describe "add_subnet" do
+    context "space does not exist in any of the address_prefixes of the virtual network" do
+      context "example-1" do
         before do
-          resource_group_name = 'rgrp-4'
-          vnet_name = 'vnet-6'
+          resource_group_name = "rgrp-4"
+          vnet_name = "vnet-6"
           @vnet_config = { :virtualNetworkName => vnet_name,
-            :addressPrefixes => [ '130.88.9.0/24', '112.90.2.0/24' ],
-            :subnets => Array.new
+                           :addressPrefixes => [ "130.88.9.0/24", "112.90.2.0/24" ],
+                           :subnets => Array.new
           }
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
         end
 
-        it 'raises error saying no space available to add subnet' do
-          expect{ @dummy_class.add_subnet('sbn18',
-            @vnet_config, @subnets) }.to raise_error(RuntimeError,
+        it "raises error saying no space available to add subnet" do
+          expect do
+            @dummy_class.add_subnet("sbn18",
+            @vnet_config, @subnets) end.to raise_error(RuntimeError,
               "Unable to add subnet sbn18 into the virtual network #{@vnet_config[:virtualNetworkName]}, no address space available !!!"
             )
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          @vnet_config = { :virtualNetworkName => 'vnet-6',
-            :addressPrefixes => [ '10.10.11.0/24' ],
-            :subnets => Array.new
+          @vnet_config = { :virtualNetworkName => "vnet-6",
+                           :addressPrefixes => [ "10.10.11.0/24" ],
+                           :subnets => Array.new
           }
-          @subnets = [OpenStruct.new({'name'=> 'sbn19',
-              'address_prefix'=> '10.10.11.0/25'
+          @subnets = [OpenStruct.new({ "name" => "sbn19",
+                                       "address_prefix" => "10.10.11.0/25"
           }),
-          OpenStruct.new({'name'=> 'sbn20',
-              'address_prefix'=> '10.10.11.128/26'
+          OpenStruct.new({ "name" => "sbn20",
+                           "address_prefix" => "10.10.11.128/26"
           }),
-          OpenStruct.new({'name'=> 'sbn21',
-              'address_prefix'=> '10.10.11.192/26'
+          OpenStruct.new({ "name" => "sbn21",
+                           "address_prefix" => "10.10.11.192/26"
           })]
         end
 
-        it 'raises error saying no space available to add subnet' do
-          expect{ @dummy_class.add_subnet('sbn22',
-            @vnet_config, @subnets) }.to raise_error(RuntimeError,
+        it "raises error saying no space available to add subnet" do
+          expect do
+            @dummy_class.add_subnet("sbn22",
+            @vnet_config, @subnets) end.to raise_error(RuntimeError,
               "Unable to add subnet sbn22 into the virtual network #{@vnet_config[:virtualNetworkName]}, no address space available !!!"
             )
         end
       end
     end
 
-    context 'space exist in the virtual network' do
-      context 'example-1' do
+    context "space exist in the virtual network" do
+      context "example-1" do
         before do
-          resource_group_name = 'rgrp-3'
-          vnet_name = 'vnet-4'
-          @subnet_name = 'sbn23'
-          new_subnet_prefix = '10.15.0.0/24'
+          resource_group_name = "rgrp-3"
+          vnet_name = "vnet-4"
+          @subnet_name = "sbn23"
+          new_subnet_prefix = "10.15.0.0/24"
           @vnet_config = { :virtualNetworkName => vnet_name,
-            :addressPrefixes => [ '10.15.0.0/20', '40.23.19.0/29' ],
-            :subnets => [{'name'=> 'sbn8',
-              'properties'=> {
-                'address_prefix'=> '40.23.19.0/29'
+                           :addressPrefixes => [ "10.15.0.0/20", "40.23.19.0/29" ],
+                           :subnets => [{ "name" => "sbn8",
+                                          "properties" => {
+                "address_prefix" => "40.23.19.0/29"
               }
             }]
           }
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
           @updated_vnet_config = { :virtualNetworkName => vnet_name,
-            :addressPrefixes => [ '10.15.0.0/20', '40.23.19.0/29' ],
-            :subnets => [{'name'=> 'sbn8',
-              'properties'=> {
-                'address_prefix'=> '40.23.19.0/29'
+                                   :addressPrefixes => [ "10.15.0.0/20", "40.23.19.0/29" ],
+                                   :subnets => [{ "name" => "sbn8",
+                                                  "properties" => {
+                "address_prefix" => "40.23.19.0/29"
               }
             },
-            {'name'=> 'sbn23',
-              'properties'=> {
-                'addressPrefix'=> new_subnet_prefix
+            { "name" => "sbn23",
+              "properties" => {
+                "addressPrefix" => new_subnet_prefix
               }
             }]
           }
         end
 
-        it 'returns the updated vnet_config with the hash added for the new subnet' do
+        it "returns the updated vnet_config with the hash added for the new subnet" do
           response = @dummy_class.add_subnet(@subnet_name, @vnet_config, @subnets)
           expect(response).to be == @updated_vnet_config
         end
       end
 
-      context 'example-2' do
+      context "example-2" do
         before do
-          resource_group_name = 'rgrp-2'
-          vnet_name = 'vnet-2'
-          @subnet_name = 'sbn24'
-          new_subnet_prefix = '10.2.16.16/28'
+          resource_group_name = "rgrp-2"
+          vnet_name = "vnet-2"
+          @subnet_name = "sbn24"
+          new_subnet_prefix = "10.2.16.16/28"
           @vnet_config = { :virtualNetworkName => vnet_name,
-            :addressPrefixes => [ '10.2.0.0/16', '192.168.172.0/24', '16.2.0.0/24' ],
-            :subnets => [{'name'=> 'sbn3',
-              'properties'=> {
-                'address_prefix'=> '10.2.0.0/20'
+                           :addressPrefixes => [ "10.2.0.0/16", "192.168.172.0/24", "16.2.0.0/24" ],
+                           :subnets => [{ "name" => "sbn3",
+                                          "properties" => {
+                "address_prefix" => "10.2.0.0/20"
               }
             },
-            {'name'=> 'sbn4',
-              'properties'=> {
-                'address_prefix'=> '192.168.172.0/25'
+            { "name" => "sbn4",
+              "properties" => {
+                "address_prefix" => "192.168.172.0/25"
               }
             },
-            {'name'=> 'sbn5',
-              'properties'=> {
-                'address_prefix'=> '10.2.16.0/28'
+            { "name" => "sbn5",
+              "properties" => {
+                "address_prefix" => "10.2.16.0/28"
               }
             }]
           }
           @subnets = stub_subnets_list_response(resource_group_name, vnet_name)
           @updated_vnet_config = { :virtualNetworkName => vnet_name,
-            :addressPrefixes => [ '10.2.0.0/16', '192.168.172.0/24', '16.2.0.0/24' ],
-            :subnets => [{'name'=> 'sbn3',
-              'properties'=> {
-                'address_prefix'=> '10.2.0.0/20'
+                                   :addressPrefixes => [ "10.2.0.0/16", "192.168.172.0/24", "16.2.0.0/24" ],
+                                   :subnets => [{ "name" => "sbn3",
+                                                  "properties" => {
+                "address_prefix" => "10.2.0.0/20"
               }
             },
-            {'name'=> 'sbn4',
-              'properties'=> {
-                'address_prefix'=> '192.168.172.0/25'
+            { "name" => "sbn4",
+              "properties" => {
+                "address_prefix" => "192.168.172.0/25"
               }
             },
-            {'name'=> 'sbn5',
-              'properties'=> {
-                'address_prefix'=> '10.2.16.0/28'
+            { "name" => "sbn5",
+              "properties" => {
+                "address_prefix" => "10.2.16.0/28"
               }
             },
-            {'name'=> 'sbn24',
-              'properties'=> {
-                'addressPrefix'=> new_subnet_prefix
+            { "name" => "sbn24",
+              "properties" => {
+                "addressPrefix" => new_subnet_prefix
               }
             }]
           }
         end
 
-        it 'returns the updated vnet_config with the hash added for the new subnet' do
+        it "returns the updated vnet_config with the hash added for the new subnet" do
           response = @dummy_class.add_subnet(@subnet_name, @vnet_config, @subnets)
           expect(response).to be == @updated_vnet_config
         end
@@ -943,24 +946,24 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'create_vnet_config' do
-    context 'user passed or default named vnet does not exist in the given resource_group' do
+  describe "create_vnet_config" do
+    context "user passed or default named vnet does not exist in the given resource_group" do
       before do
-        @resource_group_name = 'rgrp-1'
-        @vnet_name = 'vnet-11'
-        @subnet_name = 'sbn11'
+        @resource_group_name = "rgrp-1"
+        @vnet_name = "vnet-11"
+        @subnet_name = "sbn11"
         allow(@dummy_class).to receive(:get_vnet).and_return(false)
-        @vnet_config = {:virtualNetworkName => 'vnet-11',
-          :addressPrefixes => [ "10.0.0.0/16" ],
-          :subnets => [{'name'=> 'sbn11',
-            'properties'=> {
-              'addressPrefix'=> '10.0.0.0/24'
+        @vnet_config = { :virtualNetworkName => "vnet-11",
+                         :addressPrefixes => [ "10.0.0.0/16" ],
+                         :subnets => [{ "name" => "sbn11",
+                                        "properties" => {
+              "addressPrefix" => "10.0.0.0/24"
             }
           }]
         }
       end
 
-      it 'returns vnet_config with default values for vnet and subnet configurations' do
+      it "returns vnet_config with default values for vnet and subnet configurations" do
         response = @dummy_class.create_vnet_config(
           @resource_group_name, @vnet_name, @subnet_name
         )
@@ -968,31 +971,31 @@ describe Azure::ARM::VnetConfig do
       end
     end
 
-    context 'user passed or default named vnet exist in the given resource_group' do
-      context 'user passed or default named subnet exist in the given virtual network' do
-        context 'example-1' do
+    context "user passed or default named vnet exist in the given resource_group" do
+      context "user passed or default named subnet exist in the given virtual network" do
+        context "example-1" do
           before do
-            @resource_group_name = 'rgrp-2'
-            @vnet_name = 'vnet-3'
-            @subnet_name = 'sbn7'
+            @resource_group_name = "rgrp-2"
+            @vnet_name = "vnet-3"
+            @subnet_name = "sbn7"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-            @vnet_config = @vnet_config = { :virtualNetworkName => 'vnet-3',
-              :addressPrefixes => [ '25.3.16.0/20', '141.154.163.0/26' ],
-              :subnets => [{'name'=> 'sbn6',
-                'properties'=> {
-                  'addressPrefix'=> '25.3.29.0/25'
+            @vnet_config = @vnet_config = { :virtualNetworkName => "vnet-3",
+                                            :addressPrefixes => [ "25.3.16.0/20", "141.154.163.0/26" ],
+                                            :subnets => [{ "name" => "sbn6",
+                                                           "properties" => {
+                  "addressPrefix" => "25.3.29.0/25"
                 }
               },
-              {'name'=> 'sbn7',
-                'properties'=> {
-                  'addressPrefix'=> '25.3.29.128/25'
+              { "name" => "sbn7",
+                "properties" => {
+                  "addressPrefix" => "25.3.29.128/25"
                 }
               }]
             }
           end
 
-          it 'returns vnet_config with no change' do
+          it "returns vnet_config with no change" do
             response = @dummy_class.create_vnet_config(
               @resource_group_name, @vnet_name, @subnet_name
             )
@@ -1000,24 +1003,24 @@ describe Azure::ARM::VnetConfig do
           end
         end
 
-        context 'example-2' do
+        context "example-2" do
           before do
-            @resource_group_name = 'rgrp-3'
-            @vnet_name = 'vnet-4'
-            @subnet_name = 'sbn8'
+            @resource_group_name = "rgrp-3"
+            @vnet_name = "vnet-4"
+            @subnet_name = "sbn8"
             allow(@dummy_class).to receive(:network_resource_client).and_return(
               stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-            @vnet_config = @vnet_config = { :virtualNetworkName => 'vnet-4',
-              :addressPrefixes => [ '10.15.0.0/20', '40.23.19.0/29' ],
-              :subnets => [{'name'=> 'sbn8',
-                'properties'=> {
-                  'addressPrefix'=> '40.23.19.0/29'
+            @vnet_config = @vnet_config = { :virtualNetworkName => "vnet-4",
+                                            :addressPrefixes => [ "10.15.0.0/20", "40.23.19.0/29" ],
+                                            :subnets => [{ "name" => "sbn8",
+                                                           "properties" => {
+                  "addressPrefix" => "40.23.19.0/29"
                 }
               }]
             }
           end
 
-          it 'returns vnet_config with no change' do
+          it "returns vnet_config with no change" do
             response = @dummy_class.create_vnet_config(
               @resource_group_name, @vnet_name, @subnet_name
             )
@@ -1026,109 +1029,111 @@ describe Azure::ARM::VnetConfig do
         end
       end
 
-      context 'user passed or default named subnet does not exist in the given virtual network' do
-        context 'no space available in the given virtual network to add the new subnet' do
-          context 'example-1' do
+      context "user passed or default named subnet does not exist in the given virtual network" do
+        context "no space available in the given virtual network to add the new subnet" do
+          context "example-1" do
             before do
-              @resource_group_name = 'rgrp-4'
-              @vnet_name = 'vnet-6'
-              @subnet_name = 'sbn40'
+              @resource_group_name = "rgrp-4"
+              @vnet_name = "vnet-6"
+              @subnet_name = "sbn40"
               allow(@dummy_class).to receive(:network_resource_client).and_return(
                 stub_network_resource_client(nil, @resource_group_name, @vnet_name))
             end
 
-            it 'raises error' do
-              expect{ @dummy_class.create_vnet_config(
+            it "raises error" do
+              expect do
+                @dummy_class.create_vnet_config(
                 @resource_group_name, @vnet_name, @subnet_name)
-              }.to raise_error(RuntimeError,
+              end.to raise_error(RuntimeError,
                   "Unable to add subnet #{@subnet_name} into the virtual network #{@vnet_name}, no address space available !!!"
                 )
             end
           end
 
-          context 'example-2' do
+          context "example-2" do
             before do
-              @resource_group_name = 'rgrp-5'
-              @vnet_name = 'vnet-50'
-              @subnet_name = 'sbn60'
+              @resource_group_name = "rgrp-5"
+              @vnet_name = "vnet-50"
+              @subnet_name = "sbn60"
 
-              subnets = [OpenStruct.new({'name'=> 'sbn19',
-                  'address_prefix'=> '10.10.11.0/25'
+              subnets = [OpenStruct.new({ "name" => "sbn19",
+                                          "address_prefix" => "10.10.11.0/25"
               }),
-              OpenStruct.new({'name'=> 'sbn20',
-                  'address_prefix'=> '10.10.11.128/26'
+              OpenStruct.new({ "name" => "sbn20",
+                               "address_prefix" => "10.10.11.128/26"
               }),
-              OpenStruct.new({'name'=> 'sbn21',
-                  'address_prefix'=> '10.10.11.192/26'
+              OpenStruct.new({ "name" => "sbn21",
+                               "address_prefix" => "10.10.11.192/26"
               })]
 
               vnet = OpenStruct.new({
-                'location' => 'westus',
-                  'address_space' => OpenStruct.new({
-                    'address_prefixes' => [ '10.10.11.0/24' ]
+                "location" => "westus",
+                "address_space" => OpenStruct.new({
+                    "address_prefixes" => [ "10.10.11.0/24" ]
                   }),
-                  'subnets' => subnets
+                "subnets" => subnets
               })
 
               allow(@dummy_class).to receive(:get_vnet).and_return(vnet)
               allow(@dummy_class).to receive(:subnets_list).and_return(subnets)
             end
 
-            it 'raises error' do
-              expect{ @dummy_class.create_vnet_config(
+            it "raises error" do
+              expect do
+                @dummy_class.create_vnet_config(
                 @resource_group_name, @vnet_name, @subnet_name)
-              }.to raise_error(RuntimeError,
+              end.to raise_error(RuntimeError,
                   "Unable to add subnet #{@subnet_name} into the virtual network #{@vnet_name}, no address space available !!!"
                 )
             end
           end
         end
 
-        context 'space available in the given virtual network to add the new subnet' do
-          context 'example for subnet allocation in first prefix' do
+        context "space available in the given virtual network to add the new subnet" do
+          context "example for subnet allocation in first prefix" do
             before do
-              @resource_group_name = 'rgrp-3'
-              @vnet_name = 'vnet-5'
-              @subnet_name = 'sbn27'
-              new_subnet_prefix = '69.182.8.0/24'
+              @resource_group_name = "rgrp-3"
+              @vnet_name = "vnet-5"
+              @subnet_name = "sbn27"
+              new_subnet_prefix = "69.182.8.0/24"
               allow(@dummy_class).to receive(:network_resource_client).and_return(
                 stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-              @vnet_config = { :virtualNetworkName => 'vnet-5',
-                :addressPrefixes => [ '69.182.8.0/21', '12.3.19.0/24' ],
-                :subnets => [{'name'=> 'sbn9',
-                  'properties'=> {
-                    'addressPrefix'=> '69.182.9.0/24'
+              @vnet_config = { :virtualNetworkName => "vnet-5",
+                               :addressPrefixes => [ "69.182.8.0/21", "12.3.19.0/24" ],
+                               :subnets => [{ "name" => "sbn9",
+                                              "properties" => {
+                    "addressPrefix" => "69.182.9.0/24"
                   }
                 },
-                {'name'=> 'sbn10',
-                  'properties'=> {
-                    'addressPrefix'=> '69.182.11.0/24'
+                { "name" => "sbn10",
+                  "properties" => {
+                    "addressPrefix" => "69.182.11.0/24"
                   }
                 },
-                {'name'=> 'sbn11',
-                  'properties'=> {
-                    'addressPrefix'=> '12.3.19.0/25'
+                { "name" => "sbn11",
+                  "properties" => {
+                    "addressPrefix" => "12.3.19.0/25"
                   }
                 },
-                {'name'=> 'sbn12',
-                  'properties'=> {
-                    'addressPrefix'=> '69.182.14.0/24'
+                { "name" => "sbn12",
+                  "properties" => {
+                    "addressPrefix" => "69.182.14.0/24"
                   }
                 },
-                {'name'=> 'sbn13',
-                  'properties'=> {
-                    'addressPrefix'=> '12.3.19.128/25'
+                { "name" => "sbn13",
+                  "properties" => {
+                    "addressPrefix" => "12.3.19.128/25"
                   }
                 },
-                {'name'=> 'sbn27',
-                  'properties'=> {
-                    'addressPrefix'=> new_subnet_prefix
+                { "name" => "sbn27",
+                  "properties" => {
+                    "addressPrefix" => new_subnet_prefix
                   }
                 }]
               }
             end
 
-            it 'returns vnet_config with new subnet added in first prefix' do
+            it "returns vnet_config with new subnet added in first prefix" do
               response = @dummy_class.create_vnet_config(
                 @resource_group_name, @vnet_name, @subnet_name
               )
@@ -1136,76 +1141,76 @@ describe Azure::ARM::VnetConfig do
             end
           end
 
-          context 'example for subnet allocation in subsequent prefix but first' do
+          context "example for subnet allocation in subsequent prefix but first" do
             before do
-              @resource_group_name = 'rgrp-6'
-              @vnet_name = 'vnet-60'
-              @subnet_name = 'sbn70'
-              new_subnet_prefix = '133.72.16.128/25'
+              @resource_group_name = "rgrp-6"
+              @vnet_name = "vnet-60"
+              @subnet_name = "sbn70"
+              new_subnet_prefix = "133.72.16.128/25"
 
-              subnets = [OpenStruct.new({'name'=> 'sbn19',
-                  'address_prefix'=> '10.10.11.0/25'
+              subnets = [OpenStruct.new({ "name" => "sbn19",
+                                          "address_prefix" => "10.10.11.0/25"
               }),
-              OpenStruct.new({'name'=> 'sbn20',
-                  'address_prefix'=> '10.10.11.128/26'
+              OpenStruct.new({ "name" => "sbn20",
+                               "address_prefix" => "10.10.11.128/26"
               }),
-              OpenStruct.new({'name'=> 'sbn21',
-                  'address_prefix'=> '10.10.11.192/26'
+              OpenStruct.new({ "name" => "sbn21",
+                               "address_prefix" => "10.10.11.192/26"
               }),
-              OpenStruct.new({'name'=> 'sbn22',
-                  'address_prefix'=> '192.168.172.0/24'
+              OpenStruct.new({ "name" => "sbn22",
+                               "address_prefix" => "192.168.172.0/24"
               }),
-              OpenStruct.new({'name'=> 'sbn23',
-                  'address_prefix'=> '133.72.16.0/25'
+              OpenStruct.new({ "name" => "sbn23",
+                               "address_prefix" => "133.72.16.0/25"
               })]
 
               vnet = OpenStruct.new({
-                'location' => 'westus',
-                  'address_space' => OpenStruct.new({
-                    'address_prefixes' => [ '10.10.11.0/24', '192.168.172.0/24', '133.72.16.0/24' ]
+                "location" => "westus",
+                "address_space" => OpenStruct.new({
+                    "address_prefixes" => [ "10.10.11.0/24", "192.168.172.0/24", "133.72.16.0/24" ]
                   }),
-                  'subnets' => subnets
+                "subnets" => subnets
               })
 
               allow(@dummy_class).to receive(:get_vnet).and_return(vnet)
               allow(@dummy_class).to receive(:subnets_list).and_return(subnets)
 
-              @vnet_config = { :virtualNetworkName => 'vnet-60',
-                :addressPrefixes => [ '10.10.11.0/24', '192.168.172.0/24', '133.72.16.0/24' ],
-                :subnets => [{'name'=> 'sbn19',
-                  'properties'=> {
-                    'addressPrefix'=> '10.10.11.0/25'
+              @vnet_config = { :virtualNetworkName => "vnet-60",
+                               :addressPrefixes => [ "10.10.11.0/24", "192.168.172.0/24", "133.72.16.0/24" ],
+                               :subnets => [{ "name" => "sbn19",
+                                              "properties" => {
+                    "addressPrefix" => "10.10.11.0/25"
                   }
                 },
-                {'name'=> 'sbn20',
-                  'properties'=> {
-                    'addressPrefix'=> '10.10.11.128/26'
+                { "name" => "sbn20",
+                  "properties" => {
+                    "addressPrefix" => "10.10.11.128/26"
                   }
                 },
-                {'name'=> 'sbn21',
-                  'properties'=> {
-                    'addressPrefix'=> '10.10.11.192/26'
+                { "name" => "sbn21",
+                  "properties" => {
+                    "addressPrefix" => "10.10.11.192/26"
                   }
                 },
-                {'name'=> 'sbn22',
-                  'properties'=> {
-                    'addressPrefix'=> '192.168.172.0/24'
+                { "name" => "sbn22",
+                  "properties" => {
+                    "addressPrefix" => "192.168.172.0/24"
                   }
                 },
-                {'name'=> 'sbn23',
-                  'properties'=> {
-                    'addressPrefix'=> '133.72.16.0/25'
+                { "name" => "sbn23",
+                  "properties" => {
+                    "addressPrefix" => "133.72.16.0/25"
                   }
                 },
-                {'name'=> 'sbn70',
-                  'properties'=> {
-                    'addressPrefix'=> new_subnet_prefix
+                { "name" => "sbn70",
+                  "properties" => {
+                    "addressPrefix" => new_subnet_prefix
                   }
                 }]
               }
             end
 
-            it 'returns vnet_config with new subnet added in subsequent prefix but first' do
+            it "returns vnet_config with new subnet added in subsequent prefix but first" do
               response = @dummy_class.create_vnet_config(
                 @resource_group_name, @vnet_name, @subnet_name
               )
@@ -1213,30 +1218,30 @@ describe Azure::ARM::VnetConfig do
             end
           end
 
-          context 'divide_network example' do
+          context "divide_network example" do
             before do
-              @resource_group_name = 'rgrp-3'
-              @vnet_name = 'vnet-4'
-              @subnet_name = 'sbn26'
-              new_subnet_prefix = '10.15.0.0/24'
+              @resource_group_name = "rgrp-3"
+              @vnet_name = "vnet-4"
+              @subnet_name = "sbn26"
+              new_subnet_prefix = "10.15.0.0/24"
               allow(@dummy_class).to receive(:network_resource_client).and_return(
                 stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-              @vnet_config = @vnet_config = { :virtualNetworkName => 'vnet-4',
-                :addressPrefixes => [ '10.15.0.0/20', '40.23.19.0/29' ],
-                :subnets => [{'name'=> 'sbn8',
-                  'properties'=> {
-                    'addressPrefix'=> '40.23.19.0/29'
+              @vnet_config = @vnet_config = { :virtualNetworkName => "vnet-4",
+                                              :addressPrefixes => [ "10.15.0.0/20", "40.23.19.0/29" ],
+                                              :subnets => [{ "name" => "sbn8",
+                                                             "properties" => {
+                    "addressPrefix" => "40.23.19.0/29"
                   }
                 },
-                {'name'=> 'sbn26',
-                  'properties'=> {
-                    'addressPrefix'=> new_subnet_prefix
+                { "name" => "sbn26",
+                  "properties" => {
+                    "addressPrefix" => new_subnet_prefix
                   }
                 }]
               }
             end
 
-            it 'returns vnet_config with new subnet added' do
+            it "returns vnet_config with new subnet added" do
               response = @dummy_class.create_vnet_config(
                 @resource_group_name, @vnet_name, @subnet_name
               )
@@ -1248,42 +1253,42 @@ describe Azure::ARM::VnetConfig do
     end
   end
 
-  describe 'GatewaySubnet' do
-    context 'user provided or default named virtual network exist along with GatewaySubnet and other subnets also present' do
-      context 'user provided or default named subnet does not exist in the virtual network' do
+  describe "GatewaySubnet" do
+    context "user provided or default named virtual network exist along with GatewaySubnet and other subnets also present" do
+      context "user provided or default named subnet does not exist in the virtual network" do
         before do
-          @resource_group_name = 'rgrp-4'
-          @vnet_name = 'vnet-7'
-          @subnet_name = 'sbn30'
-          new_subnet_prefix = '10.3.0.0/24'
+          @resource_group_name = "rgrp-4"
+          @vnet_name = "vnet-7"
+          @subnet_name = "sbn30"
+          new_subnet_prefix = "10.3.0.0/24"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-          @vnet_config = { :virtualNetworkName => 'vnet-7',
-            :addressPrefixes => [ '10.3.0.0/16', '160.10.2.0/24' ],
-            :subnets => [{'name'=> 'sbn15',
-              'properties'=> {
-                'addressPrefix'=> '160.10.2.192/26'
+          @vnet_config = { :virtualNetworkName => "vnet-7",
+                           :addressPrefixes => [ "10.3.0.0/16", "160.10.2.0/24" ],
+                           :subnets => [{ "name" => "sbn15",
+                                          "properties" => {
+                "addressPrefix" => "160.10.2.192/26"
               }
             },
-            {'name'=> 'GatewaySubnet',
-              'properties'=> {
-                'addressPrefix'=> '10.3.1.0/24'
+            { "name" => "GatewaySubnet",
+              "properties" => {
+                "addressPrefix" => "10.3.1.0/24"
               }
             },
-            {'name'=> 'sbn16',
-              'properties'=> {
-                'addressPrefix'=> '160.10.2.0/25'
+            { "name" => "sbn16",
+              "properties" => {
+                "addressPrefix" => "160.10.2.0/25"
               }
             },
-            {'name'=> 'sbn30',
-              'properties'=> {
-                'addressPrefix'=> new_subnet_prefix
+            { "name" => "sbn30",
+              "properties" => {
+                "addressPrefix" => new_subnet_prefix
               }
             }]
           }
         end
 
-        it 'returns vnet_config with GatewaySubnet along with other subnets preserved and also new subnet added' do
+        it "returns vnet_config with GatewaySubnet along with other subnets preserved and also new subnet added" do
           response = @dummy_class.create_vnet_config(
             @resource_group_name, @vnet_name, @subnet_name
           )
@@ -1291,34 +1296,34 @@ describe Azure::ARM::VnetConfig do
         end
       end
 
-      context 'user provided or default named subnet exist in the virtual network' do
+      context "user provided or default named subnet exist in the virtual network" do
         before do
-          @resource_group_name = 'rgrp-4'
-          @vnet_name = 'vnet-7'
-          @subnet_name = 'sbn16'
+          @resource_group_name = "rgrp-4"
+          @vnet_name = "vnet-7"
+          @subnet_name = "sbn16"
           allow(@dummy_class).to receive(:network_resource_client).and_return(
             stub_network_resource_client(nil, @resource_group_name, @vnet_name))
-          @vnet_config = { :virtualNetworkName => 'vnet-7',
-            :addressPrefixes => [ '10.3.0.0/16', '160.10.2.0/24' ],
-            :subnets => [{'name'=> 'sbn15',
-              'properties'=> {
-                'addressPrefix'=> '160.10.2.192/26'
+          @vnet_config = { :virtualNetworkName => "vnet-7",
+                           :addressPrefixes => [ "10.3.0.0/16", "160.10.2.0/24" ],
+                           :subnets => [{ "name" => "sbn15",
+                                          "properties" => {
+                "addressPrefix" => "160.10.2.192/26"
               }
             },
-            {'name'=> 'GatewaySubnet',
-              'properties'=> {
-                'addressPrefix'=> '10.3.1.0/24'
+            { "name" => "GatewaySubnet",
+              "properties" => {
+                "addressPrefix" => "10.3.1.0/24"
               }
             },
-            {'name'=> 'sbn16',
-              'properties'=> {
-                'addressPrefix'=> '160.10.2.0/25'
+            { "name" => "sbn16",
+              "properties" => {
+                "addressPrefix" => "160.10.2.0/25"
               }
             }]
           }
         end
 
-        it 'returns vnet_config with no change' do
+        it "returns vnet_config with no change" do
           response = @dummy_class.create_vnet_config(
             @resource_group_name, @vnet_name, @subnet_name
           )
@@ -1327,26 +1332,28 @@ describe Azure::ARM::VnetConfig do
       end
     end
 
-    context 'user provided or default named subnet value is GatewaySubnet' do
-      it 'raises error' do
-        expect { @dummy_class.create_vnet_config(
-          'rgrp-1', 'vnet-1', 'GatewaySubnet')
-        }.to raise_error(ArgumentError, 'GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.')
+    context "user provided or default named subnet value is GatewaySubnet" do
+      it "raises error" do
+        expect do
+          @dummy_class.create_vnet_config(
+          "rgrp-1", "vnet-1", "GatewaySubnet")
+        end.to raise_error(ArgumentError, "GatewaySubnet cannot be used as the name for --azure-vnet-subnet-name option. GatewaySubnet can only be used for virtual network gateways.")
       end
     end
 
-    context 'user provided or default named subnet value is not GatewaySubnet' do
+    context "user provided or default named subnet value is not GatewaySubnet" do
       before do
-        @resource_group_name = 'rgrp-4'
-        @vnet_name = 'vnet-7'
-        @subnet_name = 'sbn26'
+        @resource_group_name = "rgrp-4"
+        @vnet_name = "vnet-7"
+        @subnet_name = "sbn26"
         allow(@dummy_class).to receive(:network_resource_client).and_return(
           stub_network_resource_client(nil, @resource_group_name, @vnet_name))
       end
 
-      it 'does not raise error' do
-        expect { @dummy_class.create_vnet_config(
-          @resource_group_name, @vnet_name, @subnet_name) }.to_not raise_error
+      it "does not raise error" do
+        expect do
+          @dummy_class.create_vnet_config(
+          @resource_group_name, @vnet_name, @subnet_name) end.to_not raise_error
       end
     end
   end

--- a/spec/unit/vnet_config_spec.rb
+++ b/spec/unit/vnet_config_spec.rb
@@ -758,7 +758,7 @@ describe Azure::ARM::VnetConfig do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be.nil?
+            expect(response).to eq nil
           end
         end
 
@@ -779,7 +779,7 @@ describe Azure::ARM::VnetConfig do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be.nil?
+            expect(response).to eq nil
           end
         end
 
@@ -795,7 +795,7 @@ describe Azure::ARM::VnetConfig do
             response = @dummy_class.new_subnet_address_prefix(
               @vnet_address_prefix, @subnets
             )
-            expect(response).to be.nil?
+            expect(response).to eq nil
           end
         end
       end

--- a/spec/unit/vnet_config_spec.rb
+++ b/spec/unit/vnet_config_spec.rb
@@ -484,7 +484,6 @@ describe Azure::ARM::VnetConfig do
 
       it "returns the cidr prefix of the given subnet" do
         response = @dummy_class.subnet_cidr_prefix(@subnet)
-        expect(response.class).to be == Integer
         expect(response).to be == 29
       end
     end
@@ -498,7 +497,6 @@ describe Azure::ARM::VnetConfig do
 
       it "returns the cidr prefix of the given subnet" do
         response = @dummy_class.subnet_cidr_prefix(@subnet)
-        expect(response.class).to be == Integer
         expect(response).to be == 25
       end
     end

--- a/spec/unit/vnet_config_spec.rb
+++ b/spec/unit/vnet_config_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Aliasgar Batterywala (<aliasgar.batterywala@clogeny.com>)
-# Copyright:: Copyright (c) 2016 Opscode, Inc.
+# Copyright:: Copyright 2016-2018 Chef Software, Inc.
 #
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")

--- a/spec/unit/vnet_spec.rb
+++ b/spec/unit/vnet_spec.rb
@@ -1,16 +1,16 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/query_azure_mock")
 
-describe 'vnets' do
+describe "vnets" do
   include AzureSpecHelper
   include QueryAzureMock
 
-  before 'setup connection' do
+  before "setup connection" do
     @server_instance = Chef::Knife::AzureServerCreate.new
     {
-      :azure_subscription_id => 'azure_subscription_id',
+      :azure_subscription_id => "azure_subscription_id",
       :azure_mgmt_cert => @cert_file,
-      :azure_api_host_name => 'preview.core.windows-int.net'
+      :azure_api_host_name => "preview.core.windows-int.net"
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -19,8 +19,8 @@ describe 'vnets' do
     @connection = @server_instance.service.connection
   end
 
-  context 'mock with actually retrieved values' do
-    it 'should find strings' do
+  context "mock with actually retrieved values" do
+    it "should find strings" do
       items = @connection.vnets.all
       expect(items.length).to be > 1
       items.each do |vnet|
@@ -30,42 +30,42 @@ describe 'vnets' do
       end
     end
 
-    it 'should find correct vnets.' do
-      expect(@connection.vnets.exists?('jm-vnet-test')).to eq(true)
-      expect(@connection.vnets.exists?('not-there')).to eq(false)
+    it "should find correct vnets." do
+      expect(@connection.vnets.exists?("jm-vnet-test")).to eq(true)
+      expect(@connection.vnets.exists?("not-there")).to eq(false)
     end
 
-    it 'should contain Created state' do
+    it "should contain Created state" do
       @connection.vnets.all.each do |item|
-        expect(item.state).to eq('Created')
+        expect(item.state).to eq("Created")
       end
     end
   end
 
-  context 'create should' do
-    it 'create a vnet that does not already exist' do
+  context "create should" do
+    it "create a vnet that does not already exist" do
       params = {
-        azure_vnet_name: 'new-vn',
-        azure_ag_name: 'someag',
-        azure_address_space: '10.0.0.0/16',
-        azure_subnet_name: 'new-sb',
+        azure_vnet_name: "new-vn",
+        azure_ag_name: "someag",
+        azure_address_space: "10.0.0.0/16",
+        azure_subnet_name: "new-sb",
       }
       @connection.vnets.create(params)
-      expect(@postname).to eq('networking/media')
-      expect(@postverb).to eq('put')
-      expect(@postbody).to eq(readFile('set_network_new.xml'))
+      expect(@postname).to eq("networking/media")
+      expect(@postverb).to eq("put")
+      expect(@postbody).to eq(readFile("set_network_new.xml"))
     end
-    it 'modify an existing vnet' do
+    it "modify an existing vnet" do
       params = {
-        azure_vnet_name: 'vnname',
-        azure_ag_name: 'new-agname',
-        azure_address_space: '192.168.0.0/20',
-        azure_subnet_name: 'new-sb',
+        azure_vnet_name: "vnname",
+        azure_ag_name: "new-agname",
+        azure_address_space: "192.168.0.0/20",
+        azure_subnet_name: "new-sb",
       }
       @connection.vnets.create(params)
-      expect(@postname).to eq('networking/media')
-      expect(@postverb).to eq('put')
-      expect(@postbody).to eq(readFile('set_network_existing.xml'))
+      expect(@postname).to eq("networking/media")
+      expect(@postverb).to eq("put")
+      expect(@postbody).to eq(readFile("set_network_existing.xml"))
     end
   end
 end

--- a/spec/unit/windows_credentials_spec.rb
+++ b/spec/unit/windows_credentials_spec.rb
@@ -2,8 +2,8 @@
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.#
 
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
-require File.expand_path(File.dirname(__FILE__) + '/../unit/query_azure_mock')
+require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
+require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")
 
 describe Chef::Knife::AzurermBase, :windows_only do
   include AzureSpecHelper
@@ -25,27 +25,27 @@ describe Chef::Knife::AzurermBase, :windows_only do
     it "should raise error if target doesn't exist" do
       allow(@windows_credentials).to receive(:target_name)
       allow(@windows_credentials.ui).to receive(:error)
-      expect {@windows_credentials.token_details_from_WCM}.to raise_error(SystemExit)
+      expect { @windows_credentials.token_details_from_WCM }.to raise_error(SystemExit)
     end
 
     it "should raise error if target is not in proper format" do
       # removing expiresOn field from target
       target = "AzureXplatCli:target=_authority:https\\://login.microsoftonline.com/common::_clientId:abc123::expiresIn:3599::identityProvider:live.com::isMRRT:true::resource:https\\://management.core.windows.net/::tokenType:Bearer::userId:abc@outlook.com--0-2"
-      translated_cred = {:TargetName => double(:read_wstring => target),
-        :CredentialBlob => double(:get_bytes => "a:access_token::r:refresh_token")}
+      translated_cred = { :TargetName => double(:read_wstring => target),
+                          :CredentialBlob => double(:get_bytes => "a:access_token::r:refresh_token") }
       allow(@windows_credentials).to receive(:target_name).and_return(target)
       allow(FFI::MemoryPointer).to receive(:new)
       allow(Azure::ARM::ReadCred::CREDENTIAL_OBJECT).to receive(:new).exactly(2).and_return(translated_cred)
       allow(@windows_credentials).to receive(:CredReadW)
       allow_any_instance_of(NilClass).to receive(:read_pointer)
       allow(@windows_credentials.ui).to receive(:error)
-      expect {@windows_credentials.token_details_from_WCM}.to raise_error(SystemExit)
+      expect { @windows_credentials.token_details_from_WCM }.to raise_error(SystemExit)
     end
 
     it "should parse the target and return a hash if target exists" do
       target = "AzureXplatCli:target=_authority:https\\://login.microsoftonline.com/common::_clientId:abc123::expiresIn:3599::expiresOn:2016-06-07T13\\:16\\:34.877Z::identityProvider:live.com::isMRRT:true::resource:https\\://management.core.windows.net/::tokenType:Bearer::userId:abc@outlook.com--0-2"
-      translated_cred = {:TargetName => double(:read_wstring => target),
-        :CredentialBlob => double(:get_bytes => "a:access_token::r:refresh_token")}
+      translated_cred = { :TargetName => double(:read_wstring => target),
+                          :CredentialBlob => double(:get_bytes => "a:access_token::r:refresh_token") }
       allow(@windows_credentials).to receive(:target_name).and_return(target)
       allow(FFI::MemoryPointer).to receive(:new)
       allow(Azure::ARM::ReadCred::CREDENTIAL_OBJECT).to receive(:new).exactly(2).and_return(translated_cred)
@@ -66,7 +66,7 @@ describe Chef::Knife::AzurermBase, :windows_only do
     it "should raise error if Azure credentials are not found" do
       cmdkey_output = double(:stdout => "")
       allow_any_instance_of(Mixlib::ShellOut).to receive(:run_command).and_return(cmdkey_output)
-      expect{@windows_credentials.target_name}.to raise_error("Azure Credentials not found. Please run xplat's 'azure login' command")
+      expect { @windows_credentials.target_name }.to raise_error("Azure Credentials not found. Please run xplat's 'azure login' command")
     end
 
     it "should fetch the credential ending with --0-" do
@@ -92,7 +92,7 @@ describe Chef::Knife::AzurermBase, :windows_only do
   context "latest_credential_target" do
     it "should raise error if no target is passed" do
       targets = []
-      expect {@windows_credentials.latest_credential_target(targets)}.to raise_error("No Target was found for windows credentials")
+      expect { @windows_credentials.latest_credential_target(targets) }.to raise_error("No Target was found for windows credentials")
     end
 
     it "should return the target if a single target is passes" do

--- a/spec/unit/windows_credentials_spec.rb
+++ b/spec/unit/windows_credentials_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Nimisha Sharad (<nimisha.sharad@msystechnologies.com>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.#
+# Copyright:: Copyright 2013-2018 Chef Software, Inc.
 
 require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 require File.expand_path(File.dirname(__FILE__) + "/../unit/query_azure_mock")


### PR DESCRIPTION
Require Ruby 2.3+ / Chef 13+
Move development deps to the Gemfile
Add yard/console tasks to the Gemfile
Autocorrect Chefstyle warnings
Use the build in gem tasks in the Rakefile
Test Chefstyle in Travis
Update all copyrights to current / Chef