### PR TITLE
Fix for wrong number of arguments error while using extended logs option.

### DIFF
--- a/lib/azure/resource_management/ARM_interface.rb
+++ b/lib/azure/resource_management/ARM_interface.rb
@@ -261,7 +261,7 @@ module Azure
           resource_group_name,
           virtual_machine_name,
           chef_extension_name,
-          "instanceView"
+          expand: "instanceView"
         ).instance_view.substatuses
 
         return nil if substatuses.nil?


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
On `master` branch getting wrong number of arguments error while using --extended-logs option. The argument structure is changed in the azure_mgmt_compute 0.18.3 version https://github.com/Azure/azure-sdk-for-ruby/blob/master/management/azure_mgmt_compute/lib/2018-06-01/generated/azure_mgmt_compute/virtual_machine_extensions.rb#L179

so need to update the same in knife-azure.
### Issues Resolved
```
Waiting for the first chef-client run on virtual machine vj-linux-vm11ERROR: wrong number of arguments (given 4, expected 3)
ERROR: Something went wrong. Please use -VV option for more details.
DEBUG: /home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/azure_mgmt_compute-0.18.3/lib/2018-06-01/generated/azure_mgmt_compute/virtual_machine_extensions.rb:179:in `get'
/home/msys/workspace/knife-azure/lib/azure/resource_management/ARM_interface.rb:260:in `fetch_substatus'
/home/msys/workspace/knife-azure/lib/azure/resource_management/ARM_interface.rb:280:in `fetch_chef_client_logs'
/home/msys/workspace/knife-azure/lib/azure/resource_management/ARM_interface.rb:368:in `block in create_server'
/home/msys/workspace/knife-azure/lib/azure/resource_management/ARM_interface.rb:364:in `each'
/home/msys/workspace/knife-azure/lib/azure/resource_management/ARM_interface.rb:364:in `create_server'
/home/msys/workspace/knife-azure/lib/chef/knife/azurerm_server_create.rb:208:in `run'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/lib/chef/knife.rb:446:in `block in run_with_pretty_exceptions'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/lib/chef/local_mode.rb:44:in `with_server_connectivity'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/lib/chef/knife.rb:445:in `run_with_pretty_exceptions'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/lib/chef/knife.rb:220:in `run'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/lib/chef/application/knife.rb:161:in `run'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/gems/chef-14.10.9/bin/knife:24:in `<top (required)>'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/bin/knife:23:in `load'
/home/msys/workspace/knife-azure/bundle/ruby/2.5.0/bin/knife:23:in `<top (required)>'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
/home/msys/.chefdk/gem/ruby/2.5.0/bin/bundle:23:in `load'
/home/msys/.chefdk/gem/ruby/2.5.0/bin/bundle:23:in `<main>'
```
### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
