### PR TITLE
Updating gemspec to reflect knife-windows update from 1.9.6 to 3.0.3 …

### DIFF
--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "nokogiri", ">= 1.5.5"
-  s.add_dependency "knife-windows", "~> 1.0"
+  s.add_dependency "knife-windows", "~> 3.0"
   s.add_dependency "azure_mgmt_resources", "~> 0.17", ">= 0.17.2"
   s.add_dependency "azure_mgmt_compute", "~> 0.18", ">= 0.18.3"
   s.add_dependency "azure_mgmt_storage", "~> 0.17", ">= 0.17.3"


### PR DESCRIPTION


### Description

Updates knife-azure gemspec to depend on knife-windows version 3.x+ and higher as released in May 2019.

### Issues Resolved

https://github.com/MicrosoftDocs/azure-docs/issues/24474

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG