### PR TITLE
Don't depend of chef-bin

### DIFF
--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.5"
 
   s.add_dependency "chef", ">= 15.1"
-  s.add_dependency "chef-bin", ">= 15.1"
   s.add_dependency "nokogiri", ">= 1.5.5"
   s.add_dependency "azure_mgmt_resources", "~> 0.17", ">= 0.17.2"
   s.add_dependency "azure_mgmt_compute", "~> 0.18", ">= 0.18.3"


### PR DESCRIPTION
chef-bin is the non-free part of chef and shouldn't be a dependency for this driver

Signed-off-by: Tim Smith <tsmith@chef.io>