### PR TITLE
Fix deprecated keyword parameters warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
     gem "chef-zero", "< 15.0"
   end
-  gem "activesupport", "6.0.2.2"
+  gem "activesupport", "6.0.3"
   gem "chefstyle"
   gem "equivalent-xml", "~> 0.6.0"
   gem "guard-rspec"

--- a/lib/chef/knife/helpers/azurerm_base.rb
+++ b/lib/chef/knife/helpers/azurerm_base.rb
@@ -99,7 +99,7 @@ class Chef
 
       def get_azure_cli_version
         if @azure_version != ""
-          get_version = shell_out!("azure -v || az -v | grep azure-cli", { returns: [0] }).stdout
+          get_version = shell_out!("azure -v || az -v | grep azure-cli", returns: [0]).stdout
           @azure_version = get_version.gsub(/[^0-9.]/, "")
         end
         @azure_prefix = @azure_version.to_i < 2 ? "azure" : "az"

--- a/spec/unit/deploys_list_spec.rb
+++ b/spec/unit/deploys_list_spec.rb
@@ -46,7 +46,7 @@ describe "deploys" do
   end
   it "each role should have values" do
     @connection.deploys.all.each do |deploy|
-    # describe_deploy deploy
+      # describe_deploy deploy
       deploy.roles.each do |role|
         # describe_role role
         expect(role.name).to_not be nil


### PR DESCRIPTION
```
/opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/knife-azure-3.0.0/lib/chef/knife/helpers/azurerm_base.rb:102: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/opt/chef-workstation/embedded/lib/ruby/gems/2.7.0/gems/chef-16.0.287/lib/chef/mixin/shell_out.rb:54: warning: The called method `shell_out!' is defined here
```
