### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/azure/resource_management/windows_credentials.rb
+++ b/lib/azure/resource_management/windows_credentials.rb
@@ -19,8 +19,8 @@
 # XPLAT stores the access token and other information in windows credential manager.
 # Using FFI to call CredRead function
 require "chef"
-require "mixlib/shellout"
-require "ffi"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "ffi" unless defined?(FFI)
 require "chef/win32/api"
 
 module Azure

--- a/lib/azure/service_management/rest.rb
+++ b/lib/azure/service_management/rest.rb
@@ -16,9 +16,10 @@
 # limitations under the License.
 #
 
-require "net/https"
-require "uri"
-require "nokogiri"
+require "net/http" unless defined?(Net::HTTP)
+require "openssl" unless defined?(OpenSSL)
+require "uri" unless defined?(URI)
+require "nokogiri" unless defined?(Nokogiri)
 
 module AzureAPI
 

--- a/lib/azure/service_management/role.rb
+++ b/lib/azure/service_management/role.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require_relative "utility"
 
 module Azure

--- a/lib/chef/knife/azure_server_create.rb
+++ b/lib/chef/knife/azure_server_create.rb
@@ -32,7 +32,7 @@ class Chef
       include Knife::Bootstrap::Bootstrapper
 
       deps do
-        require "securerandom"
+        require "securerandom" unless defined?(SecureRandom)
         require "readline"
         require "chef/json_compat"
         require "chef/knife/bootstrap"

--- a/lib/chef/knife/azurerm_server_create.rb
+++ b/lib/chef/knife/azurerm_server_create.rb
@@ -31,7 +31,7 @@ class Chef
       include Knife::Bootstrap::Bootstrapper
 
       deps do
-        require "securerandom"
+        require "securerandom" unless defined?(SecureRandom)
         include Knife::AzurermBase
       end
 

--- a/lib/chef/knife/bootstrap_azurerm.rb
+++ b/lib/chef/knife/bootstrap_azurerm.rb
@@ -29,7 +29,7 @@ class Chef
       include Knife::Bootstrap::Bootstrapper
 
       deps do
-        require "time"
+        require "time" unless defined?(Time)
         include Knife::AzurermBase
       end
 

--- a/lib/chef/knife/helpers/azure_base.rb
+++ b/lib/chef/knife/helpers/azure_base.rb
@@ -204,10 +204,10 @@ class Chef
       end
 
       def parse_publish_settings_file(filename)
-        require "nokogiri"
-        require "base64"
-        require "openssl"
-        require "uri"
+        require "nokogiri" unless defined?(Nokogiri)
+        require "base64" unless defined?(Base64)
+        require "openssl" unless defined?(OpenSSL)
+        require "uri" unless defined?(URI)
         begin
           doc = Nokogiri::XML(File.open(find_file(filename)))
           profile = doc.at_css("PublishProfile")
@@ -235,8 +235,8 @@ class Chef
       end
 
       def parse_azure_profile(filename, errors)
-        require "openssl"
-        require "uri"
+        require "openssl" unless defined?(OpenSSL)
+        require "uri" unless defined?(URI)
         errors = [] if errors.nil?
         azure_profile = File.read(File.expand_path(filename))
         azure_profile = JSON.parse(azure_profile)

--- a/lib/chef/knife/helpers/azurerm_base.rb
+++ b/lib/chef/knife/helpers/azurerm_base.rb
@@ -35,8 +35,8 @@ class Chef
             require "chef/json_compat"
             require_relative "../../../azure/resource_management/ARM_interface"
             require "chef/mixin/shell_out"
-            require "time"
-            require "json"
+            require "time" unless defined?(Time)
+            require "json" unless defined?(JSON)
 
             if Chef::Platform.windows?
               require_relative "../../azure/resource_management/windows_credentials"
@@ -172,10 +172,10 @@ class Chef
       end
 
       def parse_publish_settings_file(filename)
-        require "nokogiri"
-        require "base64"
-        require "openssl"
-        require "uri"
+        require "nokogiri" unless defined?(Nokogiri)
+        require "base64" unless defined?(Base64)
+        require "openssl" unless defined?(OpenSSL)
+        require "uri" unless defined?(URI)
         begin
           doc = Nokogiri::XML(File.open(find_file(filename)))
           profile = doc.at_css("PublishProfile")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ if Chef::Platform.windows?
   require "azure/resource_management/windows_credentials"
 end
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "knife-azure/version"
 
 def temp_dir


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>