### PR TITLE
improve load performance by autoloading ARMInterface

### DIFF
--- a/lib/chef/knife/bootstrap/bootstrapper.rb
+++ b/lib/chef/knife/bootstrap/bootstrapper.rb
@@ -16,7 +16,11 @@
 # limitations under the License.
 #
 
-require_relative "../../../azure/resource_management/ARM_interface"
+module Azure
+  class ResourceManagement
+    autoload :ARMInterface, "azure/resource_management/ARM_interface"
+  end
+end
 
 class Chef
   class Knife


### PR DESCRIPTION
This shaves 10 seconds (2/3 total time) of  loading `knife` commands on my windows laptop.

Signed-off-by: mwrock <matt@mattwrock.com>
