### PR TITLE
CHEF-1922 Fixed the knife-azure verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,21 +11,13 @@ expeditor:
 
 steps:
 
-- label: run-specs-ruby-2.7
+- label: run-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
-
-- label: run-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0-buster
+        image: ruby:3.1-buster
 
 - label: run-specs-windows
   command:
@@ -37,4 +29,4 @@ steps:
     executor:
       docker:
         host_os: windows
-        image: rubydistros/windows-2019:2.7
+        image: rubydistros/windows-2019:3.1

--- a/knife-azure.gemspec
+++ b/knife-azure.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.files = %w{LICENSE} + Dir.glob("lib/**/*")
   s.homepage = "https://github.com/chef/knife-azure"
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency "knife"
+  s.add_dependency "knife", ">= 18.0"
   s.add_dependency "nokogiri", ">= 1.5.5"
   s.add_dependency "azure_mgmt_resources", "~> 0.17", ">= 0.17.2"
   s.add_dependency "azure_mgmt_compute", "~> 0.18", ">= 0.18.3"

--- a/spec/integration/azure_spec.rb
+++ b/spec/integration/azure_spec.rb
@@ -91,7 +91,7 @@ describe "knife-azure integration test", if: is_config_present do
   end
 
   describe "display help for command" do
-    %w{server\ create server\ delete server\ list image\ list server\ show vnet\ create vnet\ list ag\ create ag\ list}.each do |command|
+    ["server create", "server delete", "server list", "image list", "server show", "vnet create", "vnet list", "ag create", "ag list"].each do |command|
       context "when --help option used with #{command} command" do
         let(:command) { "knife azure #{command} --help" }
         run_cmd_check_stdout("--help")


### PR DESCRIPTION
### Description

updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG